### PR TITLE
change box_url to be the same as controller

### DIFF
--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -2,7 +2,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "deis-server"
 
   # Ubuntu 12.04.3 LTS base with 3.8 kernel (ready for Docker)
-  config.vm.box_url = "https://oss-binaries.phusionpassenger.com/vagrant/boxes/ubuntu-12.04.3-amd64-vbox.box"
+  config.vm.box_url = "https://s3-us-west-2.amazonaws.com/opdemand/ubuntu-12.04.3-amd64-vbox.box"
 
   # Avahi-daemon will broadcast the server's address as deis-controller.local
   config.vm.host_name = "deis-controller"

--- a/contrib/vagrant/util/nodes_vagrantfile_template.rb
+++ b/contrib/vagrant/util/nodes_vagrantfile_template.rb
@@ -3,7 +3,7 @@ Vagrant.configure("2") do |config|
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  config.vm.box_url = "https://oss-binaries.phusionpassenger.com/vagrant/boxes/ubuntu-12.04.3-amd64-vbox.box"
+  config.vm.box_url = "https://s3-us-west-2.amazonaws.com/opdemand/ubuntu-12.04.3-amd64-vbox.box"
 
   # Avahi-daemon will broadcast the node's address as $id.local
   config.vm.host_name = "$id"


### PR DESCRIPTION
right now, we have our default Vagrantfile pointing its box_url to https://oss-binaries.phusionpassenger.com/vagrant/boxes/ubuntu-12.04.3-amd64-vbox.box. All Deis nodes should be on the same base VM so that we are consistent.

Also note that the reason why I hit https://github.com/opdemand/deis/pull/528#issuecomment-36702990 was because of this. I did not have a `deis-node` box under `~/.vagrant.d/boxes`, so the timeout issue was from having to re-download the same box, just with a different name.
