### PR TITLE
fix(router): docker build fails when apt archive is stale

### DIFF
--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -2,7 +2,8 @@ FROM deis/base
 MAINTAINER Gabriel Monroy <gabriel@opdemand.com>
 
 # install nginx
-RUN apt-get install -yq python-software-properties
+RUN apt-get update && \
+    apt-get install -yq python-software-properties
 RUN add-apt-repository ppa:chris-lea/redis-server -y
 RUN add-apt-repository ppa:nginx/stable -y
 RUN apt-get update


### PR DESCRIPTION
The Docker Index build for deis/router started failing with:

``` console
Get:33 http://archive.ubuntu.com/ubuntu/ precise-updates/main python-software-properties all 0.82.7.7 [23.5 kB]

Err http://archive.ubuntu.com/ubuntu/ precise-security/main libcurl3-gnutls amd64 7.22.0-3ubuntu4.7
  404  Not Found [IP: 91.189.88.149 80]

[91mFailed to fetch http://archive.ubuntu.com/ubuntu/pool/main/c/curl/libcurl3-gnutls_7.22.0-3ubuntu4.7_amd64.deb  404  Not Found [IP: 91.189.88.149 80]
[0m
Fetched 7585 kB in 4s (1698 kB/s)

[91mE: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
[0m
Error: build: The command [/bin/sh -c apt-get install -yq python-software-properties] returned a non-zero code: 100
```

`apt-get update` before the first apt command seems to fix this
in general.
