### PR TITLE
`deis run` should not be able to modify app slugs

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -550,7 +550,7 @@ class App(UuidAuditedModel):
         version = release.version
         docker_args = ' '.join(
             ['-a', 'stdout', '-a', 'stderr', '-rm',
-             '-v', '/opt/deis/runtime/slugs/{app_id}-v{version}:/app'.format(**locals()),
+             '-v', '/opt/deis/runtime/slugs/{app_id}-v{version}:/app:ro'.format(**locals()),
              'deis/slugrunner'])
         env_args = ' '.join(["-e '{k}={v}'".format(**locals())
                              for k, v in release.config.values.items()])


### PR DESCRIPTION
Big thanks to @ksikka for reporting this serious (yet hard to reproduce) issue.

Though `deis run` uses an ephemeral container, it has the release slug bind-mounted into /app.  Because bind-mounts are read-write by default, any modifications to /app persist on the runtime host (even though they were performed inside the ephemeral container).

This PR changes `deis run` to bind-mount the slug to read-only, preventing this kind of disruptive modification.  If you try to write/delete form /app you'll receive an I/O error.  In the future, bind-mounts will go away and the slug will be an additional Docker image layer providing a better long-term solution.
