### PR TITLE
Fix contrib/vagrant/Makefile to work on non bash-symlinked /bin/sh.

### DIFF
--- a/contrib/vagrant/Makefile
+++ b/contrib/vagrant/Makefile
@@ -7,9 +7,9 @@ ifndef $(DEIS_NUM_INSTANCES)
 endif
 
 define ssh_all
-  i=1 ; while [[ $$i -le $(DEIS_NUM_INSTANCES) ]] ; do \
+  i=1 ; while [ $$i -le $(DEIS_NUM_INSTANCES) ] ; do \
       vagrant ssh deis-$$i -c $(1) ; \
-      ((i = i + 1)) ; \
+      i=`expr $$i + 1` ; \
   done
 endef
 


### PR DESCRIPTION
The current `contrib/vagrant/Makefile` won't `make build` when `/bin/sh` is not symlinked to `/bin/bash` (as on standard Ubuntu), because the `[[ .. ]]` and `(( .. ))` syntax are bash-specific. This PR rewrites the loop using standard `/bin/sh` syntax.
