### PR TITLE
Script to reset DB and add basic fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ contrib/vagrant/nodes/
 # See Vagrantfile.local.example
 logs
 venv
+static
+!static/

--- a/api/fixtures/deis_dev.sql
+++ b/api/fixtures/deis_dev.sql
@@ -1,0 +1,41 @@
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+SET search_path = public, pg_catalog;
+
+--
+-- Data for Name: auth_user; Type: TABLE DATA; Schema: public; Owner: deis
+--
+
+COPY auth_user (id, password, last_login, is_superuser, username, first_name, last_name, email, is_staff, is_active, date_joined) FROM stdin;
+2	pbkdf2_sha256$12000$AMAIZeSq7IBP$6F8fYzjn7z1BBuBBDJfAA84eTW+SNknv6aqiYdc8OyY=	2014-01-20 07:58:08.834168-07	t	dev			dev@dev.com	t	t	2014-01-20 07:58:08.07811-07
+\.
+
+
+--
+-- Data for Name: api_formation; Type: TABLE DATA; Schema: public; Owner: deis
+--
+
+COPY api_formation (uuid, created, updated, owner_id, id, domain, nodes) FROM stdin;
+8edebda0-8a73-4de7-a32d-0760daa9563e	2014-01-20 07:58:10.749391-07	2014-01-20 07:58:10.74948-07	2	dev	\N	{}
+\.
+
+
+--
+-- Name: auth_user_id_seq; Type: SEQUENCE SET; Schema: public; Owner: deis
+--
+
+SELECT pg_catalog.setval('auth_user_id_seq', 2, true);
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/contrib/vagrant/README.md
+++ b/contrib/vagrant/README.md
@@ -89,10 +89,8 @@ the one from Pip.
   * Get a list of commands with; `./manage.py help`.
 
 * To reset the DB:
-  * On the VM run `sudo su postgres -c 'dropdb deis && createdb --encoding=utf8 --template=template0 deis'`
-  * When you restart the server with `sudo service deis-server restart` Django will reinstall the DB.
-  * You'll need to reupdate the Django's Site Object
-  `sudo su deis -c "psql deis -c \"UPDATE django_site SET domain = 'deis-controller.local', name = 'deis-controller.local' WHERE id = 1 \""`
+  * There is a script at `contrib/vagrant/util/reset-db.sh` that resets the DB and installs some basic fixtures.
+  * It installs a formation named 'dev' and a super user with username 'dev' and password 'dev'.
 
 * This is useful for uploading your own local version of the cookbooks, rather than the Github versions:
   * `knife cookbook upload deis --cookbook-path [deis-cookbook path] --force`

--- a/contrib/vagrant/util/reset-db.sh
+++ b/contrib/vagrant/util/reset-db.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+# NB. Command for exporting fixtures
+# pg_dump --data-only --table=api_formations --table=auth_user deis > api/fixtures/deis_dev.sql
+# And then edit the resulting SQL to remove the default anonymous user
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
+echo "Dropping and recreating Deis database..."
+su postgres -c 'dropdb deis && createdb --encoding=utf8 --template=template0 deis'
+echo "Running South migrations..."
+su deis -c '/opt/deis/controller/venv/bin/python /opt/deis/controller/manage.py syncdb --migrate --noinput'
+echo "Updating the Django site object..."
+su deis -c "psql deis -c \"UPDATE django_site SET domain = 'deis-controller.local', name = 'deis-controller.local' WHERE id = 1 \""
+echo "Importing fixtures for formation and super user..."
+su deis -c 'psql deis < /opt/deis/controller/api/fixtures/deis_dev.sql'


### PR DESCRIPTION
I found myself resetting the DB a lot, so I automated. It resets the DB, installs the migrations, updates the site object and installs fixtures for a formation (named 'dev') and a super user (with username 'dev' and password 'dev').

I've also added a gitignore for static, which is one of the symlinks that's created with `Vagrantfile.local`.
