### PR TITLE
feat(controller): make Procfile mandatory

### DIFF
--- a/builder/templates/builder
+++ b/builder/templates/builder
@@ -58,7 +58,9 @@ if __name__ == '__main__':
         # check for Procfile
         dockerfile = os.path.join(temp_dir, 'Dockerfile')
         procfile = os.path.join(temp_dir, 'Procfile')
-        if not os.path.exists(dockerfile) and os.path.exists(procfile):
+        if not os.path.exists(procfile):
+            raise Exception('Procfile must exist')
+        if not os.path.exists(dockerfile):
             if os.path.exists('/buildpacks'):
                 build_cmd = "docker run -i -a stdin -v {cache_dir}:/tmp/cache:rw -v /buildpacks:/tmp/buildpacks deis/slugbuilder".format(**locals())
             else:

--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -257,7 +257,7 @@ class Container(UuidAuditedModel):
     def _get_command(self):
         c_type = self.type
         if c_type:
-            return 'start {c_type}'
+            return "cat Procfile | grep ^{c_type} | cut -f 1 -d ' ' --complement | sh -"
         else:
             return ''
 


### PR DESCRIPTION
At the moment, all custom Dockerfile apps will not start because the 'start' command is not present in the container. Instead, we can generically parse the Procfile for the process type and start that instead. This makes two important changes:

1) All applications **must** specify a Procfile
2) All custom Dockerfile apps must have access to cat, grep, cut and sh

The justification for 1) is so that we have a known place to search for runnable processes. 2) is because of the change from `start web` to parse the Procfile for the process types.

fixes #668
