### PR TITLE
refactor(contrib/coreos): update override-plugin and user-data

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,19 +32,13 @@ Vagrant.configure("2") do |config|
     # Uncomment below to enable NFS for sharing the host machine into the coreos-vagrant VM.
     config.vm.synced_folder ".", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
 
-    # workaround missing /etc/hosts
-    config.vm.provision :shell, :inline => "echo #{ip} #{vm_name} > /etc/hosts", :privileged => true
-
-    # workaround missing /etc/environment
-    config.vm.provision :shell, :inline => "touch /etc/environment", :privileged => true
-
     # disable update-engine to prevent reboots
     config.vm.provision :shell, :inline => "systemctl stop update-engine-reboot-manager && systemctl disable update-engine-reboot-manager && systemctl mask update-engine-reboot-manager", :privileged => true
     config.vm.provision :shell, :inline => "systemctl stop update-engine && systemctl disable update-engine && systemctl mask update-engine", :privileged => true
 
     # user-data bootstrapping
-    config.vm.provision :file, :source => "contrib/coreos/user-data", :destination => "/tmp/user-data"
-    config.vm.provision :shell, :inline => "mkdir -p /var/lib/coreos-vagrant && mv /tmp/user-data /var/lib/coreos-vagrant", :privileged => true
+    config.vm.provision :file, :source => "contrib/coreos/user-data", :destination => "/tmp/vagrantfile-user-data"
+    config.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
 
   end
 

--- a/contrib/coreos/override-plugin.rb
+++ b/contrib/coreos/override-plugin.rb
@@ -1,45 +1,116 @@
 # -*- mode: ruby -*-
 # # vi: set ft=ruby :
 
-# <hack>
-
 # NOTE: This monkey-patching of the coreos guest plugin is a terrible
-# hack that needs to be removed once the upstream plugin works with the
-# new CoreOS images.
+# hack that needs to be removed once the upstream plugin works with
+# alpha CoreOS images.
 
+require 'tempfile'
+require 'ipaddr'
 require Vagrant.source_root.join("plugins/guests/coreos/cap/configure_networks.rb")
+
+BASE_CLOUD_CONFIG = <<EOF
+#cloud-config
+
+coreos:
+    units:
+      - name: coreos-cloudinit-vagrant-user.path
+        command: start
+        runtime: no
+        content: |
+          [Path]
+          PathExists=/var/lib/coreos-vagrant/vagrantfile-user-data
+      - name: coreos-cloudinit-vagrant-user.service
+        runtime: no
+        content: |
+          [Unit]
+          ConditionFileNotEmpty=/var/lib/coreos-vagrant/vagrantfile-user-data
+
+          [Service]
+          Type=oneshot
+          EnvironmentFile=/etc/environment
+          ExecStart=/usr/bin/coreos-cloudinit --from-file /var/lib/coreos-vagrant/vagrantfile-user-data
+          RemainAfterExit=yes
+EOF
+
+NETWORK_UNIT = <<EOF
+      - name: %s
+        runtime: no
+        content: |
+          [Match]
+          Name=%s
+
+          [Network]
+          Address=%s
+EOF
+
+# Borrowed from http://stackoverflow.com/questions/1825928/netmask-to-cidr-in-ruby
+IPAddr.class_eval do
+  def to_cidr
+    self.to_i.to_s(2).count("1")
+  end
+end
 
 module VagrantPlugins
   module GuestCoreOS
-	module Cap
-	  class ConfigureNetworks
-		include Vagrant::Util
+    module Cap
+      class ConfigureNetworks
+        include Vagrant::Util
 
-		def self.configure_networks(machine, networks)
-		  machine.communicate.tap do |comm|
-			# Read network interface names
-			interfaces = []
-			comm.sudo("ifconfig | grep enp0 | cut -f1 -d:") do |_, result|
-			  interfaces = result.split("\n")
-			end
+        def self.configure_networks(machine, networks)
+          cfg = BASE_CLOUD_CONFIG
+          machine.communicate.tap do |comm|
 
-			# Configure interfaces
-			# FIXME: fix matching of interfaces with IP adresses
-			networks.each do |network|
-			  comm.sudo("ifconfig #{interfaces[network[:interface].to_i]} #{network[:ip]} netmask #{network[:netmask]}")
-			end
+            # Read network interface names
+            interfaces = []
+            comm.sudo("ifconfig | grep enp0 | cut -f1 -d:") do |_, result|
+              interfaces = result.split("\n")
+            end
 
