### PR TITLE
chore(contrib/vagrant): lower memory to 2GB

### DIFF
--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provider :virtualbox do |vb, override|
-    vb.customize ["modifyvm", :id, "--memory", "4096"]
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
     # Fix docker not being able to resolve private registry in VirtualBox
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]


### PR DESCRIPTION
When we had the full stack on one VM, 4GB was reasonable. Now
that we are launching multiple VMs and splitting the stack
across them, each one should use less memory.
