### PR TITLE
Revert bind-mounting slugs read-only.

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -550,7 +550,7 @@ class App(UuidAuditedModel):
         version = release.version
         docker_args = ' '.join(
             ['-a', 'stdout', '-a', 'stderr', '-rm',
-             '-v', '/opt/deis/runtime/slugs/{app_id}-v{version}:/app:ro'.format(**locals()),
+             '-v', '/opt/deis/runtime/slugs/{app_id}-v{version}:/app'.format(**locals()),
              'deis/slugrunner'])
         env_args = ' '.join(["-e '{k}={v}'".format(**locals())
                              for k, v in release.config.values.items()])


### PR DESCRIPTION
``` irc
<n 12:37> whatever I do I get Warning: non-zero return code 1
<n 12:37> /runner/init: line 23: .profile.d/config_vars: Read-only file system
<g 12:37> shell interpolation rules are strange
<g 12:38> n: does the command run?
<n 12:38> no
<n 12:39> any app has the same problem
<n 12:39> even ones without any (non default) config variables set
<g 12:40> bug was introduced here: https://github.com/opdemand/deis/pull/489
<n 12:40> yep
<m 12:40> oh...
<n 12:40> I guess
<g 12:40> problem is that slugrunner does this https://github.com/flynn/slugrunner/blob/master/runner/init#L23
<n 12:41> yep I saw :)
<g 12:41> on the whole this problem is going away, since we'll be running straight off a docker r/w layer
<g 12:43> i'm going to suggest reverting the PR, since a functioning `deis run` is _slightly_ more important than integrity of the slug contents..
<g 12:45> though both are bad
<g 12:45> again, this is fixed w/ the new docker image runtime
<g 12:45> m: can you do me a favor and roll back that PR in master?
```