-		  end
-		end
-	  end
+            ip = ""
+
+            # Configure interfaces
+            # FIXME: fix matching of interfaces with IP adresses
+            networks.each do |network|
+              iface_num = network[:interface].to_i
+              iface_name = interfaces[iface_num]
+              cidr = IPAddr.new('255.255.255.0').to_cidr
+              address = "%s/%s" % [network[:ip], cidr]
+              unit_name = "50-%s.network" % [iface_name]
+              unit = NETWORK_UNIT % [unit_name, iface_name, address]
+
+              cfg = "#{cfg}#{unit}"
+              ip = network[:ip]
+            end
+
+            cfg = <<EOF
+#{cfg}
+write_files:
+  - path: /etc/environment
+    content: |
+      COREOS_PUBLIC_IPV4=#{ip}
+      COREOS_PRIVATE_IPV4=#{ip}
+
+hostname: #{machine.name}
+EOF
+
+            temp = Tempfile.new("coreos-vagrant")
+            temp.write(cfg)
+            temp.close
+
+            comm.upload(temp.path, "/tmp/user-data")
+            comm.sudo("mkdir -p /var/lib/coreos-vagrant")
+            comm.sudo("mv /tmp/user-data /var/lib/coreos-vagrant/")
+
+          end
+        end
+      end
 
       class ChangeHostName
         def self.change_host_name(machine, name)
-			# do nothing!
+          # This is handled in configure_networks
         end
       end
     end
   end
 end
-
-# </hack>

--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -2,8 +2,11 @@
 ---
 coreos:
   etcd:
-    addr: 172.17.8.100:4001
-    peer-addr: 172.17.8.100:7001
+    # generate a new token for each unique cluster from https://discovery.etcd.io/new
+    # uncomment the following line and replace it with your discovery URL
+    # discovery: https://discovery.etcd.io/12345693838asdfasfadf13939923
+    addr: $public_ipv4:4001
+    peer-addr: $public_ipv4:7001
   units:
   - name: docker.service
     content: |
@@ -15,7 +18,7 @@ coreos:
       ExecStartPre=/bin/mount --make-rprivate /
       # Run docker but don't have docker automatically restart
       # containers. This is a job for systemd and unit files.
-      ExecStart=/usr/bin/docker -d -s=btrfs --bip=10.212.0.1/16 -r=false -H fd://
+      ExecStart=/usr/bin/docker -d -s=btrfs -r=false -H fd://
 
       [Install]
       WantedBy=multi-user.target
@@ -34,38 +37,12 @@ coreos:
       WantedBy=sockets.target
   - name: etcd.service
     command: start
-    content: |
-      [Unit]
-      Description=etcd
-
-      [Service]
-      User=etcd
-      PermissionsStartOnly=true
-      Environment=ETCD_DATA_DIR=/var/lib/etcd ETCD_NAME=default
-      ExecStart=/usr/bin/etcd
-      Restart=always
-      RestartSec=10s
   - name: fleet.service
     command: start
-    content: |-
+    content: |
       [Unit]
       Description=fleet
 
       [Service]
+      Environment=FLEET_PUBLIC_IP=$public_ipv4
       ExecStart=/usr/bin/fleet
-
-      [Install]
-      WantedBy=multi-user.target
-  - name: stop-reboot-manager.service
-    command: start
-    content: |
-      [Unit]
-      Description=stop update-engine-reboot-manager
-
-      [Service]
-      Type=oneshot
-      ExecStart=/usr/bin/systemctl stop update-engine-reboot-manager.service
-      ExecStartPost=/usr/bin/systemctl mask update-engine-reboot-manager.service
-
-      [Install]
-      WantedBy=multi-user.target

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -35,20 +35,14 @@ Vagrant.configure("2") do |config|
       # Enable NFS for sharing the host machine into the coreos-vagrant VM.
       config.vm.synced_folder "../..", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
 
-      # workaround missing /etc/hosts
-      config.vm.provision :shell, :inline => "echo #{ip} #{vm_name} > /etc/hosts", :privileged => true
-
-      # workaround missing /etc/environment
-      config.vm.provision :shell, :inline => "touch /etc/environment", :privileged => true
-
       # disable update-engine to prevent reboots
       config.vm.provision :shell, :inline => "systemctl stop update-engine-reboot-manager && systemctl disable update-engine-reboot-manager && systemctl mask update-engine-reboot-manager", :privileged => true
       config.vm.provision :shell, :inline => "systemctl stop update-engine && systemctl disable update-engine && systemctl mask update-engine", :privileged => true
 
-
       # user-data bootstrapping
-      config.vm.provision :file, :source => "../coreos/user-data", :destination => "/tmp/user-data"
-      config.vm.provision :shell, :inline => "mkdir -p /var/lib/coreos-vagrant && mv /tmp/user-data /var/lib/coreos-vagrant", :privileged => true
+      config.vm.provision :file, :source => "../coreos/user-data", :destination => "/tmp/vagrantfile-user-data"
+      config.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
+
     end
   end
 


### PR DESCRIPTION
This commit updates the override-plugin and user-data to better
reflect upstream, and to enable both the 1-node and n-node Vagrantfiles
to use the same user-data. This is easier to maintain, and allows
us to pull in upstream changes with greater ease.

closes #760
