### PR TITLE
docs(readme): move cluster testing section out of developer workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ $ make run
 * Because of the DNS quandary, we don't start the deis-router component for you. You'll need to start this manually once DNS is setup: `systemctl start deis-router`.
 
 ## Testing the cluster
-Logging into one of the CoreOS machines and stopping a container service should cause the same component on another CoreOS
-host to take over as master
+Integration tests and corresponding documentation can be found under the `test/` folder.
 
 These systemd services run the various containers which compose Deis, and can be stopped on a machine with `sudo systemctl stop servicename`.
 * deis-builder.service
@@ -89,7 +88,9 @@ These systemd services run the various containers which compose Deis, and can be
 * deis-registry.service
 * deis-router.service
 
-Similarly, bringing down a VM should enable the services on another VM to take over as master
+Logging into one of the CoreOS machines and stopping a container service should cause the same component on another CoreOS
+host to take over as master.
+Similarly, bringing down a VM should enable the services on another VM to take over as master.
 
 ## Install the Deis Client
 If you're using the latest Deis release, use `pip install deis` to install the latest [Deis Client](https://pypi.python.org/pypi/deis/) or download [pre-compiled binaries](https://github.com/deis/deis/tree/master/client#get-started).


### PR DESCRIPTION
This fixes a problem where we mix Ops and Dev workflows.
