### PR TITLE
pin ruby to v2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.0.0'
+
 gem 'chef'
 gem 'foodcritic'
 #gem 'berkshelf', '3.0.0.beta3' # needed for --ssl-verify=false support


### PR DESCRIPTION
There are some gem issues when running the knife client with ruby v1.9.3. Let's pin the version to v2.0.0, which has no known gem dependency issues.

```
><> knife vault list
/Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/provider/package/dpkg.rb:26:in `<class:Package>': uninitialized constant Chef::Provider::Package::Apt (NameError)
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/provider/package/dpkg.rb:25:in `<class:Provider>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/provider/package/dpkg.rb:24:in `<class:Chef>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/provider/package/dpkg.rb:23:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/platform.rb:24:in `require'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/platform.rb:24:in `block in <top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/platform.rb:24:in `each'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/platform.rb:24:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/provider/package.rb:23:in `require'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/provider/package.rb:23:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/provider/package/apt.rb:19:in `require'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/provider/package/apt.rb:19:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/resource/apt_package.rb:20:in `require'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/resource/apt_package.rb:20:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/recipe.rb:21:in `require'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/recipe.rb:21:in `block in <top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/recipe.rb:21:in `each'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/recipe.rb:21:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/cookbook.rb:23:in `require'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/cookbook.rb:23:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/cookbook_loader.rb:22:in `require'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/cookbook_loader.rb:22:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/mixin/find_preferred_file.rb:19:in `require'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/mixin/find_preferred_file.rb:19:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef.rb:27:in `require'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef.rb:27:in `block in <top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef.rb:27:in `each'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef.rb:27:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/log.rb:20:in `require'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/log.rb:20:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/config.rb:20:in `require'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/config.rb:20:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/application.rb:18:in `require'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/application.rb:18:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/application/knife.rb:19:in `require'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/lib/chef/application/knife.rb:19:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/bin/knife:24:in `require'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/gems/chef-0.8.10/bin/knife:24:in `<top (required)>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/bin/knife:23:in `load'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/bin/knife:23:in `<main>'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/bin/ruby_executable_hooks:15:in `eval'
    from /Users/bacongobbler/.rvm/gems/ruby-1.9.3-p545/bin/ruby_executable_hooks:15:in `<main>'
```
