### PR TITLE
Use DO creds from knife.rb. Also, respond to failed knife bootstrap by deleting things.

### DIFF
--- a/contrib/digitalocean/provision-digitalocean-controller.sh
+++ b/contrib/digitalocean/provision-digitalocean-controller.sh
@@ -24,16 +24,16 @@ if ! $CONTRIB_DIR/check-deis-deps.sh; then
 fi
 
 # connection details for using digital ocean's API
-client_id=$(knife exec -E"puts Chef::Config[:knife][:digital_ocean_client_id]")
-api_key=$(knife exec -E"puts Chef::Config[:knife][:digital_ocean_api_key]")
+client_id=${DIGITALOCEAN_CLIENT_ID:-$(knife exec -E"puts Chef::Config[:knife][:digital_ocean_client_id]")}
+api_key=${DIGITALOCEAN_API_KEY:-$(knife exec -E"puts Chef::Config[:knife][:digital_ocean_api_key]")}
 
 # Check that client ID and API key was set
 if test -z $client_id; then
-  echo "Please add your client id to ${knife_file}."
+  echo "Please add your Digital Ocean Client ID to the shell's environment or knife.rb."
 fi
 
 if test -z $api_key; then
-  echo "Please add your api key to ${knife_file}."
+  echo "Please add your Digital Ocean API Key to the shell's environment or knife.rb."
 fi
 
 #################
@@ -122,9 +122,9 @@ if [ $result -ne 0 ]; then
   knife digital_ocean droplet destroy -S $droplet_id
   # Remove node and client from Chef Server
   echo_color "Deleting Chef client..."
-  knife client delete deis-controller
+  knife client delete deis-controller -y
   echo_color "Deleting Chef node..."
-  knife node delete deis-controller
+  knife node delete deis-controller -y
 else
   echo_color "Knife bootstrap successful."
   # Need Chef admin permission in order to add and remove nodes and clients


### PR DESCRIPTION
I want to be able to use multiple Digital Ocean accounts on my machine, so I'm not putting my DO credentials in environment variables but rather using multiple `.chef` folders that I switch between using symlinks. The current provision script relies on the DO creds being in the environment.

Including the above error I had more errors and had to delete the failed DO server and Chef node/client a few times, so I thought I'd automate that process by detecting if `knife bootstrap` failed and doing the various deletions programatically.

I guess it would make sense if the CLI client also used `knife.rb` to get the credentials. In my case I just did `DIGITAL_OCEAN_CLIENT_ID=abc123 DIGITAL_OCEAN_API_KEY=abc123 deis providers:discover` to get around it.
