### PR TITLE
fix(controller): update Django admin fields

### DIFF
--- a/controller/api/admin.py
+++ b/controller/api/admin.py
@@ -33,7 +33,7 @@ class BuildAdmin(admin.ModelAdmin):
     in the Django admin.
     """
     date_hierarchy = 'created'
-    list_display = ('sha', 'owner', 'app')
+    list_display = ('created', 'owner', 'app')
     list_filter = ('owner', 'app')
 admin.site.register(Build, BuildAdmin)
 
@@ -43,7 +43,7 @@ class ClusterAdmin(admin.ModelAdmin):
     in the Django admin.
     """
     date_hierarchy = 'created'
-    list_display = ('id', 'owner',)
+    list_display = ('id', 'owner', 'domain')
     list_filter = ('owner',)
 admin.site.register(Cluster, ClusterAdmin)
 
@@ -53,7 +53,7 @@ class ConfigAdmin(admin.ModelAdmin):
     in the Django admin.
     """
     date_hierarchy = 'created'
-    list_display = ('version', 'owner', 'app')
+    list_display = ('created', 'owner', 'app')
     list_filter = ('owner', 'app')
 admin.site.register(Config, ConfigAdmin)
 
@@ -83,6 +83,7 @@ class ReleaseAdmin(admin.ModelAdmin):
     in the Django admin.
     """
     date_hierarchy = 'created'
-    list_display = ('owner', 'app', 'version')
+    list_display = ('created', 'version', 'owner', 'app')
+    list_display_links = ('created', 'version')
     list_filter = ('owner', 'app')
 admin.site.register(Release, ReleaseAdmin)


### PR DESCRIPTION
The declarative definition for presenting Build model objects
in the Django admin still referenced "sha," which is no longer
a field on the Build model. Same for the "version" field on
Config. Both of these caused a 500 error when browsing at
http://local.deisapp.com:8000/admin/

I also added "created" to Build, Config, and Release and
"domain" to Cluster in the admin list display.
