### PR TITLE
fix(logger): import syslog package from github

### DIFF
--- a/logger/syslogd/syslogd.go
+++ b/logger/syslogd/syslogd.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"regexp"
 	"syscall"
-	"syslog"
+	"github.com/opdemand/deis/logger/syslog"
 )
 
 const logRoot = "/var/log/deis"


### PR DESCRIPTION
Since package syslog is located at https://github.com/opdemand/deis/tree/master/logger/syslog, we should be importing from there. Without this change, running syslogd.go will complain that the syslog package does not exist.
