### PR TITLE
fix(contrib/ec2): fix ephemeral port range

### DIFF
--- a/contrib/ec2/deis.template
+++ b/contrib/ec2/deis.template
@@ -144,7 +144,7 @@
     "IngressEphemeral": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
-        "GroupName": {"Ref": "DeisSecurityGroup"}, "IpProtocol": "tcp", "FromPort": "49156", "ToPort": "65535", "SourceSecurityGroupId": {
+        "GroupName": {"Ref": "DeisSecurityGroup"}, "IpProtocol": "tcp", "FromPort": "49152", "ToPort": "65535", "SourceSecurityGroupId": {
           "Fn::GetAtt" : [ "DeisSecurityGroup", "GroupId" ]
         }
       }


### PR DESCRIPTION
The default ephemeral port range is set to 49152 according to http://www.ncftp.com/ncftpd/doc/misc/ephemeral_ports.html. Some apps that start on 49153 will be blocked by the firewall otherwise.
