### PR TITLE
docs(chef): update for the new manage.opscode.com

### DIFF
--- a/contrib/ec2/provision-ec2-controller.sh
+++ b/contrib/ec2/provision-ec2-controller.sh
@@ -133,4 +133,4 @@ knife ec2 server create \
 set +x
 
 # Need Chef admin permission in order to add and remove nodes and clients
-echo -e "\033[35mPlease ensure that \"deis-controller\" is added to the Chef \"admins\" group.\033[0m"
+echo -e "\033[35mPlease ensure that the \"deis-controller-ec2\" client object is added to the Chef \"admins\" group.\033[0m"

--- a/contrib/rackspace/README.md
+++ b/contrib/rackspace/README.md
@@ -72,8 +72,7 @@ Provision a Deis Controller on Rackspace
     3. (optionally) Distribute the image to other regions
     4. (optionally) Create/update your Deis flavors to use your new images
 
-6. Make sure to add the `deis-controller` and the `<your_username>-validator` usernames to the Chef 'admins' group.
-    * If you are using hosted Chef, you may need to use the older console to do this: <https://manage.opscode.com/groups/admins/edit>
+6. Make sure to add the `deis-controller` client object and the `<your_username>-validator` usernames to the Chef 'admins' group.
 
 7. Back on your machine with deis cloned and the deis CLI installed, run the provisioning script to create a new Deis controller:
     * Change ```<region>``` to match the region your image is in (we will add SYD and HKG as soon as performance flavors are available there):

--- a/contrib/vagrant/README.md
+++ b/contrib/vagrant/README.md
@@ -20,12 +20,10 @@ bear in mind that a local Chef Server VM will take up at least 1GB of RAM.
 
     **Hosted Chef Server**
     * Goto https://getchef.opscode.com/signup and fill in your details.
-    * Goto https://preview.opscode.com/login and sign in to your Chef Server.
+    * Goto https://manage.opscode.com/login and sign in to your Chef Server.
     * Click on the 'Administration' tab and choose your organisation. There should be a tab in the sidebar that says
     'Starter Kit'. Click it and it will start a small download.
     * Inside the Starter Kit there is a '.chef' folder. Copy it to the root of your Deis codebase.
-    * **NB**: You can also manage your Chef Server through https://manage.opscode.com This is the old
-    interface and has more features, like being able to add clients to permission groups.
 
 3. Now you can follow the standard deis setup:
   * If you're running a local chef server, you should adjust the `Gemfile` and make sure the version of berkshelf is 3.0.x. This is needed for the `--ssl-verify` option to work correctly.
@@ -54,9 +52,11 @@ you will need a running SSH server open on port 22 and a means to broadcast your
     and delete nodes. Use:
       * For a local Chef Server just type `knife client edit deis-controller` and your default text
       editor will launch, you need to set 'admin' to 'true'.
-      * For Hosted Chef you need to log into https://manage.opscode.com/ Then goto the Groups tab,
-      click the 'edit' link on the 'admins' row and then under the 'clients' heading toggle the
-      'deis-controller' radio button to be enabled. Then confirm the change by saving the group.
+      * For Hosted Chef, log in to https://manage.opscode.com/. Go to the
+      Administration tab, click on the "Groups" entry to the left, then the "admins" entry
+      under "All Groups". Choose the "Permissions" tab and click the "+ Add" button, then
+      type in "deis-controller" and add it. Assign all permissions to the "deis-controller"
+      client object.
 
 6. If you want to hack on the command line client (`client/deis.py`), install your local dev version rather than
 the one from Pip.

--- a/docs/contributing/localdev.rst
+++ b/docs/contributing/localdev.rst
@@ -87,7 +87,7 @@ If you don't want to run your own Chef server, you can
 `sign up for a free Hosted Chef account`_. This is a free service for up to 5 nodes. After
 that, you'll have to start paying.
 
- * `Login to the Chef Server <https://preview.opscode.com/login>`_
+ * `Login to the Chef Server <https://manage.opscode.com/login>`_
  * Click on the ``Administration`` tab and choose your organization
  * Click ``Starter Kit`` in the sidebar to start a download
  * Copy the ``.chef`` directory inside the Starter Kit into the root of your Deis checkout

--- a/docs/operations/provision-controller.rst
+++ b/docs/operations/provision-controller.rst
@@ -116,6 +116,6 @@ Save and close the file. The "deis-controller" user is now in the "admins" group
 .. _`Digital Ocean`: https://github.com/opdemand/deis/tree/master/contrib/digitalocean#readme
 .. _`add the controller to the admins group`: #add-controller-to-admins-group
 .. _`knife`: http://docs.opscode.com/knife.html
-.. _`OpsCode management interface`: https://manage.opscode.com/groups/admins/edit
+.. _`OpsCode management interface`: https://manage.opscode.com/
 .. _`steps`: http://docs.opscode.com/manage_server_hosted_groups.html#add-user-to-group
 


### PR DESCRIPTION
Deis docs' current reference to https://manage.opscode.com/groups/admins/edit for hosted Chef is now invalid since their web UI was updated. This corrects references to that and to preview.opscode.com, and makes clear that the client is named "deis-controller-ec2" on EC2.
