### PR TITLE
fix(registry): Use cache host and port from confd

### DIFF
--- a/registry/templates/config.yml
+++ b/registry/templates/config.yml
@@ -27,23 +27,18 @@ dev:
 # $ export SETTINGS_FLAVOR=prod
 prod:
     storage: s3
-    storage_path: "_env:STORAGE_PATH:/prod"
+    storage_path: /data
     # Amazon S3 Storage Configuration
     s3_access_key: {{ .deis_registry_s3accessKey }}
     s3_secret_key: {{ .deis_registry_s3secretKey }}
     s3_bucket: {{ .deis_registry_s3bucket }}
     s3_encrypt: {{ .deis_registry_s3encrypt }}
     s3_secure: {{ .deis_registry_s3secure }}
-    # Enabling LRU cache for small files. This speeds up read/write on small files
-    # when using a remote storage backend (like S3).
+    # Enabling query cache on Redis
     cache:
-        host: _env:CACHE_REDIS_HOST
-        port: _env:CACHE_REDIS_PORT
-        password: _env:CACHE_REDIS_PASSWORD
-    cache_lru:
-        host: _env:CACHE_LRU_REDIS_HOST
-        port: _env:CACHE_LRU_REDIS_PORT
-        password: _env:CACHE_LRU_REDIS_PASSWORD
+        host: {{ .deis_cache_host }}
+        port: {{ .deis_cache_port }}
+        db: 1
     # Enabling these options makes the Registry send an email on each code Exception
     email_exceptions:
         smtp_host: {{ .deis_registry_smtpHost }}


### PR DESCRIPTION
The registry was crashing when trying to read cache settings from unset environment variables.
confd is now also population those settings. Fixes #724

I also disabled the LRU cache as this would require to set Redis into LRU mode: http://redis.io/topics/config and this is maybe not what you want for the controller. So the registry is not using redis as a file cache today. As the controller is using redis-db 0, I configured the registry to use 1 to avoid namespace clashes.

I'm currently struggling with setting up my local Vagrant, but I thought I could give this a shoot.
