### PR TITLE
feat(test): add integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,5 +115,8 @@ status: check-fleet
 stop: check-fleet
 	fleetctl --strict-host-key-checking=false stop $(ALL_UNITS)
 
+tests:
+	cd test && bundle install && bundle exec rake
+
 uninstall: check-fleet stop
 	fleetctl --strict-host-key-checking=false destroy $(ALL_UNITS)

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+example-*

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'mixlib-shellout', '~> 1.4.0'
+gem 'rainbow', '~> 2.0.0'
+gem 'rake', '~> 10.3.1'

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,0 +1,14 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    mixlib-shellout (1.4.0)
+    rainbow (2.0.0)
+    rake (10.3.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mixlib-shellout (~> 1.4.0)
+  rainbow (~> 2.0.0)
+  rake (~> 10.3.1)

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,29 @@
+# Deis integration testing
+This directory includes a Rakefile which will run integration tests on an existing Deis cluster.
+
+To run all tests:
+
+```console
+$ bundle install
+$ bundle exec rake
+```
+
+The namespaces `setup`, `tests`, and `cleanup` are defined. The default task runs `setup:all`, `tests:all`, `cleanup:all` and then exits.
+
+Namespaces can also be run manually:
+
+```console
+$ bundle exec rake setup:all
+```
+
+...and so can tests:
+
+```console
+$ bundle exec rake tests:create_cluster
+```
+
+The test environment uses several environment variables, which can be set to customize the run:
+* `DEIS_TEST_AUTH_KEY` - SSH key used to register with the Deis controller -- will be generated if it doesn't exist (default: `~/.ssh/deis`)
+* `DEIS_TEST_KEY` - SSH key used to login to the controller machine (default: `~/.vagrant.d/insecure_private_key`)
+* `DEIS_TEST_HOST` - hostname which resolves to the controller host (default: `local.deisapp.com`)
+* `DEIS_TEST_APP` - name of the Deis example app to use, which is cloned from GitHub (default: `example-ruby-sinatra`)

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -1,0 +1,78 @@
+#!/usr/bin/env rake
+
+require 'mixlib/shellout'
+require 'rainbow/ext/string'
+
+AUTH_KEY = ENV['DEIS_TEST_KEY'] || '~/.ssh/deis'
+SSH_KEY = ENV['DEIS_TEST_SSH_KEY'] || '~/.vagrant.d/insecure_private_key'
+HOST = ENV['DEIS_TEST_HOST'] || 'local.deisapp.com'
+EXAMPLE_APP = ENV['DEIS_TEST_APP'] || 'example-ruby-sinatra'
+
+namespace :setup do
+  task :all => ['create_ssh_key','clone_example_app']
+  task :create_ssh_key do
+    run_command("if [ ! -f #{AUTH_KEY} ]; then ssh-keygen -q -t rsa -f #{AUTH_KEY} -N '' -C deis && ssh-add -K #{AUTH_KEY} ; fi")
+  end
+  task :clone_example_app do
+    run_command("if [ ! -d ./#{EXAMPLE_APP} ]; then git clone https://github.com/opdemand/#{EXAMPLE_APP}.git ; fi")
+  end
+end
+
+namespace :tests do
+  task :all => ['register','login','add_key','create_cluster','create_app','push_app','scale_app','verify_app']
+  task :register do
+    run_command("deis register http://#{HOST}:8000 --username=test --email=test@test.co.nz --password=asdf1234")
+  end
+  task :login do
+    run_command("deis login http://#{HOST}:8000 --username=test --password=asdf1234")
+  end
+  task :add_key do
+    run_command("deis keys:add #{AUTH_KEY}.pub")
+  end
+  task :create_cluster do
+    run_command("deis init dev #{HOST} --hosts=#{HOST} --auth=#{SSH_KEY}")
+  end
+  task :create_app do
+    run_command("cd #{EXAMPLE_APP} && deis apps:create testing")
+  end
+  task :push_app do
+    run_command("cd #{EXAMPLE_APP} && git push deis master")
+  end
+  task :scale_app do
+    run_command("cd #{EXAMPLE_APP} && deis scale web=2")
+  end
+  task :verify_app do
+    run_command("curl -s http://testing.#{HOST} | grep -q 'Powered by Deis'")
+  end
+end
+
+namespace :cleanup do
+  task :all => ['destroy_app','destroy_cluster','remove_key','logout']
+  task :destroy_app do
+    run_command("cd #{EXAMPLE_APP} && deis apps:destroy --app=testing --confirm=testing")
+  end
+  task :destroy_cluster do
+    run_command("deis clusters:destroy dev --confirm=dev")
+  end
+  task :remove_key do
+    run_command("deis keys:remove deis")
+  end
+  task :logout do
+    run_command("deis auth:logout")
+  end
+end
+
+def run_command(cmd)
+  print "Running #{cmd}... ".color(:yellow)
+  cmd = Mixlib::ShellOut.new(cmd).run_command
+  if not cmd.error?
+    puts "Success!".color(:green)
+  else
+    puts "Failed!".color(:red)
+    puts cmd.stdout.color(:red)
+    puts cmd.stderr.color(:red)
+    raise "Command failed - stopping"
+  end
+end
+
+task :default => ['setup:all', 'tests:all', 'cleanup:all']


### PR DESCRIPTION
Adds a test/ directory with a Rakefile that defines
integration tests to fully exercise a Deis cluster.

Currently these are written in Ruby, as the goal here was
to get tests implemented quickly. The tests were written so
they can be easily ported later.
