### PR TITLE
fix(services): use COREOS_PRIVATE_IPV4 for advertised IP

### DIFF
--- a/builder/systemd/deis-builder.service
+++ b/builder/systemd/deis-builder.service
@@ -2,10 +2,11 @@
 Description=deis-builder
 
 [Service]
+EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/builder >/dev/null || /usr/bin/docker pull deis/builder"
 ExecStartPre=/bin/bash -c "/usr/bin/docker start deis-builder-data || /usr/bin/docker run --name deis-builder-data -v /var/lib/docker deis/base /bin/true"
-ExecStart=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && exec /usr/bin/docker run --name deis-builder -p 2222:22 -e PUBLISH=22 -e HOST=$HOST_IP -e PORT=2222 --volumes-from deis-builder-data --privileged deis/builder"
+ExecStart=/bin/sh -c "docker run --name deis-builder -p 2222:22 -e PUBLISH=22 -e HOST=$COREOS_PRIVATE_IPV4 -e PORT=2222 --volumes-from deis-builder-data --privileged deis/builder"
 ExecStop=/usr/bin/docker rm -f deis-builder
 
 [Install]

--- a/cache/systemd/deis-cache.service
+++ b/cache/systemd/deis-cache.service
@@ -2,9 +2,10 @@
 Description=deis-cache
 
 [Service]
+EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/cache || /usr/bin/docker pull deis/cache"
-ExecStart=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && exec /usr/bin/docker run --name deis-cache -p 6379:6379 -e PUBLISH=6379 -e HOST=$HOST_IP deis/cache"
+ExecStart=/bin/sh -c "docker run --name deis-cache -p 6379:6379 -e PUBLISH=6379 -e HOST=$COREOS_PRIVATE_IPV4 deis/cache"
 ExecStop=/usr/bin/docker rm -f deis-cache
 
 [Install]

--- a/controller/scheduler/coreos.py
+++ b/controller/scheduler/coreos.py
@@ -223,7 +223,7 @@ BindsTo={name}.service
 [Service]
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/sh -c "until /usr/bin/docker port {name} {port} >/dev/null 2>&1; do sleep 2; done; port=$(docker port {name} {port} | cut -d ':' -f2); echo Waiting for $port/tcp...; until netstat -lnt | grep :$port >/dev/null; do sleep 1; done"
-ExecStart=/bin/sh -c "port=$(docker port {name} {port} | cut -d ':' -f2); echo Connected to $COREOS_PUBLIC_IPV4:$port/tcp, publishing to etcd...; while netstat -lnt | grep :$port >/dev/null; do etcdctl set /deis/services/{app}/{name} $COREOS_PUBLIC_IPV4:$port --ttl 60 >/dev/null; sleep 45; done"
+ExecStart=/bin/sh -c "port=$(docker port {name} {port} | cut -d ':' -f2); echo Connected to $COREOS_PRIVATE_IPV4:$port/tcp, publishing to etcd...; while netstat -lnt | grep :$port >/dev/null; do etcdctl set /deis/services/{app}/{name} $COREOS_PRIVATE_IPV4:$port --ttl 60 >/dev/null; sleep 45; done"
 ExecStop=/usr/bin/etcdctl rm --recursive /deis/services/{app}/{name}
 
 [X-Fleet]

--- a/controller/systemd/deis-controller.service
+++ b/controller/systemd/deis-controller.service
@@ -4,9 +4,10 @@ Requires=deis-logger.service deis-builder.service
 After=deis-logger.service deis-builder.service
 
 [Service]
+EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/controller >/dev/null || /usr/bin/docker pull deis/controller"
-ExecStart=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && exec /usr/bin/docker run --name deis-controller -p 8000:8000 -e PUBLISH=8000 -e HOST=$HOST_IP --volumes-from=deis-logger deis/controller"
+ExecStart=/bin/sh -c "docker run --name deis-controller -p 8000:8000 -e PUBLISH=8000 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from=deis-logger deis/controller"
 ExecStop=/usr/bin/docker rm -f deis-controller
 
 [Install]

--- a/database/systemd/deis-database.service
+++ b/database/systemd/deis-database.service
@@ -2,10 +2,11 @@
 Description=deis-database
 
 [Service]
+EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/database >/dev/null || /usr/bin/docker pull deis/database"
 ExecStartPre=/bin/bash -c "/usr/bin/docker start deis-database-data || /usr/bin/docker run --name deis-database-data -v /var/lib/postgresql deis/base /bin/true"
