### PR TITLE
Only run commands against nodes in runtime layers

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -516,7 +516,7 @@ class App(UuidAuditedModel):
 
     def run(self, command):
         """Run a one-off command in an ephemeral app container."""
-        nodes = self.formation.node_set.order_by('?')
+        nodes = self.formation.node_set.filter(layer__runtime=True).order_by('?')
         if not nodes:
             raise EnvironmentError('No nodes available to run command')
         app_id, node = self.id, nodes[0]


### PR DESCRIPTION
When building complex formations with dedicated proxy layers, the prior code would sometimes try to run an ephemeral command against a proxy node.  This ensures only runtime nodes are used.
