### PR TITLE
log django.request and api errors to console, where gunicorn will dump a stacktrace fixes #79

### DIFF
--- a/deis/settings.py
+++ b/deis/settings.py
@@ -213,7 +213,7 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.NullHandler',
         },
-        'console':{
+        'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'formatter': 'simple'


### PR DESCRIPTION
Turns out this was just tuning Django logging configuration.
