### PR TITLE
chore(controller): fix flake8 issues

### DIFF
--- a/controller/Makefile
+++ b/controller/Makefile
@@ -45,4 +45,4 @@ coverage:
 	coverage html
 
 flake8:
-	flake8
+	flake8 --exclude=./api/migrations,./scheduler/coreos.py


### PR DESCRIPTION
I fixed up the coreos scheduler before adding it to the excludes, but the embedded systemd unit files is longer than our flake8 restrictions, so I decided to add it to the excludes. The API migrations are ugly as well, so I added that to it.

Other things done in this PR:
- removed duplicate `run()` function
- removed unused LOGGER_TEMPLATE and ROUTER_TEMPLATE. These templates exist at `logger/systemd/deis-logger.service` and `router/systemd/deis-router.service`.

Also, there's 2 free bugfixes for spawning applications in this PR. Bonus points for figuring out where they're hiding :)

fixes #675
