### PR TITLE
feat(registry): add s3 redirect support

### DIFF
--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -16,7 +16,7 @@ RUN useradd -s /bin/bash registry
 RUN git clone https://github.com/dotcloud/docker-registry /docker-registry
 
 # lock the registry version to a tag
-RUN cd /docker-registry && git checkout 0.6.6
+RUN cd /docker-registry && git checkout 0.6.8
 
 # install boto configuration
 RUN cp /docker-registry/config/boto.cfg /etc/boto.cfg

--- a/registry/templates/config.yml
+++ b/registry/templates/config.yml
@@ -31,9 +31,11 @@ prod:
     # Amazon S3 Storage Configuration
     s3_access_key: {{ .deis_registry_s3accessKey }}
     s3_secret_key: {{ .deis_registry_s3secretKey }}
+    s3_region: {{ .deis_registry_s3region }}
     s3_bucket: {{ .deis_registry_s3bucket }}
     s3_encrypt: {{ .deis_registry_s3encrypt }}
     s3_secure: {{ .deis_registry_s3secure }}
+    storage_redirect: True
     # Enabling query cache on Redis
     cache:
         host: {{ .deis_cache_host }}


### PR DESCRIPTION
Allow to configure a s3 region and enable redirecting for
faster and cheaper image downloads.
Further details: https://github.com/dotcloud/docker-registry/pull/293

Fixes #746
