### PR TITLE
If CM's purge_node() fails then raise an error.

### DIFF
--- a/cm/chef.py
+++ b/cm/chef.py
@@ -140,8 +140,13 @@ def purge_node(node):
     :param node: a dict containing the id of a node to purge
     """
     client = _get_client()
-    client.delete_node(node['id'])
-    client.delete_client(node['id'])
+    node_id = node['id']
+    body, status = client.delete_node(node_id)
+    if status != 200:
+        raise RuntimeError('Could not purge node {node_id}: {body}'.format(**locals()))
+    body, status = client.delete_client(node_id)
+    if status != 200:
+        raise RuntimeError('Could not purge node client {node_id}: {body}'.format(**locals()))
 
 
 def converge_controller():


### PR DESCRIPTION
Just provides some helpful logging.

BTW how does everyone else add their Deis Controller client to the Chef admin group? I thought you could do it on the command line with `knife client edit deis-controller` and then change the admin key to 'true'. But I'm wondering if that key even refers to the admin group? Do you actually have to go into the Chef Server web UI and edit the admin group there?
