### PR TITLE
fix(vagrant): use start on make run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ restart:
 logs:
 	vagrant ssh -c 'journalctl -f -u deis-*'
 
-run: install restart logs
+run: install start logs
 
 clean: uninstall
 	vagrant ssh -c 'cd share && for c in $(COMPONENTS); do docker rm -f deis-$$c; done'


### PR DESCRIPTION
the command hangs if there's nothing to restart, which is the case when booting for the first time. It makes more sense for make run to run make start, and the user should have to specify make restart in order to restart a systemd unit.
