### PR TITLE
Default formation lookup on application creation

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -160,7 +160,7 @@ class AppSerializer(serializers.ModelSerializer):
 
     owner = serializers.Field(source='owner.username')
     id = serializers.SlugField(default=utils.generate_app_name)
-    formation = OwnerSlugRelatedField(slug_field='id')
+    formation = OwnerSlugRelatedField(slug_field='id', required=False)
 
     class Meta:
         """Metadata options for a :class:`AppSerializer`."""

--- a/api/tests/test_app.py
+++ b/api/tests/test_app.py
@@ -111,6 +111,34 @@ class AppTest(TestCase):
         self.assertContains(response, 'App with this Id already exists.', status_code=400)
         return response
 
+    def test_app_default_formation(self):
+        # delete formation created in setUp
+        response = self.client.delete('/api/formations/autotest')
+        self.assertEqual(response.status_code, 204)
+        # try creating an app with no formation specified
+        url = '/api/apps'
+        response = self.client.post(url)
+        self.assertContains(response, 'No formations available', status_code=400)
+        # create a formation
+        formation1 = 'autotest'
+        response = self.client.post('/api/formations', json.dumps({'id': formation1}),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+        # try again to create an app with no formation specified
+        url = '/api/apps'
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(formation1, response.data['formation'])
+        # create a second formation
+        formation2 = 'autotest2'
+        response = self.client.post('/api/formations', json.dumps({'id': formation2}),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+        # create another app with no formation specified
+        url = '/api/apps'
+        response = self.client.post(url)
+        self.assertContains(response, 'Could not determine default formation', status_code=400)
+
     def test_multiple_apps(self):
         url = '/api/apps'
         body = {'formation': 'autotest'}

--- a/api/views.py
+++ b/api/views.py
@@ -308,6 +308,16 @@ class AppViewSet(OwnerViewSet):
         return super(AppViewSet, self).pre_save(app, **kwargs)
 
     def create(self, request, **kwargs):
+        if not 'formation' in request.DATA:
+            count = models.Formation.objects.count()
+            if count == 1:
+                request.DATA['formation'] = models.Formation.objects.first()
+            elif count == 0:
+                return Response('No formations available',
+                                status=HTTP_400_BAD_REQUEST)
+            else:
+                return Response('Could not determine default formation',
+                                status=HTTP_400_BAD_REQUEST)
         try:
             return OwnerViewSet.create(self, request, **kwargs)
         except EnvironmentError as e:

--- a/client/deis.py
+++ b/client/deis.py
@@ -391,11 +391,10 @@ class DeisClient(object):
         """
         Create a new application
 
-        Must provide a target formation to host the application
-        containers. If no ID is provided, one will be generated
-        automatically.
+        If no ID is provided, one will be generated automatically.
+        If no formation is provided, the first available will be used.
 
-        Usage: deis apps:create --formation=<formation> [--id=<id>]
+        Usage: deis apps:create [--id=<id> --formation=<formation>]
         """
         body = {}
         try:
@@ -413,11 +412,6 @@ class DeisClient(object):
             o = args.get(opt)
             if o:
                 body.update({opt.strip('-'): o})
-        formation = args.get('--formation')
-        response = self._dispatch('get', '/api/formations/{}'.format(formation))
-        if response.status_code != 200:
-            print('Formation not found')
-            return
         sys.stdout.write('Creating application... ')
         sys.stdout.flush()
         try:


### PR DESCRIPTION
When a developer creates an application, they shouldn't have to specify a formation.  If there is a single formation available (common) the app should use it.  If there are none or > 1, we should raise an error.  We can implement user preferences later.

Fixes #282
