### PR TITLE
fix(controller/systemd): schedule on same machine as logger

### DIFF
--- a/controller/systemd/deis-controller.service
+++ b/controller/systemd/deis-controller.service
@@ -10,3 +10,6 @@ ExecStop=/usr/bin/docker rm -f deis-controller
 
 [Install]
 WantedBy=multi-user.target
+
+[X-Fleet]
+X-ConditionMachineOf=deis-logger.service


### PR DESCRIPTION
Since the controller currently depends on a volume that deis-logger
provides, they must be on the same machine.

See https://github.com/opdemand/deis/blob/master/controller/systemd/deis-controller.service#L8
