### PR TITLE
fix(controller): rename destroy() to delete() and call its super()

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -121,9 +121,10 @@ class App(UuidAuditedModel):
         build = Build.objects.create(owner=self.owner, app=self, image=settings.DEFAULT_BUILD)
         Release.objects.create(version=1, owner=self.owner, app=self, config=config, build=build)
 
-    def destroy(self, *args, **kwargs):
+    def delete(self, *args, **kwargs):
         for c in self.container_set.all():
             c.destroy()
+        return super(App, self).delete(*args, **kwargs)
 
     def deploy(self, release):
         tasks.deploy_release.delay(self, release).get()


### PR DESCRIPTION
To ensure that we destroy containers and fleet jobs when deleting an
app, destroy containers in the Django model lifecycle method delete(), 
not the REST API-ish destroy() which was not connected to anything.

See https://docs.djangoproject.com/en/1.6/topics/db/models/#overriding-model-methods

Fixes #838.
