### PR TITLE
Return 404 if app cannot be found during queryset lookup

### DIFF
--- a/api/tests/app.py
+++ b/api/tests/app.py
@@ -197,6 +197,13 @@ class AppTest(TestCase):
         body = {'command': 'ls -al'}
         response = self.client.post(url, json.dumps(body), content_type='application/json')
         self.assertContains(response, 'No nodes available to run command', status_code=400)
+        url = '/api/apps/{app_id}'.format(**locals())
+        response = self.client.delete(url)
+        self.assertEquals(response.status_code, 204)
+        for endpoint in ('containers', 'config', 'releases', 'builds'):
+            url = '/api/apps/{app_id}/{endpoint}'.format(**locals())
+            response = self.client.get(url)
+            self.assertEquals(response.status_code, 404)
 
 
 FAKE_LOG_DATA = """

--- a/api/views.py
+++ b/api/views.py
@@ -330,7 +330,8 @@ class AppViewSet(OwnerViewSet):
 class BaseAppViewSet(OwnerViewSet):
 
     def get_queryset(self, **kwargs):
-        app = models.App.objects.get(owner=self.request.user, id=self.kwargs['id'])
+        app = get_object_or_404(models.App.objects.filter(
+            owner=self.request.user, id=self.kwargs['id']))
         return self.model.objects.filter(owner=self.request.user, app=app)
 
     def get_object(self, *args, **kwargs):
@@ -401,8 +402,8 @@ class AppContainerViewSet(OwnerViewSet):
     serializer_class = serializers.ContainerSerializer
 
     def get_queryset(self, **kwargs):
-        app = models.App.objects.get(
-            owner=self.request.user, id=self.kwargs['id'])
+        app = get_object_or_404(models.App.objects.filter(
+            owner=self.request.user, id=self.kwargs['id']))
         qs = self.model.objects.filter(owner=self.request.user, app=app)
         container_type = self.kwargs.get('type')
         if container_type:


### PR DESCRIPTION
This fixes #182, where 500s were being thrown if the app was deleted.  This can happen if a formation is deleted (which deletes contained apps).  Git repositories may still be associated with the orphaned application.
