### PR TITLE
Nathan/client config improvements

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -790,11 +790,13 @@ class DeisClient(object):
         """
         List environment variables for an application
 
-        Usage: deis config:list [--app=<app>]
+        Usage: deis config:list [--oneline] [--app=<app>]
         """
         app = args.get('--app')
         if not app:
             app = self._session.app
+
+        oneline = args.get('--oneline')
         response = self._dispatch('get', "/api/apps/{}/config".format(app))
         if response.status_code == requests.codes.ok:  # @UndefinedVariable
             config = response.json()
@@ -805,10 +807,18 @@ class DeisClient(object):
                 print('No configuration')
                 return
             keys = sorted(values)
-            width = max(map(len, keys)) + 5
-            for k in keys:
-                v = values[k]
-                print(("{k:<"+str(width)+"} {v}").format(**locals()))
+
+            if not oneline:
+                width = max(map(len, keys)) + 5
+                for k in keys:
+                    v = values[k]
+                    print(("{k:<"+str(width)+"} {v}").format(**locals()))
+            else:
+                output = []
+                for k in keys:
+                    v = values[k]
+                    output.append("{k}={v}".format(**locals()))
+                print(' '.join(output))
         else:
             raise ResponseError(response)
 


### PR DESCRIPTION
Add some improvements to the config:list command.

A) It shows the list of config variables sorted on key name (makes it easier to find back the correct key)
B) In the default output it aligns the values under each other (looks nicer, might break layout with long keys and/or value combinations)
(Note that this is an almost exact copy of Heroku's config output)

C) it adds a --oneline option to format the values in "KEY1=VALUE  KEY2=VALUE" format. This is usefull to copy (new) configuration to a production app.

I noticed that options passed to config (which should be an exact alias of config:list) do not work. I assume the same problem might exist for other aliases. I did not fix it yet but I might create another pull request later.
