### PR TITLE
fix(vagrant): use rsync for shared folders

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,8 +29,8 @@ Vagrant.configure("2") do |config|
     ip = "172.17.8.100"
     config.vm.network :private_network, ip: ip
 
-    # Uncomment below to enable NFS for sharing the host machine into the coreos-vagrant VM.
-    config.vm.synced_folder ".", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
+    # enabling rsync for sharing the host machine into the coreos-vagrant VM.
+    config.vm.synced_folder ".", "/home/core/share", type: "rsync"
 
     # workaround missing /etc/hosts
     config.vm.provision :shell, :inline => "echo #{ip} #{vm_name} > /etc/hosts", :privileged => true

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -32,8 +32,8 @@ Vagrant.configure("2") do |config|
       ip = "172.17.8.#{i+99}"
       config.vm.network :private_network, ip: ip
 
-      # Enable NFS for sharing the host machine into the coreos-vagrant VM.
-      config.vm.synced_folder "../..", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
+      # Enable rsync for sharing the host machine into the coreos-vagrant VM.
+      config.vm.synced_folder "../..", "/home/core/share", type: "rsync"
 
       # workaround missing /etc/hosts
       config.vm.provision :shell, :inline => "echo #{ip} #{vm_name} > /etc/hosts", :privileged => true

--- a/docs/contributing/localdev.rst
+++ b/docs/contributing/localdev.rst
@@ -34,9 +34,7 @@ clone your fork of the repository for local development:
 
 Provision the Controller
 ------------------------
-First bring up a virtual machine to host Deis. To share your local
-codebase into the CoreOS VM, Deis uses NFS mounts, so you will be
-prompted for an administrative password.
+First bring up a virtual machine to host Deis:
 
 .. code-block:: console
 
@@ -64,6 +62,11 @@ your workstation connect to the VM:
 Next, run ``make pull && make build`` to SSH into the VM, pull Deis'
 images from the Docker Index, then update those images with any local
 changes.
+
+.. note::
+
+    Deis uses rsync to share your local codebase into the CoreOS VM, so you will have
+    to re-synchronize your changes using vagrant rsync.
 
 .. code-block:: console
 


### PR DESCRIPTION
In terms of stability, nfs seems to drop the mount every so often, which is not good for development. running `vagrant rsync` to synchronize changes between the server and the host machine will not have any missing mount issues, so let's switch over to rsync.

fixes #752
