### PR TITLE
Added client binary support via PyInstaller, refs #472.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,8 @@ coverage:
 test_client:
 	python -m unittest discover client.tests
 
+client_binary:
+	cd client && pyinstaller deis.spec
+
 flake8:
 	flake8

--- a/client/deis.spec
+++ b/client/deis.spec
@@ -1,0 +1,17 @@
+# -*- mode: python -*-
+a = Analysis(['deis.py'],
+             pathex=['.'],
+             hiddenimports=[],
+             hookspath=None,
+             runtime_hooks=None)
+pyz = PYZ(a.pure)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name='deis',
+          debug=False,
+          strip=None,
+          upx=True,
+          console=True )

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -26,6 +26,9 @@ python-dateutil==2.2
 #PyYAML==3.10
 requests==2.2.1
 
+# PyInstaller builds client binaries
+PyInstaller==2.1
+
 # Deis documentation requirements
 Sphinx>=1.2.1
 smartypants>=1.8.3


### PR DESCRIPTION
Seems to work fine on Windows 7 and Mac OS 10.8.
