### PR TITLE
Updated Chef references to 11.8.2.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.16)
+    activesupport (3.2.17)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     addressable (2.3.5)
@@ -25,7 +25,7 @@ GEM
     buff-config (0.4.0)
       buff-extensions (~> 0.3)
       varia_model (~> 0.1)
-    buff-extensions (1.0.0)
+    buff-extensions (0.6.0)
     buff-ignore (1.1.1)
     buff-ruby_engine (0.1.0)
     buff-shell_out (0.1.1)
@@ -59,11 +59,11 @@ GEM
       faraday_middleware (~> 0.9.0)
       json
       rash
-    em-winrm (0.5.4)
-      eventmachine (= 1.0.3)
+    em-winrm (0.5.5)
+      eventmachine (~> 1.0.0)
       mixlib-log (>= 1.3.0)
       uuidtools (~> 2.1.1)
-      winrm (~> 1.1.0)
+      winrm (~> 1.1.2)
     erubis (2.7.0)
     eventmachine (1.0.3)
     excon (0.25.3)
@@ -89,7 +89,7 @@ GEM
     gyoku (1.1.1)
       builder (>= 2.1.2)
     hashie (2.0.5)
-    highline (1.6.20)
+    highline (1.6.21)
     hitimes (1.2.1)
     httpclient (2.3.4.1)
     httpi (0.9.7)
@@ -109,8 +109,8 @@ GEM
       chef (>= 0.10.10)
       fog (~> 1.12)
       knife-windows
-    knife-windows (0.5.14)
-      em-winrm (= 0.5.4)
+    knife-windows (0.5.15)
+      em-winrm (~> 0.5, >= 0.5.4)
     little-plugger (1.1.3)
     logging (1.8.2)
       little-plugger (>= 1.1.3)
@@ -124,7 +124,7 @@ GEM
     mixlib-config (1.1.2)
     mixlib-log (1.6.0)
     mixlib-shellout (1.3.0)
-    multi_json (1.8.4)
+    multi_json (1.9.0)
     multipart-post (1.2.0)
     net-http-persistent (2.9.4)
     net-scp (1.1.2)

--- a/contrib/digitalocean/provision-digitalocean-controller.sh
+++ b/contrib/digitalocean/provision-digitalocean-controller.sh
@@ -43,7 +43,7 @@ fi
 #################
 node_name="deis-controller-$(LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 5 | xargs)"
 run_list="recipe[deis::controller]"
-chef_version=11.6.2
+chef_version=11.8.2
 
 if [ $node_name = 'deis-controller-' ]; then
   echo "Couldn't generate unique name for deis-controller. Aborting."

--- a/contrib/rackspace/provision-rackspace-controller.sh
+++ b/contrib/rackspace/provision-rackspace-controller.sh
@@ -32,7 +32,7 @@ fi
 #################
 node_name=deis-controller
 run_list="recipe[deis::controller]"
-chef_version=11.6.2
+chef_version=11.8.2
 
 ######################
 # Rackspace settings #

--- a/contrib/vagrant/provision-vagrant-controller.sh
+++ b/contrib/vagrant/provision-vagrant-controller.sh
@@ -54,7 +54,7 @@ git submodule init && git submodule update
 #################
 node_name=deis-controller
 run_list="recipe[deis::controller]"
-chef_version=11.6.2
+chef_version=11.8.2
 
 ################
 # SSH settings #

--- a/docs/operations/provision-controller.rst
+++ b/docs/operations/provision-controller.rst
@@ -51,7 +51,7 @@ Here is an example ``knife bootstrap`` command:
 .. code-block:: console
 
     $ knife bootstrap 198.51.100.22 \
-    >  --bootstrap-version 11.6.2 \
+    >  --bootstrap-version 11.8.2 \
     >  --ssh-user ubuntu \
     >  --sudo \
     >  --identity-file ~/.ssh/id_rsa \


### PR DESCRIPTION
We had some refs to 11.6.2 and some to 11.8.2 (still a somewhat outdated version). Our recipes seem to work fine with either. This syncs up all Chef references to the same version we've been using in EC2 provisioning.
