### PR TITLE
Pin pep8, pyflakes and flake8 to avoid Travis errors

### DIFF
--- a/controller/dev_requirements.txt
+++ b/controller/dev_requirements.txt
@@ -19,7 +19,9 @@ coverage>=3.7.1
 docutils>=0.11
 
 # Run "make flake8" to check python syntax and style
-flake8>=2.1.0
+flake8==2.1.0
+pep8==1.4.6
+pyflakes==0.7.3
 
 # Python expect is used to automate client-driven tests
 pexpect>=3.1


### PR DESCRIPTION
New versions of pep8 and pyflakes came out, which resulted in lots of flake8 errors on Travis:

```
$ make -C controller flake8
make: Entering directory `/home/travis/build/opdemand/deis/controller'
flake8
./api/models.py:850:16: E713 test for membership should be 'not in'
./api/views.py:316:12: E713 test for membership should be 'not in'
./api/views.py:472:12: E713 test for membership should be 'not in'
./api/migrations/0001_initial.py:2:1: F401 'datetime' imported but unused
./api/migrations/0001_initial.py:5:1: F401 'models' imported but unused
./api/migrations/0001_initial.py:13:100: E501 line too long (100 > 99 characters)
./api/migrations/0001_initial.py:14:100: E501 line too long (105 > 99 characters)
...
```

Pinning versions to what we currently have until we can catch up with the new rules.
