### PR TITLE
refactor(seed-deis-registry): move to .service file

### DIFF
--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -96,17 +96,3 @@ coreos:
 
       [Install]
       WantedBy=multi-user.target
-  - name: seed-deis-registry.service
-    command: start
-    content: |
-      [Unit]
-      Description=Seed Deis Registry with Docker Images
-      Requires=seed-docker-images.service deis-registry.service
-      After=deis-registry.service
-
-      [Service]
-      Type=oneshot
-      ExecStart=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && docker pull deis/slugrunner:latest && docker tag deis/slugrunner $HOST_IP:5000/deis/slugrunner && docker push $HOST_IP:5000/deis/slugrunner"
-
-      [Install]
-      WantedBy=multi-user.target

--- a/registry/systemd/seed-deis-registry.service
+++ b/registry/systemd/seed-deis-registry.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Seed Deis Registry with Docker Images
+Requires=seed-docker-images.service deis-registry.service
+After=deis-registry.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && docker pull deis/slugrunner:latest && docker tag deis/slugrunner $HOST_IP:5000/deis/slugrunner && docker push $HOST_IP:5000/deis/slugrunner"
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Moves seed-deis-registry to its own .service file, as it doesn't
need to run on all hosts (and shouldn't be specified in user-data).
