### PR TITLE
Updated EC2 AMIs from prep scripts.

### DIFF
--- a/contrib/ec2/provision-ec2-controller.sh
+++ b/contrib/ec2/provision-ec2-controller.sh
@@ -45,21 +45,21 @@ region=$1
 # see contrib/prepare-ubuntu-ami.sh for instructions
 # on creating your own deis-optmized AMIs
 if [ "$region" == "ap-northeast-1" ]; then
-  image=ami-ed7503ec
+  image=ami-55007154
 elif [ "$region" == "ap-southeast-1" ]; then
-  image=ami-76673624
+  image=ami-4eb4e51c
 elif [ "$region" == "ap-southeast-2" ]; then
-  image=ami-7dbb2247
+  image=ami-6f5bc255
 elif [ "$region" == "eu-west-1" ]; then
-  image=ami-bd31c3ca
+  image=ami-c7ef12b0
 elif [ "$region" == "sa-east-1" ]; then
-  image=ami-2964c734
+  image=ami-3945e624
 elif [ "$region" == "us-east-1" ]; then
-  image=ami-f9080a90
+  image=ami-c50408ac
 elif [ "$region" == "us-west-1" ]; then
-  image=ami-148bb751
+  image=ami-963906d3
 elif [ "$region" == "us-west-2" ]; then
-  image=ami-f082eec0
+  image=ami-606a0550
 else
   echo "Cannot find AMI for region: $region"
   exit 1

--- a/provider/ec2.py
+++ b/provider/ec2.py
@@ -17,14 +17,14 @@ from deis import settings
 # Deis-optimized EC2 amis -- with 3.8 kernel, chef 11 deps,
 # and large docker images (e.g. buildstep) pre-installed
 IMAGE_MAP = {
-    'ap-northeast-1': 'ami-f37503f2',
-    'ap-southeast-1': 'ami-7867362a',
-    'ap-southeast-2': 'ami-71bb224b',
-    'eu-west-1': 'ami-af31c3d8',
-    'sa-east-1': 'ami-2b64c736',
-    'us-east-1': 'ami-c1080aa8',
-    'us-west-1': 'ami-1c8bb759',
-    'us-west-2': 'ami-f282eec2',
+    'ap-northeast-1': 'ami-59007158',
+    'ap-southeast-1': 'ami-4cb4e51e',
+    'ap-southeast-2': 'ami-6d5bc257',
+    'eu-west-1': 'ami-c3ef12b4',
+    'sa-east-1': 'ami-3b45e626',
+    'us-east-1': 'ami-d90408b0',
+    'us-west-1': 'ami-9c3906d9',
+    'us-west-2': 'ami-8c6a05bc',
 }
 
 


### PR DESCRIPTION
``` console
rhialto:ec2 matt$ # Distribute the controller image
rhialto:ec2 matt$ ./distribute-amis.sh us-west-2 ami-606a0550
+ src_region=us-west-2
+ src_ami=ami-606a0550
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' ap-northeast-1 = us-west-2 ']'
+ ec2-copy-image -r us-west-2 -s ami-606a0550 --region ap-northeast-1
IMAGE   ami-55007154
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' ap-southeast-1 = us-west-2 ']'
+ ec2-copy-image -r us-west-2 -s ami-606a0550 --region ap-southeast-1
IMAGE   ami-4eb4e51c
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' ap-southeast-2 = us-west-2 ']'
+ ec2-copy-image -r us-west-2 -s ami-606a0550 --region ap-southeast-2
IMAGE   ami-6f5bc255
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' eu-west-1 = us-west-2 ']'
+ ec2-copy-image -r us-west-2 -s ami-606a0550 --region eu-west-1
IMAGE   ami-c7ef12b0
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' sa-east-1 = us-west-2 ']'
+ ec2-copy-image -r us-west-2 -s ami-606a0550 --region sa-east-1
IMAGE   ami-3945e624
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' us-east-1 = us-west-2 ']'
+ ec2-copy-image -r us-west-2 -s ami-606a0550 --region us-east-1
IMAGE   ami-c50408ac
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' us-west-1 = us-west-2 ']'
+ ec2-copy-image -r us-west-2 -s ami-606a0550 --region us-west-1
IMAGE   ami-963906d3
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' us-west-2 = us-west-2 ']'
+ continue
rhialto:ec2 matt$ # Distribute the node image
rhialto:ec2 matt$ ./distribute-amis.sh us-west-2 ami-8c6a05bc
+ src_region=us-west-2
+ src_ami=ami-8c6a05bc
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' ap-northeast-1 = us-west-2 ']'
+ ec2-copy-image -r us-west-2 -s ami-8c6a05bc --region ap-northeast-1
IMAGE   ami-59007158
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' ap-southeast-1 = us-west-2 ']'
+ ec2-copy-image -r us-west-2 -s ami-8c6a05bc --region ap-southeast-1
IMAGE   ami-4cb4e51e
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' ap-southeast-2 = us-west-2 ']'
+ ec2-copy-image -r us-west-2 -s ami-8c6a05bc --region ap-southeast-2
IMAGE   ami-6d5bc257
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' eu-west-1 = us-west-2 ']'
+ ec2-copy-image -r us-west-2 -s ami-8c6a05bc --region eu-west-1
IMAGE   ami-c3ef12b4
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' sa-east-1 = us-west-2 ']'
+ ec2-copy-image -r us-west-2 -s ami-8c6a05bc --region sa-east-1
IMAGE   ami-3b45e626
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' us-east-1 = us-west-2 ']'
+ ec2-copy-image -r us-west-2 -s ami-8c6a05bc --region us-east-1
IMAGE   ami-d90408b0
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' us-west-1 = us-west-2 ']'
+ ec2-copy-image -r us-west-2 -s ami-8c6a05bc --region us-west-1
IMAGE   ami-9c3906d9
+ for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-west-1 sa-east-1 us-east-1 us-west-1 us-west-2
+ '[' us-west-2 = us-west-2 ']'
+ continue
rhialto:ec2 matt$ 
```
