### PR TITLE
Fix Celery deadlocks by removing all blocking tasks from parent tasks

### DIFF
--- a/api/tasks.py
+++ b/api/tasks.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import importlib
 
 from celery import task
-from celery.canvas import group
 
 from deis import settings
 from provider import import_provider_module
@@ -56,44 +55,6 @@ def run_node(node, command):
     if rc != 0 and 'failed to setup the container' in output:
         output = '\033[35mPlease run `git push deis master` first.\033[0m\n' + output
     return output, rc
-
-
-@task
-def build_formation(formation):
-    return
-
-
-@task
-def destroy_formation(formation):
-    app_tasks = [destroy_app.si(a) for a in formation.app_set.all()]
-    node_tasks = [destroy_node.si(n) for n in formation.node_set.all()]
-    layer_tasks = [destroy_layer.si(l) for l in formation.layer_set.all()]
-    group(app_tasks + node_tasks).apply_async().join()
-    group(layer_tasks).apply_async().join()
-    CM.purge_formation(formation.flat())
-    formation.delete()
-
-
-@task
-def converge_formation(formation):
-    nodes = formation.node_set.all()
-    subtasks = []
-    for n in nodes:
-        subtask = converge_node.si(n)
-        subtasks.append(subtask)
-    group(*subtasks).apply_async().join()
-
-
-@task
-def build_app(app):
-    return
-
-
-@task
-def destroy_app(app):
-    CM.purge_app(app.flat())
-    app.delete()
-    app.formation.publish()
 
 
 @task


### PR DESCRIPTION
After discussing the issue at length with the helpful folks on IRC, it was confirmed that the upgrade to Celery 3.1.x made this problem much worse for us as "the pool prefetching will (now) write the tasks to the same process that is waiting".

Celery best practice is to not call blocking tasks within other tasks or risk resource starvation and deadlocking, see:
http://docs.celeryproject.org/en/latest/userguide/tasks.html#avoid-launching-synchronous-subtasks

This PR moves much of the blocking subtasks into the model methods.  It has the added benefit of simplifying view/task code with a net decrease in total lines of code.  While it's possible this introduced a regression, I did heavy testing with a pool of 1.
