### PR TITLE
return a proper 404 when no logs exist fixes #101

### DIFF
--- a/api/tests/formation.py
+++ b/api/tests/formation.py
@@ -136,9 +136,13 @@ class FormationTest(TestCase):
         if not os.path.exists(settings.DEIS_LOG_DIR):
             os.mkdir(settings.DEIS_LOG_DIR)
         path = os.path.join(settings.DEIS_LOG_DIR, formation_id + '.log')
+        url = '/api/formations/{formation_id}/logs'.format(**locals())
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data, 'No logs for {}'.format(formation_id))
+        # write out some fake log data and try again
         with open(path, 'w') as f:
             f.write(FAKE_LOG_DATA)
-        url = '/api/formations/{formation_id}/logs'.format(**locals())
         response = self.client.post(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, FAKE_LOG_DATA)

--- a/api/views.py
+++ b/api/views.py
@@ -225,7 +225,12 @@ class FormationViewSet(OwnerViewSet):
 
     def logs(self, request, **kwargs):
         formation = self.get_object()
-        logs = formation.logs()
+        try:
+            logs = formation.logs()
+        except EnvironmentError:
+            return Response("No logs for {}".format(formation.id),
+                            status=status.HTTP_404_NOT_FOUND,
+                            content_type='text/plain')
         return Response(logs, status=status.HTTP_200_OK,
                         content_type='text/plain')
 

--- a/client/deis.py
+++ b/client/deis.py
@@ -1056,6 +1056,8 @@ class DeisClient(object):
                                   "/api/formations/{}/logs".format(formation))
         if response.status_code == requests.codes.ok:  # @UndefinedVariable
             print(response.json())
+        elif response.status_code == requests.codes.not_found:  # @UndefinedVariable
+            print(response.json())
         else:
             print('Error!', response.text)
 


### PR DESCRIPTION
On any EnvironmentError we now return a 404 with a body of: No logs found for <formation>.  Test coverage included.
