### PR TITLE
Change default behavior of keys:add to upload as key_comment if...

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -1225,7 +1225,6 @@ class DeisClient(object):
                         selected_key[2], selected_key[3]
                     )
                 }
-                
                 sys.stdout.write("Uploading {} to Deis...".format(selected_key[1]))
             else:
                 body = {
@@ -1234,7 +1233,6 @@ class DeisClient(object):
                         selected_key[2], selected_key[3]
                     )
                 }
-                
                 sys.stdout.write("Uploading {} to Deis...".format(selected_key[4]))
             sys.stdout.flush()
             response = self._dispatch('post', '/api/keys', json.dumps(body))


### PR DESCRIPTION
... available.

This edit will default to uploading the users key as identified by its key comment if the key comment is defined, and gracefully fall back to the older method if it is not.

This should improve usability for some users working from multiple workstations.
