### PR TITLE
Adding port 8000 to the EC2 security group

### DIFF
--- a/contrib/ec2/provision-ec2-controller.sh
+++ b/contrib/ec2/provision-ec2-controller.sh
@@ -83,13 +83,14 @@ if ! ec2-describe-group | grep -q "$sg_name"; then
   set -x
   ec2-create-group $sg_name -d "Created by Deis"
   set +x
-  echo_color "Authorizing TCP ports 22,80,443,514 from $sg_src..."
+  echo_color "Authorizing TCP ports 22,80,443,514,2222,8000 from $sg_src..."
   set -x
   ec2-authorize deis-controller -P tcp -p 22 -s $sg_src >/dev/null
   ec2-authorize deis-controller -P tcp -p 80 -s $sg_src >/dev/null
   ec2-authorize deis-controller -P tcp -p 443 -s $sg_src >/dev/null
   ec2-authorize deis-controller -P tcp -p 514 -s $sg_src >/dev/null
   ec2-authorize deis-controller -P tcp -p 2222 -s $sg_src >/dev/null
+  ec2-authorize deis-controller -P tcp -p 8000 -s $sg_src >/dev/null
   set +x
 else
   echo_color "Security group $sg_name exists"


### PR DESCRIPTION
This pull request intends to get the EC2 to allow you to register a brand new provisioned controller by getting port 8000 in the security group. This issue was mentioned on #291

The http://deis.io/get-deis/ page also needs to be improved. How can I contribute that?
