### PR TITLE
fix(logger): update rsyslog repo endpoint

### DIFF
--- a/logger/Dockerfile
+++ b/logger/Dockerfile
@@ -2,11 +2,12 @@ FROM deis/base:latest
 MAINTAINER Gabriel Monroy <gabriel@opdemand.com>
 
 # install rsyslog from rsyslog.com
-RUN echo "deb http://ubuntu.adiscon.com/v7-stable precise/" > /etc/apt/sources.list.d/rsyslog.list
+RUN echo "deb http://ppa.launchpad.net/adiscon/v7-stable/ubuntu precise main" > /etc/apt/sources.list.d/rsyslog.list
+RUN echo "deb-src http://ppa.launchpad.net/adiscon/v7-stable/ubuntu precise main" >> /etc/apt/sources.list.d/rsyslog.list
 RUN gpg --recv-keys --keyserver keyserver.ubuntu.com AEF0CF8E
 RUN gpg --export --armor AEF0CF8E | sudo apt-key add -
 RUN apt-get update
-RUN apt-get install -yq rsyslog
+RUN apt-get install -yq --force-yes rsyslog
 
 # create /var/log/deis for holding logs (access via bind mount)
 RUN mkdir -p /var/log/deis


### PR DESCRIPTION
ubuntu.adiscon.com has moved to launchpad. See http://ubuntu.adiscon.com/v7-stable and http://www.rsyslog.com/ubuntu-repository/.
