### PR TITLE
fix(builder+contrib): install lxc explicitly

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install -yq aufs-tools iptables ca-certificates lxc
 RUN echo "deb http://get.docker.io/ubuntu docker main" > /etc/apt/sources.list.d/docker.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 RUN apt-get update -q
-RUN apt-get install -yq lxc-docker-0.9.0
+RUN apt-get install -yq lxc lxc-docker-0.9.0
 
 # install recent pip
 RUN wget -qO- https://raw.github.com/pypa/pip/1.5.4/contrib/get-pip.py | python -

--- a/contrib/digitalocean/prepare-controller-image.sh
+++ b/contrib/digitalocean/prepare-controller-image.sh
@@ -28,7 +28,7 @@ apt-get upgrade -yq
 wget -qO- https://raw.github.com/pypa/pip/1.5.4/contrib/get-pip.py | python -
 
 # install required packages
-apt-get install lxc-docker-0.9.0 fail2ban curl git inotify-tools make -yq
+apt-get install lxc lxc-docker-0.9.0 fail2ban curl git inotify-tools make -yq
 
 # wait for docker to start
 while [ ! -e /var/run/docker.sock ] ; do

--- a/contrib/digitalocean/prepare-node-image.sh
+++ b/contrib/digitalocean/prepare-node-image.sh
@@ -28,7 +28,7 @@ apt-get upgrade -yq
 wget -qO- https://raw.github.com/pypa/pip/1.5.4/contrib/get-pip.py | python -
 
 # install required packages
-apt-get install lxc-docker-0.9.0 fail2ban curl git inotify-tools make -yq
+apt-get install lxc lxc-docker-0.9.0 fail2ban curl git inotify-tools make -yq
 
 # wait for docker to start
 while [ ! -e /var/run/docker.sock ] ; do

--- a/contrib/ec2/prepare-controller-ami.sh
+++ b/contrib/ec2/prepare-controller-ami.sh
@@ -33,7 +33,7 @@ apt-get dist-upgrade -yq
 wget -qO- https://raw.github.com/pypa/pip/1.5.4/contrib/get-pip.py | python -
 
 # install required packages
-apt-get install lxc-docker-0.9.0 fail2ban curl git inotify-tools make -yq
+apt-get install lxc lxc-docker-0.9.0 fail2ban curl git inotify-tools make -yq
 
 # wait for docker to start
 while [ ! -e /var/run/docker.sock ] ; do

--- a/contrib/ec2/prepare-node-ami.sh
+++ b/contrib/ec2/prepare-node-ami.sh
@@ -33,7 +33,7 @@ apt-get dist-upgrade -yq
 wget -qO- https://raw.github.com/pypa/pip/1.5.4/contrib/get-pip.py | python -
 
 # install required packages
-apt-get install lxc-docker-0.9.0 fail2ban curl git inotify-tools make -yq
+apt-get install lxc lxc-docker-0.9.0 fail2ban curl git inotify-tools make -yq
 
 # wait for docker to start
 while [ ! -e /var/run/docker.sock ] ; do

--- a/contrib/rackspace/prepare-node-image.sh
+++ b/contrib/rackspace/prepare-node-image.sh
@@ -34,7 +34,7 @@ apt-get dist-upgrade -yq
 wget -qO- https://raw.github.com/pypa/pip/1.5.4/contrib/get-pip.py | python -
 
 # install required packages
-apt-get install lxc-docker-0.9.0 fail2ban curl git inotify-tools make -yq
+apt-get install lxc lxc-docker-0.9.0 fail2ban curl git inotify-tools make -yq
 
 # wait for docker to start
 while [ ! -e /var/run/docker.sock ] ; do

--- a/contrib/vagrant/prepare-ubuntu-box.sh
+++ b/contrib/vagrant/prepare-ubuntu-box.sh
@@ -35,7 +35,7 @@ apt-get dist-upgrade -yq
 wget -qO- https://raw.github.com/pypa/pip/1.5.4/contrib/get-pip.py | python -
 
 # install required packages
-apt-get install lxc-docker-0.9.0 fail2ban curl git inotify-tools make -yq
+apt-get install lxc lxc-docker-0.9.0 fail2ban curl git inotify-tools make -yq
 
 # wait for docker to start
 while [ ! -e /var/run/docker.sock ] ; do


### PR DESCRIPTION
As of lxc-docker-9.0, the lxc package is no longer installed on Ubuntu.
