### PR TITLE
Allow controller to run behind an SSL termination proxy

### DIFF
--- a/deis/settings.py
+++ b/deis/settings.py
@@ -312,6 +312,8 @@ DATABASES = {
 # see https://docs.djangoproject.com/en/1.5/ref/settings/#std:setting-ALLOWED_HOSTS
 ALLOWED_HOSTS = ['*']
 
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 # import dynamic confd settings from /app, if they exist
 try:
     if os.path.exists('/app/confd_settings.py'):


### PR DESCRIPTION
If you have SSL termination setup on an AWS ELB (or other SSL termination proxy), the controller incorrectly redirects to HTTP when using HTTPS causing browser hangs and other problems.   
