### PR TITLE
fix(logger): fix publish loop

### DIFF
--- a/logger/bin/boot
+++ b/logger/bin/boot
@@ -24,8 +24,8 @@ SERVICE_PID=$!
 
 # smart shutdown on SIGINT and SIGTERM
 function on_exit() {
-	kill -TERM $SERVICE_PID
-	wait $SERVICE_PID 2>/dev/null
+    kill -TERM $SERVICE_PID
+    wait $SERVICE_PID 2>/dev/null
 }
 trap on_exit INT TERM
 
@@ -34,24 +34,24 @@ echo deis-logger running...
 # publish the service to etcd using the injected PORT
 if [[ ! -z $PUBLISH ]]; then
 
-	# configure service discovery
-	PORT=${PORT:-514}
-	PROTO=${PROTO:-tcp}
+    # configure service discovery
+    PORT=${PORT:-514}
+    PROTO=${PROTO:-udp}
 
-	set +e
+    set +e
 
-	# wait for the service to become available on PUBLISH port
-	sleep 1 && while [[ -z $(netstat -lnt | awk "\$6 == \"LISTEN\" && \$4 ~ \".$PUBLISH\" && \$1 ~ \"$PROTO.?\"") ]] ; do sleep 1; done
+    # wait for the service to become available on PUBLISH port
+    sleep 1 && while [[ -z $(netstat -lnu | awk "\$4 ~ \".$PUBLISH\" && \$1 ~ \"$PROTO.?\"") ]] ; do sleep 1; done
 
-	# while the port is listening, publish to etcd
-	while [[ ! -z $(netstat -lnt | awk "\$6 == \"LISTEN\" && \$4 ~ \".$PUBLISH\" && \$1 ~ \"$PROTO.?\"") ]] ; do
-		etcdctl --no-sync -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
-		etcdctl --no-sync -C $ETCD set $ETCD_PATH/port $PORT --ttl $ETCD_TTL >/dev/null
-		sleep $(($ETCD_TTL/2)) # sleep for half the TTL
-	done
+    # while the port is listening, publish to etcd
+    while [[ ! -z $(netstat -lnu | awk "\$4 ~ \".$PUBLISH\" && \$1 ~ \"$PROTO.?\"") ]] ; do
+        etcdctl -C $ETCD set --ttl $ETCD_TTL $ETCD_PATH/host $HOST --no-sync >/dev/null
+        etcdctl -C $ETCD set --ttl $ETCD_TTL $ETCD_PATH/port $PORT --no-sync >/dev/null
+        sleep $(($ETCD_TTL/2)) # sleep for half the TTL
+    done
 
-	# if the loop quits, something went wrong
-	exit 1
+    # if the loop quits, something went wrong
+    exit 1
 
 fi
 


### PR DESCRIPTION
before, the logger's publish loop would be searching for a TCP connection. Since the logger runs on UDP, the publish loop would not find it running and would run forever. This changes netstat to search over UDP for the logger instead, allowing it to publish its values to etcd.

fixes #738 

Surprisingly, as soon as I rebooted deis-logger (as well as usable-woodshed's logger) with this change, the application logs became available:

```
(venv)><> deis logs --app=usable-woodshed
2014-04-17 19:49:49 10.0.2.15:49962 usable-woodshed[web.1]: [2014-04-17 18:25:47] INFO  WEBrick 1.3.1
2014-04-17 19:49:49 10.0.2.15:49962 usable-woodshed[web.1]: [2014-04-17 18:25:47] INFO  ruby 2.0.0 (2014-02-24) [x86_64-linux]
2014-04-17 19:49:49 10.0.2.15:49962 usable-woodshed[web.1]: [2014-04-17 18:25:47] INFO  WEBrick::HTTPServer#start: pid=16 port=5000
2014-04-17 19:49:49 10.0.2.15:49962 usable-woodshed[web.1]: 172.17.8.1 - - [17/Apr/2014 18:27:19] "GET / HTTP/1.1" 200 11 0.0022
2014-04-17 19:49:49 10.0.2.15:49962 usable-woodshed[web.1]: 172.17.8.1 - - [17/Apr/2014 18:27:19] "GET /favicon.ico HTTP/1.1" 404 18 0.0005
2014-04-17 19:49:49 10.0.2.15:49962 usable-woodshed[web.1]: 172.17.8.1 - - [17/Apr/2014 18:27:19] "GET /favicon.ico HTTP/1.1" 404 18 0.0007
2014-04-17 19:49:49 10.0.2.15:49962 usable-woodshed[web.1]: 172.17.8.1 - - [17/Apr/2014 18:39:49] "GET / HTTP/1.1" 200 11 0.0017
```

Also, I removed the occurrence of tabs.
