### PR TITLE
remove ffi dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,6 @@ GEM
       multipart-post (~> 1.2.0)
     faraday_middleware (0.9.0)
       faraday (>= 0.7.4, < 0.9)
-    ffi (1.9.1)
     fog (1.15.0)
       builder
       excon (~> 0.25.0)


### PR DESCRIPTION
This somehow snuck into my lockfile from #259: https://github.com/bacongobbler/deis/commit/1ca8d840f5b655a269370aa9d7a8fe8e7c8da577#diff-e79a60dc6b85309ae70a6ea8261eaf95R70

There's no need for it, I think. knife-digital_ocean does not depend on this gem. People are running into this issue:

```
Could not find ffi-1.9.1 in any of the sources
```
