### PR TITLE
downgrade eventmachine version to v1.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,12 +56,12 @@ GEM
       json
       rash
     em-winrm (0.5.4)
-      eventmachine (= 1.0.0.beta.3)
+      eventmachine (= 1.0.0)
       mixlib-log (>= 1.3.0)
       uuidtools (~> 2.1.1)
       winrm (~> 1.1.0)
     erubis (2.7.0)
-    eventmachine (1.0.0.beta.3)
+    eventmachine (1.0.0)
     excon (0.25.3)
     faraday (0.8.8)
       multipart-post (~> 1.2.0)


### PR DESCRIPTION
Seeing this error:

```


Installing eventmachine (1.0.0.beta.3)
Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

        /usr/bin/ruby1.9.1 extconf.rb
checking for main() in -lssl... no
checking for rb_trap_immediate in ruby.h,rubysig.h... no
checking for rb_thread_blocking_region()... yes
checking for inotify_init() in sys/inotify.h... yes
checking for writev() in sys/uio.h... yes
checking for rb_thread_check_ints()... yes
checking for rb_time_new()... yes
checking for sys/event.h... no
checking for epoll_create() in sys/epoll.h... yes
creating Makefile

make
compiling em.cpp
em.cpp: In member function ‘bool EventMachine_t::_RunEpollOnce()’:
em.cpp:525:13: warning: ‘int rb_thread_select(int, fd_set*, fd_set*, fd_set*, timeval*)’ is deprecated (declared at /usr/include/ruby-1.9.1/ruby/intern.h:379) [-Wdeprecated-declarations]
em.cpp:525:65: warning: ‘int rb_thread_select(int, fd_set*, fd_set*, fd_set*, timeval*)’ is deprecated (declared at /usr/include/ruby-1.9.1/ruby/intern.h:379) [-Wdeprecated-declarations]
em.cpp:566:3: warning: ‘int rb_thread_select(int, fd_set*, fd_set*, fd_set*, timeval*)’ is deprecated (declared at /usr/include/ruby-1.9.1/ruby/intern.h:379) [-Wdeprecated-declarations]
em.cpp:566:37: warning: ‘int rb_thread_select(int, fd_set*, fd_set*, fd_set*, timeval*)’ is deprecated (declared at /usr/include/ruby-1.9.1/ruby/intern.h:379) [-Wdeprecated-declarations]
em.cpp: In member function ‘bool EventMachine_t::_RunSelectOnce()’:
em.cpp:951:6: warning: ‘int rb_thread_select(int, fd_set*, fd_set*, fd_set*, timeval*)’ is deprecated (declared at /usr/include/ruby-1.9.1/ruby/intern.h:379) [-Wdeprecated-declarations]
em.cpp:951:40: warning: ‘int rb_thread_select(int, fd_set*, fd_set*, fd_set*, timeval*)’ is deprecated (declared at /usr/include/ruby-1.9.1/ruby/intern.h:379) [-Wdeprecated-declarations]
em.cpp: In member function ‘void EventMachine_t::_ReadInotifyEvents()’:
em.cpp:2221:3: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
em.cpp: In member function ‘void EventMachine_t::_ReadLoopBreaker()’:
em.cpp:998:50: warning: ignoring return value of ‘ssize_t read(int, void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
em.cpp: In member function ‘void EventMachine_t::SignalLoopBreaker()’:
em.cpp:282:34: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
compiling pipe.cpp
compiling cmain.cpp
compiling kb.cpp
kb.cpp: In member function ‘virtual void KeyboardDescriptor::Read()’:
kb.cpp:77:27: warning: ignoring return value of ‘ssize_t read(int, void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
compiling binder.cpp
compiling rubymain.cpp
rubymain.cpp: In function ‘VALUE t_connect_server(VALUE, VALUE, VALUE)’:
rubymain.cpp:504:42: error: format not a string literal and no format arguments [-Werror=format-security]
rubymain.cpp: In function ‘VALUE t_bind_connect_server(VALUE, VALUE, VALUE, VALUE, VALUE)’:
rubymain.cpp:525:42: error: format not a string literal and no format arguments [-Werror=format-security]
rubymain.cpp: In function ‘VALUE t_watch_filename(VALUE, VALUE)’:
rubymain.cpp:798:38: error: format not a string literal and no format arguments [-Werror=format-security]
rubymain.cpp: In function ‘VALUE t_watch_pid(VALUE, VALUE)’:
rubymain.cpp:824:38: error: format not a string literal and no format arguments [-Werror=format-security]
rubymain.cpp: In function ‘VALUE t_start_proxy(VALUE, VALUE, VALUE, VALUE, VALUE)’:
rubymain.cpp:1024:42: error: format not a string literal and no format arguments [-Werror=format-security]
rubymain.cpp: In function ‘VALUE t_stop_proxy(VALUE, VALUE)’:
rubymain.cpp:1039:42: error: format not a string literal and no format arguments [-Werror=format-security]
cc1plus: some warnings being treated as errors
make: *** [rubymain.o] Error 1


Gem files will remain installed in /var/lib/gems/1.9.1/gems/eventmachine-1.0.0.beta.3 for inspection.
Results logged to /var/lib/gems/1.9.1/gems/eventmachine-1.0.0.beta.3/ext/gem_make.out

An error occurred while installing eventmachine (1.0.0.beta.3), and Bundler
cannot continue.
Make sure that `gem install eventmachine -v '1.0.0.beta.3'` succeeds before
bundling.
```

downgrading to v1.0.0 fixes this.