-ExecStart=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && exec /usr/bin/docker run --name deis-database -p 5432:5432 -e PUBLISH=5432 -e HOST=$HOST_IP --volumes-from deis-database-data deis/database
+ExecStart=/bin/sh -c "docker run --name deis-database -p 5432:5432 -e PUBLISH=5432 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-database-data deis/database
 ExecStop=/usr/bin/docker rm -f deis-database
 
 [Install]

--- a/logger/systemd/deis-logger.service
+++ b/logger/systemd/deis-logger.service
@@ -2,10 +2,11 @@
 Description=deis-logger
 
 [Service]
+EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/logger >/dev/null || /usr/bin/docker pull deis/logger"
 ExecStartPre=/bin/bash -c "/usr/bin/docker start deis-logger-data || /usr/bin/docker run --name deis-logger-data -v /var/log/deis deis/base /bin/true"
-ExecStart=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && exec /usr/bin/docker run --name deis-logger -p 514:514/udp -e PUBLISH=514 -e HOST=$HOST_IP --volumes-from deis-logger-data deis/logger"
+ExecStart=/bin/sh -c "docker run --name deis-logger -p 514:514/udp -e PUBLISH=514 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-logger-data deis/logger"
 ExecStop=/usr/bin/docker rm -f deis-logger
 
 [Install]

--- a/registry/systemd/deis-registry.service
+++ b/registry/systemd/deis-registry.service
@@ -2,11 +2,12 @@
 Description=deis-registry
 
 [Service]
+EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/registry >/dev/null || /usr/bin/docker pull deis/registry"
 ExecStartPre=/bin/bash -c "/usr/bin/docker start deis-registry-data || /usr/bin/docker run --name deis-registry-data -v /data deis/base /bin/true"
-ExecStart=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && exec /usr/bin/docker run --name deis-registry -p 5000:5000 -e PUBLISH=5000 -e HOST=$HOST_IP --volumes-from deis-registry-data deis/registry"
-ExecStartPost=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && echo 'Waiting for listener on 5000/tcp...' && until cat </dev/null>/dev/tcp/$HOST_IP/5000; do sleep 1; done && docker pull deis/slugrunner:latest && docker tag deis/slugrunner $HOST_IP:5000/deis/slugrunner && docker push $HOST_IP:5000/deis/slugrunner"
+ExecStart=/bin/sh -c "docker run --name deis-registry -p 5000:5000 -e PUBLISH=5000 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-registry-data deis/registry"
+ExecStartPost=/bin/sh -c "echo 'Waiting for listener on 5000/tcp...' && until cat </dev/null>/dev/tcp/$COREOS_PRIVATE_IPV4/5000; do sleep 1; done && docker pull deis/slugrunner:latest && docker tag deis/slugrunner $COREOS_PRIVATE_IPV4:5000/deis/slugrunner && docker push $COREOS_PRIVATE_IPV4:5000/deis/slugrunner"
 ExecStop=/usr/bin/docker rm -f deis-registry
 
 [Install]

--- a/router/systemd/deis-router.service
+++ b/router/systemd/deis-router.service
@@ -2,9 +2,10 @@
 Description=deis-router
 
 [Service]
+EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/router >/dev/null || /usr/bin/docker pull deis/router"
-ExecStart=/bin/sh -c "IFACE=$(netstat -nr | grep ^0.0.0.0 | awk '{print $8}') && HOST_IP=$(/bin/ifconfig $IFACE | awk '/inet /{print $2}') && exec /usr/bin/docker run --name deis-router -p 80:80 -e PUBLISH=80 -e HOST=$HOST_IP deis/router"
+ExecStart=/bin/sh -c "docker run --name deis-router -p 80:80 -e PUBLISH=80 -e HOST=$COREOS_PRIVATE_IPV4 deis/router"
 ExecStop=/usr/bin/docker rm -f deis-router
 
 [Install]


### PR DESCRIPTION
Currently, all containers use a hacky method to determine the IP
to advertise to etcd - the method determines the machine's default
route, and uses that IP. However, this can be configured very differently
depending on the environment, and in some cases doesn't work at all.
Instead, we use COREOS_PRIVATE_IPV4, as that is set on every CoreOS host,
and we trust that CoreOS knows the machine's networks better than we do.

fixes #845
