### PR TITLE
Only take into account the first equal sign when setting config vars

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -262,7 +262,7 @@ def dictify(args):
     data = {}
     for arg in args:
         try:
-            var, val = arg.split('=')
+            var, val = arg.split('=', 1)
         except ValueError:
             raise DocoptExit()
         # Try to coerce the value to an int since that's a common use case


### PR DESCRIPTION
Fixing a bug mentioned by mil0 on IRC

`deis config:set DATABASE_URL=postgres://user:p@$$w0<=rd@ip:/dbname` does not work'
