### PR TITLE
feat(Makefile): let each project manage how it builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,5 @@ test_client:
 
 build:
 	for image in builder cache controller database discovery logger registry; do \
-		pushd $$image; \
-		docker build -t deis/$$image .; \
-		popd; \
+		make -C $$image build; \
 	done


### PR DESCRIPTION
Instead of hardcoding `docker build -t deis/<component> .`, we should let each project manage how they build themselves by handing it over to their `make build` command.
