### PR TITLE
Be specific about required package versions in client setup.py.

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -39,7 +39,8 @@ setup(name='deis',
       author_email='info@opdemand.com',
       url='https://github.com/opdemand/deis',
       keywords=[
-          'opdemand', 'deis', 'cloud', 'chef', 'docker', 'heroku', 'aws', 'ec2', 'rackspace'
+          'opdemand', 'deis', 'paas', 'cloud', 'chef', 'docker', 'heroku',
+          'aws', 'ec2', 'rackspace', 'digitalocean'
       ],
       classifiers=[
           'Development Status :: 4 - Beta',
@@ -59,6 +60,6 @@ setup(name='deis',
           ('.', ['README.rst']),
       ],
       long_description=LONG_DESCRIPTION,
-      requires=['docopt', 'PyYAML', 'requests'],
+      requires=['docopt(>=0.6.1)', 'PyYAML(>=3.10)', 'requests(>=2.1.0)'],
       zip_safe=True,
       **KWARGS)


### PR DESCRIPTION
We weren't specifying the versions for docopt, requests, and pyyaml, but we apparently require a more recent version of requests in order not to trigger a MozillaCookieJar bug. I tested with the old and new versions of requests.
