### PR TITLE
chore(contrib/vagrant): update CoreOS box image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,11 +4,11 @@
 require_relative 'contrib/coreos/override-plugin.rb'
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "coreos-alpha"
-  config.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_vagrant.box"
+  config.vm.box = "coreos-286.0.0"
+  config.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/286.0.0/coreos_production_vagrant.box"
 
   config.vm.provider :vmware_fusion do |vb, override|
-    override.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_vagrant_vmware_fusion.box"
+    override.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/286.0.0/coreos_production_vagrant_vmware_fusion.box"
   end
 
   config.vm.provider :virtualbox do |vb, override|

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -6,11 +6,11 @@ require_relative '../coreos/override-plugin.rb'
 DEIS_NUM_INSTANCES = (ENV['DEIS_NUM_INSTANCES'].to_i > 0 && ENV['DEIS_NUM_INSTANCES'].to_i) || 3
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "coreos-alpha"
-  config.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_vagrant.box"
+  config.vm.box = "coreos-286.0.0"
+  config.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/286.0.0/coreos_production_vagrant.box"
 
   config.vm.provider :vmware_fusion do |vb, override|
-    override.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_vagrant_vmware_fusion.box"
+    override.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/286.0.0/coreos_production_vagrant_vmware_fusion.box"
   end
 
   config.vm.provider :virtualbox do |vb, override|


### PR DESCRIPTION
Ideally the CoreOS team will start publishing their
.box images to vagrantcloud.com, but until they do,
to bake the fresh version we'll need to point to a
specific CoreOS release.

fixes #755
