### PR TITLE
Fixed #198 -- ensure new users have is_active == True.

### DIFF
--- a/api/tests/auth.py
+++ b/api/tests/auth.py
@@ -48,6 +48,7 @@ class AuthTest(TestCase):
         self.assertEqual(response.data['email'], email)
         self.assertEqual(response.data['first_name'], first_name)
         self.assertEqual(response.data['last_name'], last_name)
+        self.assertTrue(response.data['is_active'])
         self.assertFalse(response.data['is_superuser'])
         self.assertFalse(response.data['is_staff'])
         self.assertTrue(

--- a/api/views.py
+++ b/api/views.py
@@ -78,6 +78,7 @@ class UserRegistrationView(viewsets.GenericViewSet,
         now = timezone.now()
         obj.last_login = now
         obj.date_joined = now
+        obj.is_active = True
         obj.email = User.objects.normalize_email(obj.email)
         obj.set_password(obj.password)
 

--- a/client/deis.py
+++ b/client/deis.py
@@ -576,14 +576,16 @@ class DeisClient(object):
             password = getpass('password: ')
             confirm = getpass('password (confirm): ')
             if password != confirm:
-                print('Password mispatch, aborting registration.')
+                print('Password mismatch, aborting registration.')
                 return False
         email = args.get('--email')
         if not email:
             email = raw_input('email: ')
         url = urlparse.urljoin(controller, '/api/auth/register')
         payload = {'username': username, 'password': password, 'email': email}
-        response = self._session.post(url, data=payload, allow_redirects=False)
+        response = self._session.post(url, data=payload,
+                                      headers={'content-type': 'application/json'},
+                                      allow_redirects=False)
         if response.status_code == requests.codes.created:  # @UndefinedVariable
             self._settings['controller'] = controller
             self._settings.save()


### PR DESCRIPTION
Strangely, the unit test for this in api.auth.AuthTest succeeds regardless. I debugged as far as I could and can't figure out why is_active defaults to True anyway in the test run: looks like the same POST data and stack trace. This does fix the issue but it's frustrating the test didn't also fail.
