### PR TITLE
feat(Makefile): pull deis/slugrunner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ install: check-fleet
 
 pull:
 	$(call ssh_all,'for c in $(ALL_COMPONENTS); do docker pull deis/$$c; done')
+	$(call ssh_all,'docker pull deis/slugrunner')
 
 restart: stop start
 


### PR DESCRIPTION
Pulling deis/slugrunner on every host will significantly speed up both application launch times on nodes that have not yet started an app as well as speeding up launch times for deis/registry on vagrant deploys or any other deployment option that utilizes `make pull`.
