### PR TITLE
chore(contrib/vagrant): update vagrant box to coreos-291.0.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,11 +4,11 @@
 require_relative 'contrib/coreos/override-plugin.rb'
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "coreos-286.0.0"
-  config.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/286.0.0/coreos_production_vagrant.box"
+  config.vm.box = "coreos-291.0.0"
+  config.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/291.0.0/coreos_production_vagrant.box"
 
   config.vm.provider :vmware_fusion do |vb, override|
-    override.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/286.0.0/coreos_production_vagrant_vmware_fusion.box"
+    override.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/291.0.0/coreos_production_vagrant_vmware_fusion.box"
   end
 
   config.vm.provider :virtualbox do |vb, override|

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -6,11 +6,11 @@ require_relative '../coreos/override-plugin.rb'
 DEIS_NUM_INSTANCES = (ENV['DEIS_NUM_INSTANCES'].to_i > 0 && ENV['DEIS_NUM_INSTANCES'].to_i) || 3
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "coreos-286.0.0"
-  config.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/286.0.0/coreos_production_vagrant.box"
+  config.vm.box = "coreos-291.0.0"
+  config.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/291.0.0/coreos_production_vagrant.box"
 
   config.vm.provider :vmware_fusion do |vb, override|
-    override.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/286.0.0/coreos_production_vagrant_vmware_fusion.box"
+    override.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/291.0.0/coreos_production_vagrant_vmware_fusion.box"
   end
 
   config.vm.provider :virtualbox do |vb, override|


### PR DESCRIPTION
I've been testing with this instead of 286.0.0 and haven't seen any difference yet for Deis. Please give it a try.
