### PR TITLE
Fix `deis run` environment and remove ephemeral container

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -541,10 +541,12 @@ class App(UuidAuditedModel):
         # prepare ssh command
         version = release.version
         docker_args = ' '.join(
-            ['-a', 'stdout', '-a', 'stderr',
+            ['-a', 'stdout', '-a', 'stderr', '-rm',
              '-v', '/opt/deis/runtime/slugs/{app_id}-v{version}:/app'.format(**locals()),
              'deis/slugrunner'])
-        command = "sudo docker run {docker_args} {command}".format(**locals())
+        env_args = ' '.join(["-e '{k}={v}'".format(**locals())
+                             for k, v in release.config.values.items()])
+        command = "sudo docker run {env_args} {docker_args} {command}".format(**locals())
         return node.run(command)
 
 


### PR DESCRIPTION
Two notable changes to fix #356:
1. We now construct `-e` flags for `docker run` based on the current release
2. We now pass `-rm` to `docker run` to ensure the container is removed automatically when it exits

Getting this to show up in testing is a bit tricky, since there are 3 layers of shell interpolation we must contend with:
1. `deis` client shell on the workstation
2. `docker run` command on the host
3. the shell inside the container itself

Proof it now works:

```
$ deis config:set SHELL_INTERPOLATION=hard
=== player-yearling
SHELL_INTERPOLATION: hard
$ deis run 'echo \$SHELL_INTERPOLATION'
hard
```
