### PR TITLE
Adds friendly name in VirtualBox

### DIFF
--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -10,9 +10,12 @@ Vagrant.configure("2") do |config|
   # IP will be associated to 'deis-controller.local' using avahi-daemon
   config.vm.network :private_network, ip: "192.168.61.100"
 
-  # The Deis Controller requires at least 2G of RAM to install.
   config.vm.provider :virtualbox do |vb|
+    # The Deis Controller requires at least 2G of RAM to install.
     vb.customize ["modifyvm", :id, "--memory", "2048"]
+    
+    # Displays a friendly name in the VirtualBox GUI
+    vb.name = "deis-controller"
   end
 
   config.vm.synced_folder "../../", "/vagrant"


### PR DESCRIPTION
Currently, the VM gets the name of "default" in VirtualBox. Anyone who is using VirtualBox for other purposes will find this confusing, and will be unable to identify the VM by name.

This commit gives the VM a name of "deis-controller" in VirtualBox.
