### PR TITLE
Return the body of chef-client even on failed node convergence

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -282,7 +282,11 @@ class NodeViewSet(FormationNodeViewSet):
 
     def converge(self, request, **kwargs):
         node = self.get_object()
-        output, _ = node.converge()
+        try:
+            output, _ = node.converge()
+        except RuntimeError as e:
+            return Response(e.output, status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            content_type='text/plain')
         return Response(output, status=status.HTTP_200_OK, content_type='text/plain')
 
 


### PR DESCRIPTION
Before this pull request, the only way to get the output of a failed `chef-client` run was to look at server logs.  This allows us to get the output regardless of success or failure.  Use `deis nodes:converge <node-id>`.
