### PR TITLE
fix(coverage): cd to controller dir before submitting to coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,4 @@ script:
   - make -C docs
 
 after_success:
-  - coveralls
+  - cd controller && coveralls


### PR DESCRIPTION
The `.coverage` file is created in the `controller/` dir now, but the `coveralls` upload tool looks in the default dir. I verified that this fixes our coverage data and badge on the fix-coveralls-io branch (then I deleted that branch from `.travis.yml` to make this a PR).

closes #818.
