### PR TITLE
Updated vagrant readme

### DIFF
--- a/contrib/vagrant/README.md
+++ b/contrib/vagrant/README.md
@@ -17,14 +17,6 @@ bear in mind that a local Chef Server VM will take up at least 1GB of RAM.
     * copy the admin.pem and validation.pem files for your own knife client
     `scp -r root@chefserver.local:/etc/chef-server/admin.pem [DEIS_DIR]/contrib/vagrant/knife-config/`
     `scp -r root@chefserver.local:/etc/chef-server/chef-validator.pem [DEIS_DIR]/contrib/vagrant/knife-config/`
-    * If you are on a OS X your should `vagrant ssh` into the chef server and set the hostname to `chefserver.local`.
-      Do this by running:
-      
-      ```
-      sudo hostname 'chefserver.local'
-      echo "chefserver.local" | sudo tee /etc/hostname
-      sudo chef-server-ctl reconfigure
-      ```
 
     **Hosted Chef Server**
     * Goto https://getchef.opscode.com/signup and fill in your details.

--- a/contrib/vagrant/chef-server/Vagrantfile
+++ b/contrib/vagrant/chef-server/Vagrantfile
@@ -27,6 +27,8 @@ Vagrant.configure("2") do |config|
       sudo aptitude install avahi-daemon avahi-discover libnss-mdns -y
       sudo wget https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chef-server_11.0.8-1.ubuntu.12.04_amd64.deb
       sudo dpkg -i chef-server_11.0.8-1.ubuntu.12.04_amd64.deb
+      sudo hostname 'chefserver.local'
+      echo "chefserver.local" | sudo tee /etc/hostname
       sudo chef-server-ctl reconfigure
       sudo chef-server-ctl test # Optional
     fi


### PR DESCRIPTION
Added docs about the berkshelf dependency for --ssl-verify and the local chef server hostname. These were problems I encountered when following this guide.
