### PR TITLE
added install script for avahi

### DIFF
--- a/contrib/vagrant/util/nodes_vagrantfile_template.rb
+++ b/contrib/vagrant/util/nodes_vagrantfile_template.rb
@@ -15,16 +15,11 @@ Vagrant.configure("2") do |config|
     vb.customize ["modifyvm", :id, "--memory", "$memory"]
   end
 
-  config.vm.provision :shell, inline: <<-SCRIPT
-    # Avahi-daemon broadcasts the machine's hostname to local DNS.
-    # Therefore 'deis-controller.local' in this case.
-    sudo apt-get install -yq avahi-daemon
-  SCRIPT
-
   # Enable [hostname].local autodiscovery between VMs
   config.vm.provision :shell, inline: <<-SCRIPT
     # Avahi-daemon broadcasts the machine's hostname to local DNS.
     # So $id.local in this case
+    sudo apt-get install -yq avahi-daemon
     sudo service avahi-daemon restart
     echo "*.* @@192.168.61.100:514" > /etc/rsyslog.d/51-remote.conf
   SCRIPT


### PR DESCRIPTION
Fixes #599 

`avahi` was missing on the vagrant nodes, so their hostnames could not route properly.
