### PR TITLE
docs(contrib): maintainers merge their own PRs

### DIFF
--- a/docs/contributing/standards.rst
+++ b/docs/contributing/standards.rst
@@ -114,6 +114,10 @@ Deis maintainers add "**LGTM**" (Looks Good To Me) in code
 review comments to indicate that a PR is acceptable. Any code change--other than
 a simple typo fix or one-line documentation change--requires at least two of
 Deis' maintainers to accept the change in this manner before it can be merged.
+If the PR is from a Deis maintainer, then he or she should be the one to merge
+it. This is for cleanliness in the commit stream as well as giving the
+maintainer the benefit of adding more fixes or commits to a PR before the
+merge.
 
 .. _Python: http://www.python.org/
 .. _Go: http://golang.org/


### PR DESCRIPTION
if the PR submitter is a maintainer, he or she merges it themself (after 2 LGTMs). This is intended for commit stream cleanliness and to allow them to fix their own PR before merging it.
