### PR TITLE
refactor(seed-deis-registry): remove seed-deis-registry dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ uninstall: stop
 	vagrant ssh -c 'cd share && for c in $(COMPONENTS); do cd $$c && sudo systemctl disable $$(pwd)/systemd/* && cd ..; done'
 
 start:
+	echo "\033[0;33mStarting services can take some time... grab some coffee!\033[0m"
 	vagrant ssh -c 'cd share && for c in $(COMPONENTS); do cd $$c/systemd && sudo systemctl start * && cd ../..; done'
 
 stop:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ make build
 
 ## Run Deis
 
-Use `make run` to start all Deis containers and attach to their log output.
+Use `make run` to start all Deis containers and attach to their log output. This can take some time - the registry service will pull and prepare a Docker image. Grab some more coffee!
 
 ```
 make run

--- a/builder/systemd/deis-builder.service
+++ b/builder/systemd/deis-builder.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=deis-builder
+Requires=deis-registry.service
+After=deis-registry.service
 
 [Service]
 TimeoutStartSec=20m

--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -69,16 +69,3 @@ coreos:
 
       [Install]
       WantedBy=multi-user.target
-  - name: seed-docker-images.service
-    command: start
-    content: |
-      [Unit]
-      Description=Seed Docker images used by Deis
-      Requires=docker.service
-
-      [Service]
-      Type=oneshot
-      ExecStart=/bin/sh -c 'docker pull deis/slugrunner:latest'
-
-      [Install]
-      WantedBy=multi-user.target

--- a/contrib/vagrant/Makefile
+++ b/contrib/vagrant/Makefile
@@ -31,6 +31,7 @@ uninstall: stop
 	for c in $(COMPONENTS); do fleetctl --strict-host-key-checking=false destroy ../../$$c/systemd/*; done
 
 start:
+	echo "\033[0;33mStarting services can take some time... grab some coffee!\033[0m"
 	for c in $(COMPONENTS); do fleetctl --strict-host-key-checking=false start ../../$$c/systemd/*; done
 
 stop:

--- a/controller/systemd/deis-controller.service
+++ b/controller/systemd/deis-controller.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=deis-controller
-Requires=deis-logger.service
+Requires=deis-logger.service deis-builder.service
+After=deis-logger.service deis-builder.service
 
 [Service]
 TimeoutStartSec=20m

--- a/registry/systemd/deis-registry.service
+++ b/registry/systemd/deis-registry.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=deis-registry
-Requires=seed-docker-images.service
-After=seed-docker-images.service
 
 [Service]
 TimeoutStartSec=20m


### PR DESCRIPTION
Currently, startup takes forever because registry blocks until the
slugrunner container has been pulled. Users think things have stalled
and/or are broken - this is a bad user experience.

The ExecStartPost of the registry service already pulls the slugrunner
image, so we don't need to block until this job occurs beforehand.
Additionally, it's friendlier if the controller blocks until registry
and logger are ready - if a user attempts to make an account, all of
Deis should be up.
