### PR TITLE
fix(contrib/vagrant): fix vagrant n-node Makefile

### DIFF
--- a/contrib/vagrant/Makefile
+++ b/contrib/vagrant/Makefile
@@ -18,9 +18,6 @@ COMPONENTS=registry logger database cache controller builder router
 
 all: build run
 
-test_client:
-	python -m unittest discover client.tests
-
 pull:
 	$(call ssh_all,'for c in $(COMPONENTS); do docker pull deis/$$c; done')
 
@@ -28,24 +25,23 @@ build:
 	$(call ssh_all,'cd share && for c in $(COMPONENTS); do cd $$c && docker build -t deis/$$c . && cd ..; done')
 
 install:
-	for c in $(COMPONENTS); do fleetctl enable ../../$$c/systemd/*; done
+	for c in $(COMPONENTS); do fleetctl --strict-host-key-checking=false submit ../../$$c/systemd/*; done
 
 uninstall: stop
-	for c in $(COMPONENTS); do fleetctl disable ../../$$c/systemd/*; done
+	for c in $(COMPONENTS); do fleetctl --strict-host-key-checking=false destroy ../../$$c/systemd/*; done
 
 start:
-	for c in $(COMPONENTS); do fleetctl start ../../$$c/systemd/*; done
+	for c in $(COMPONENTS); do fleetctl --strict-host-key-checking=false start ../../$$c/systemd/*; done
 
 stop:
-	for c in $(COMPONENTS); do fleetctl stop ../../$$c/systemd/*; done
+	for c in $(COMPONENTS); do fleetctl --strict-host-key-checking=false stop ../../$$c/systemd/*; done
 
-restart:
-	for c in $(COMPONENTS); do fleetctl restart ../../$$c/systemd/*; done
+restart: stop start
 
-run: install restart
+run: install start
 
 clean: uninstall
-	$(call ssh_all,'cd share && for c in $(COMPONENTS); do docker rm -f deis-$$c; done')
+	$(call ssh_all,'for c in $(COMPONENTS); do docker rm -f deis-$$c; done')
 
 full-clean: clean
-	$(call ssh_all,'cd share && for c in $(COMPONENTS); do docker rmi deis-$$c; done')
+	$(call ssh_all,'for c in $(COMPONENTS); do docker rmi deis-$$c; done')

--- a/contrib/vagrant/README.md
+++ b/contrib/vagrant/README.md
@@ -12,6 +12,8 @@ On your workstation:
 * Configure the fleetctl client to tunnel through one of the VMs:
   * `export FLEETCTL_TUNNEL=172.17.8.100`
   * (Note that IP addressing for the VMs starts at .100, but you can connect to any VM in the cluster)
+* Add your Vagrant-generated SSH key to the ssh-agent (fleetctl tunnel requires the agent to have this key)
+  * `ssh-add ~/.vagrant.d/insecure_private_key`
 
 ## Launching Deis
 Follow the normal instructions in the [README](../../README.md) for launching and using Deis, with the caveat that


### PR DESCRIPTION
The fleetctl commands weren't valid, and we should disable host
checking, as Vagrant nodes will change frequently.
