### PR TITLE
add username validation check to on register

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -649,9 +649,9 @@ class DeisClient(object):
             username = raw_input('username: ')
             # this is limited due to docker's limit on image names
             # when pushed to repository
-            match = re.match(r'[a-z0-9_]+', username)
+            match = re.match(r'^[a-z0-9_]{4,30}$', username)
             if not match:
-                print("Illegal username, only [a-z0-9_] are allowed")
+                print("Illegal username, only [a-z0-9_] are allowed, size between 4 and 30")
                 return False
         password = args.get('--password')
         if not password:


### PR DESCRIPTION
I've tried to register a user with "." in the username and found this prevents me from successfully pushing an app to the builder.

Further research yielded these lines:

```
docker push 10.88.103.88:5000/n.friedman/example-ruby-sinatra
2014/02/27 11:29:38 Invalid namespace name (n.friedman), only [a-z0-9_] are allowed, size between 4 and 30
```

I've run this when attached to the builder container using `lxc-attach`

Another option to solve this would be to sanitize the images name, but this could result in similar names for different users, which is probably not good.
