### PR TITLE
Added major *scheduler* branch to Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ branches:
   only:
     - master
     - release
+    - scheduler
 
 services:
   - postgresql


### PR DESCRIPTION
The _scheduler_ branch is a large refactoring that would benefit from CI testing. To do that for travis-ci.org, we add it to the branches -> only YAML in the _master_ branch.
