### PR TITLE
fix(docker): remove patched docker, switch to deis/base data container

### DIFF
--- a/builder/systemd/deis-builder.service
+++ b/builder/systemd/deis-builder.service
@@ -4,7 +4,7 @@ Description=deis-builder
 [Service]
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/builder >/dev/null || /usr/bin/docker pull deis/builder"
-ExecStartPre=/bin/bash -c "/usr/bin/docker start deis-builder-data || /usr/bin/docker run --name deis-builder-data -v /var/lib/docker deis/data"
+ExecStartPre=/bin/bash -c "/usr/bin/docker start deis-builder-data || /usr/bin/docker run --name deis-builder-data -v /var/lib/docker deis/base /bin/true"
 ExecStart=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && exec /usr/bin/docker run --name deis-builder -p 2222:22 -e PUBLISH=22 -e HOST=$HOST_IP -e PORT=2222 --volumes-from deis-builder-data --privileged deis/builder"
 ExecStop=/usr/bin/docker rm -f deis-builder
 

--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -5,20 +5,6 @@ coreos:
     addr: 172.17.8.100:4001
     peer-addr: 172.17.8.100:7001
   units:
-  - name: docker-patch.service
-    command: start
-    content: |
-      [Unit]
-      Description=patch /usr/bin/docker with an S3 binary
-
-      [Service]
-      Type=oneshot
-      ExecStart=/usr/bin/wget --no-check-certificate -q -O /home/core/docker.symlink-fix https://s3-us-west-2.amazonaws.com/deis/docker.symlink-fix
-      ExecStartPost=/bin/chmod 0755 /home/core/docker.symlink-fix
-      ExecStartPost=/bin/mount --bind /home/core/docker.symlink-fix /usr/bin/docker
-
-      [Install]
-      WantedBy=multi-user.target
   - name: docker.service
     content: |
       [Unit]

--- a/database/systemd/deis-database.service
+++ b/database/systemd/deis-database.service
@@ -4,7 +4,7 @@ Description=deis-database
 [Service]
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/database >/dev/null || /usr/bin/docker pull deis/database"
-ExecStartPre=/bin/bash -c "/usr/bin/docker start deis-database-data || /usr/bin/docker run --name deis-database-data -v /var/lib/postgresql deis/data"
+ExecStartPre=/bin/bash -c "/usr/bin/docker start deis-database-data || /usr/bin/docker run --name deis-database-data -v /var/lib/postgresql deis/base /bin/true"
 ExecStart=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && exec /usr/bin/docker run --name deis-database -p 5432:5432 -e PUBLISH=5432 -e HOST=$HOST_IP --volumes-from deis-database-data deis/database
 ExecStop=/usr/bin/docker rm -f deis-database
 

--- a/logger/systemd/deis-logger.service
+++ b/logger/systemd/deis-logger.service
@@ -4,7 +4,7 @@ Description=deis-logger
 [Service]
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/logger >/dev/null || /usr/bin/docker pull deis/logger"
-ExecStartPre=/bin/bash -c "/usr/bin/docker start deis-logger-data || /usr/bin/docker run --name deis-logger-data -v /var/log/deis deis/data"
+ExecStartPre=/bin/bash -c "/usr/bin/docker start deis-logger-data || /usr/bin/docker run --name deis-logger-data -v /var/log/deis deis/base /bin/true"
 ExecStart=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && exec /usr/bin/docker run --name deis-logger -p 514:514/udp -e PUBLISH=514 -e HOST=$HOST_IP --volumes-from deis-logger-data deis/logger"
 ExecStop=/usr/bin/docker rm -f deis-logger
 

--- a/registry/systemd/deis-registry.service
+++ b/registry/systemd/deis-registry.service
@@ -6,7 +6,7 @@ After=seed-docker-images.service
 [Service]
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/registry >/dev/null || /usr/bin/docker pull deis/registry"
-ExecStartPre=/bin/bash -c "/usr/bin/docker start deis-registry-data || /usr/bin/docker run --name deis-registry-data -v /data deis/data"
+ExecStartPre=/bin/bash -c "/usr/bin/docker start deis-registry-data || /usr/bin/docker run --name deis-registry-data -v /data deis/base /bin/true"
 ExecStart=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && exec /usr/bin/docker run --name deis-registry -p 5000:5000 -e PUBLISH=5000 -e HOST=$HOST_IP --volumes-from deis-registry-data deis/registry"
 ExecStartPost=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && echo 'Waiting for listener on 5000/tcp...' && until cat </dev/null>/dev/tcp/$HOST_IP/5000; do sleep 1; done && docker pull deis/slugrunner:latest && docker tag deis/slugrunner $HOST_IP:5000/deis/slugrunner && docker push $HOST_IP:5000/deis/slugrunner"
 ExecStop=/usr/bin/docker rm -f deis-registry


### PR DESCRIPTION
While we much prefer the lightweight `deis/data` container based on `tianon/true`, we're waiting on the following commit:
https://github.com/dotcloud/docker/commit/3d9cd1e5f102d5e59011ec4baca2662f3dacbad4
