### PR TITLE
fix(Makefile): upload fleetctl units all at once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ else
 	COMPONENTS=builder cache controller database logger registry
 endif
 
+UNIT_FILES = $(foreach C, $(COMPONENTS), $(wildcard $(C)/systemd/*))
+
 all: build run
 
 pull:
@@ -30,17 +32,17 @@ build:
 	$(call ssh_all,'cd share && for c in $(COMPONENTS); do cd $$c && docker build -t deis/$$c . && cd ..; done')
 
 install:
-	for c in $(COMPONENTS); do fleetctl --strict-host-key-checking=false submit $$c/systemd/*; done
+	fleetctl --strict-host-key-checking=false submit $(UNIT_FILES)
 
-uninstall: stop
-	for c in $(COMPONENTS); do fleetctl --strict-host-key-checking=false destroy $$c/systemd/*; done
+uninstall:  stop
+	fleetctl --strict-host-key-checking=false destroy $(UNIT_FILES)
 
 start:
 	echo "\033[0;33mStarting services can take some time... grab some coffee!\033[0m"
-	for c in $(COMPONENTS); do fleetctl --strict-host-key-checking=false start $$c/systemd/*; done
+	fleetctl --strict-host-key-checking=false start $(UNIT_FILES)
 
 stop:
-	for c in $(COMPONENTS); do fleetctl --strict-host-key-checking=false stop $$c/systemd/*; done
+	fleetctl --strict-host-key-checking=false stop $(UNIT_FILES)
 
 restart: stop start
 

--- a/contrib/ec2/initialize-ec2-cluster.sh
+++ b/contrib/ec2/initialize-ec2-cluster.sh
@@ -27,14 +27,14 @@ fi
 
 cd $ROOT_DIR
 
-# upload each component's systemd unit to the fleet cluster
-for component in registry logger database cache controller builder router
-do
-  pushd $component/systemd > /dev/null
-  fleetctl submit deis-$component.service
-  fleetctl start deis-$component.service
-  popd > /dev/null
+# upload all systemd unit to the fleet cluster
+units=()
+for component in builder cache controller database logger registry router; do
+  units+=($component/systemd/*)
 done
+
+fleetctl submit ${units[@]}
+fleetctl start ${units[@]}
 
 echo_green "Done! Inspect the state of the services with: fleetctl list-units"
 echo_green "Once all the services are running, you can register with your Deis cluster: deis register http://ec2-34-567-890-123.us-west-1.compute.amazonaws.com:8000"

--- a/contrib/rackspace/initialize-rackspace-cluster.sh
+++ b/contrib/rackspace/initialize-rackspace-cluster.sh
@@ -27,14 +27,14 @@ fi
 
 cd $ROOT_DIR
 
-# upload each component's systemd unit to the fleet cluster
-for component in registry logger database cache controller builder router
-do
-  pushd $component/systemd > /dev/null
-  fleetctl submit deis-$component.service
-  fleetctl start deis-$component.service
-  popd > /dev/null
+# upload all systemd unit to the fleet cluster
+units=()
+for component in builder cache controller database logger registry router; do
+  units+=($component/systemd/*)
 done
+
+fleetctl submit ${units[@]}
+fleetctl start ${units[@]}
 
 echo_green "Done! Inspect the state of the services with: fleetctl list-units"
 echo_green "Once all the services are running, you can register with your Deis cluster: deis register 1.2.3.4:8000"


### PR DESCRIPTION
Submitting and then starting systemctl units one-by-one
with fleet causes some issues because of dependencies -
if bar depends on foo, foo must be defined and started first.

This commit makes sure we always submit/start _all_ units at
once, making this no longer order-dependent.

fixes #806
