### PR TITLE
fix some inconstancies within the rackspace contrib instructions

### DIFF
--- a/contrib/rackspace/README.md
+++ b/contrib/rackspace/README.md
@@ -44,9 +44,9 @@ Provision a Deis Controller on Rackspace
         ...
         ```
 
-1. Create a new image from the `deis-prepare-image` server named `deis-base-image`.
+1. Create a new image from the `deis-prepare-image` server named `deis-node-image`.
     1. In the server list in the Control Panel click the action cog for `deis-prepare-image`
-    1. Select "Create New Image" name that image `deis-base-image`
+    1. Select "Create New Image" name that image `deis-node-image`
     1. (optionally) Distribute the image to other regions
     1. (optionally) Create/update your Deis flavors to use your new images
 

--- a/contrib/rackspace/provision-rackspace-controller.sh
+++ b/contrib/rackspace/provision-rackspace-controller.sh
@@ -93,4 +93,4 @@ knife rackspace server create \
 set +x
 
 # Need Chef admin permission in order to add and remove nodes and clients
-echo -e "\033[35mPlease ensure that \"deis-controller\" is added to the Chef \"admins\" group.\033[0m"
+echo -e "\033[35mPlease ensure that \"$node_name\" is added to the Chef \"admins\" group.\033[0m"


### PR DESCRIPTION
During my initial installation the inconsistency of image name caused some confusion.
Rackspace don't allow you to rename server images.

I also added a small change the the provisioner to use the variable $node_name rather than hard coding 'deis-controller' within the final notice, as this made the notice make more sence if $node_name had been changed.
