### PR TITLE
feat(contrib/ec2): add m3 instances to template

### DIFF
--- a/contrib/ec2/deis.template
+++ b/contrib/ec2/deis.template
@@ -33,7 +33,7 @@
     "InstanceType" : {
       "Description" : "EC2 instance type (m1.small, etc).",
       "Type" : "String",
-      "Default" : "m3.medium",
+      "Default" : "m3.large",
       "AllowedValues" : [ "t1.micro","m1.small","m1.medium","m1.large","m1.xlarge", "m3.medium", "m3.large", "m3.xlarge", "m3.2xlarge", "m2.xlarge","m2.2xlarge","m2.4xlarge","c1.medium","c1.xlarge","cc1.4xlarge","cc2.8xlarge","cg1.4xlarge", "hi1.4xlarge", "hs1.8xlarge"],
       "ConstraintDescription" : "must be a valid EC2 instance type."
     },


### PR DESCRIPTION
The current generation of EC2 instances (M3) is faster and cheaper than the old T1 instances. It's a more reasonable default to use m3.medium as the default instance size.

fixes #689
