### PR TITLE
fix ssh_username not being read in 'deis ssh'

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -1473,7 +1473,7 @@ class DeisClient(object):
             with open(key_path, 'w') as f:
                 f.write(layer['ssh_private_key'])
             ssh_args = ['-o UserKnownHostsFile=/dev/null', '-o StrictHostKeyChecking=no',
-                        '-i', key_path, 'ubuntu@{fqdn}'.format(**node)]
+                        '-i', key_path, '{}@{}'.format(layer['ssh_username'], node['fqdn'])]
             command = args.get('<command>')
             if command:
                 ssh_args.extend(command)


### PR DESCRIPTION
we should be using the specified username in our layer's configuration, rather than hardcoding 'ubuntu'.
