### PR TITLE
refactor(client): rename containers to ps

### DIFF
--- a/docs/client/containers.rst
+++ b/docs/client/containers.rst
@@ -1,10 +1,10 @@
-:title: Containers
-:description: Learn how to list and scale Deis containers for an application using the Deis client.
+:title: Processes
+:description: Learn how to list and scale Deis processes for an application using the Deis client.
 
 
-containers
-==========
+processes
+=========
 
-.. automethod:: client.deis.DeisClient.containers_list
-.. automethod:: client.deis.DeisClient.containers_scale
+.. automethod:: client.deis.DeisClient.ps_list
+.. automethod:: client.deis.DeisClient.ps_scale
 

--- a/docs/client/index.rst
+++ b/docs/client/index.rst
@@ -28,7 +28,7 @@ Client Reference
     keys
 
     apps
-    containers
+    ps
     config
     builds
     releases

--- a/docs/client/scale.rst
+++ b/docs/client/scale.rst
@@ -1,9 +1,9 @@
 :title: Scale
-:description: Learn how to scale containers for a Deis application using the Deis client.
+:description: Learn how to scale processes for a Deis application using the Deis client.
 
 
 scale
 =====
 
-.. automethod:: client.deis.DeisClient.containers_scale
+.. automethod:: client.deis.DeisClient.ps_scale
    :noindex:

--- a/docs/developer/manage-application.rst
+++ b/docs/developer/manage-application.rst
@@ -32,10 +32,10 @@ that power your app.
 .. code-block:: console
 
     $ deis scale web=8
-    Scaling containers... but first, coffee!
+    Scaling processes... but first, coffee!
     done in 20s
 
-    === peachy-waxworks Containers
+    === peachy-waxworks Processes
 
     --- web: `java -cp target/classes:target/dependency/* HelloWorld`
     web.1 up 2013-12-03T00:00:25.836Z (dev-runtime-1)

--- a/docs/gettingstarted/concepts.rst
+++ b/docs/gettingstarted/concepts.rst
@@ -46,7 +46,7 @@ CoreOS
 needed by modern infrastructure stacks and targeted at massive
 server deployments.
 
-Deis applications are containers running on CoreOS machines, which can
+Deis applications are processes running on CoreOS machines, which can
 be private or public cloud instances, or bare metal. CoreOS clusters
 allow Deis to host applications and services at scale with
 high resilience.
@@ -75,7 +75,7 @@ An :ref:`application`, or app, lives on a :ref:`cluster`, where it uses
 deployed git repository.
 
 Developers use :ref:`Applications <application>` to push code, change
-configuration, scale containers, view logs, or run admin commands --
+configuration, scale processes, view logs, or run admin commands --
 regardless of the cluster's underlying infrastructure.
 
 .. _concepts_build_release_run:
@@ -99,7 +99,7 @@ changed, making it easy to rollback code and configuration.
 Run Stage
 ^^^^^^^^^
 The run stage shells out jobs to the scheduler. The scheduler is in control of balancing the
-containers evenly across the cluster, as well as the announcers and the loggers for each
+processes evenly across the cluster, as well as the announcers and the loggers for each
 application. The scheduler uses SSH to submit jobs to each node in the cluster and updates
 the proxy component between releases, making zero downtime deployments possible.
 


### PR DESCRIPTION
'ps' is the naming convention that Heroku uses for application containers. We should folow suit so that developers migrating from Heroku are more comfortable with the Deis CLI. I've also changed around some of the wording in the docs as well as left some instances of an app container behind, because both are fundamentally different. Let me know what you guys think.
