### PR TITLE
Restored deis data bags creation to provision script.

### DIFF
--- a/contrib/vagrant/provision-vagrant-controller.sh
+++ b/contrib/vagrant/provision-vagrant-controller.sh
@@ -93,6 +93,10 @@ else
   echo_color "Key already added."
 fi
 
+# create data bags
+knife data bag create deis-formations 2>/dev/null
+knife data bag create deis-apps 2>/dev/null
+
 chef_json=$(echo '
 {
   "deis": {


### PR DESCRIPTION
Fixes #664.

At some point during Vagrant refactoring we lost the data bag creation in the provision script, although it's still in EC2, Rackspace, and DO.
