### PR TITLE
Fix double converge on new release

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -797,8 +797,6 @@ def new_release(sender, **kwargs):
     release = Release.objects.create(
         owner=user, app=app, config=config,
         build=build, version=new_version)
-    # converge the application
-    app.converge()
     return release
 
 


### PR DESCRIPTION
When build or config changes, we were converging in the view/push handling code as well as in the release handler.  This speeds things up significantly.
