### PR TITLE
Updated CLI binaries and links in client README.

### DIFF
--- a/client/README.rst
+++ b/client/README.rst
@@ -78,9 +78,9 @@ Get Started
 If you don't have `Python`_ installed, you can download a binary executable
 version of the Deis client for Mac OS X, Windows, or Debian Linux:
 
-    - https://s3-us-west-2.amazonaws.com/opdemand/deis-osx-0.5.2.tgz
-    - https://s3-us-west-2.amazonaws.com/opdemand/deis-win64-0.5.2.zip
-    - https://s3-us-west-2.amazonaws.com/opdemand/deis-deb-wheezy-0.5.2.tgz
+    - https://s3-us-west-2.amazonaws.com/opdemand/deis-osx-0.6.0.tgz
+    - https://s3-us-west-2.amazonaws.com/opdemand/deis-win64-0.6.0.zip
+    - https://s3-us-west-2.amazonaws.com/opdemand/deis-deb-wheezy-0.6.0.tgz
 
 2. `Register a User`_:
 


### PR DESCRIPTION
As per the README.rst, binary clients built on target platforms via "pyinstaller deis.spec", tested, uploaded to opdemand S3 bucket as publicly downloadable.
