### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,12 +60,12 @@ GEM
       json
       rash
     em-winrm (0.5.4)
-      eventmachine (= 1.0.0.beta.3)
+      eventmachine (= 1.0.3)
       mixlib-log (>= 1.3.0)
       uuidtools (~> 2.1.1)
       winrm (~> 1.1.0)
     erubis (2.7.0)
-    eventmachine (1.0.0.beta.3)
+    eventmachine (1.0.3)
     excon (0.25.3)
     faraday (0.8.9)
       multipart-post (~> 1.2.0)


### PR DESCRIPTION
eventmachine (1.0.0.beta.3) is not available anymore, changed to 1.0.3
