### PR TITLE
fix(contrib/vagrant): fix Makefile loop

### DIFF
--- a/contrib/vagrant/Makefile
+++ b/contrib/vagrant/Makefile
@@ -2,7 +2,7 @@
 # Deis Makefile
 #
 
-ifndef $(DEIS_NUM_INSTANCES)
+ifndef DEIS_NUM_INSTANCES
     DEIS_NUM_INSTANCES = 3
 endif
 


### PR DESCRIPTION
The Makefile condition was broken, and was always resetting to 3.
