### PR TITLE
fix(builder): start after controller, block until running

### DIFF
--- a/builder/systemd/deis-builder.service
+++ b/builder/systemd/deis-builder.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=deis-builder
+Requires=deis-controller.service
+After=deis-controller.service
 
 [Service]
 EnvironmentFile=/etc/environment
@@ -7,12 +9,11 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/builder >/dev/null || /usr/bin/docker pull deis/builder"
 ExecStartPre=/bin/bash -c "/usr/bin/docker start deis-builder-data || /usr/bin/docker run --name deis-builder-data -v /var/lib/docker deis/base /bin/true"
 ExecStart=/bin/sh -c "docker run --name deis-builder -p 2222:22 -e PUBLISH=22 -e HOST=$COREOS_PRIVATE_IPV4 -e PORT=2222 --volumes-from deis-builder-data --privileged deis/builder"
+ExecStartPost=/bin/sh -c "echo 'Waiting for builder on 2222/tcp...' && until cat </dev/null>/dev/tcp/$COREOS_PRIVATE_IPV4/2222; do sleep 1; done"
 ExecStop=/usr/bin/docker rm -f deis-builder
 
 [Install]
 WantedBy=multi-user.target
 
-# We only need this so that when we start controller, it's guaranteed to be scheduled
-# (If logger and builder are on separate machines, controller can never be scheduled)
 [X-Fleet]
-X-ConditionMachineOf=deis-logger.service
+X-ConditionMachineOf=deis-controller.service

--- a/controller/systemd/deis-controller.service
+++ b/controller/systemd/deis-controller.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=deis-controller
-Requires=deis-logger.service deis-builder.service
-After=deis-logger.service deis-builder.service
+Requires=deis-logger.service
+After=deis-logger.service
 
 [Service]
 EnvironmentFile=/etc/environment
@@ -15,4 +15,3 @@ WantedBy=multi-user.target
 
 [X-Fleet]
 X-ConditionMachineOf=deis-logger.service
-X-ConditionMachineOf=deis-builder.service


### PR DESCRIPTION
deis-builder was reporting as running very quickly,
but inside the container slugrunner and slugbuilder were
taking many minutes to make the container actually active.

Here, we add an ExecStartPost to block a 'running' status
until we're listening on 2222.

We also start the controller before builder, as builder checks
for /deis/controller.

fixes #857
