### PR TITLE
Allow the provision-controller.sh script to run in a directory with spaces

### DIFF
--- a/contrib/vagrant/provision-controller.sh
+++ b/contrib/vagrant/provision-controller.sh
@@ -7,11 +7,11 @@ function echo_color {
   echo -e "\033[1m$1\033[0m"
 }
 
-THIS_DIR=$(cd $(dirname $0); pwd) # absolute path
-CONTRIB_DIR=$(dirname $THIS_DIR)
+THIS_DIR="$(cd $(dirname $0); pwd)" # absolute path
+CONTRIB_DIR=$(dirname "$THIS_DIR")
 
 # check for Deis' general dependencies
-if ! $CONTRIB_DIR/check-deis-deps.sh; then
+if ! "$CONTRIB_DIR/check-deis-deps.sh"; then
   echo 'Deis is missing some dependencies.'
   exit 1
 fi


### PR DESCRIPTION
I encountered this issue when trying to develop locally.

Note that the script is not yet finished running (donwloading a rather large .box file :)) so I might encounter more problems along the way (I will update this Merge proposal then).
