### PR TITLE
fix(systemd): handle app containers on restarts

### DIFF
--- a/controller/scheduler/coreos.py
+++ b/controller/scheduler/coreos.py
@@ -195,11 +195,10 @@ SchedulerClient = FleetClient
 CONTAINER_TEMPLATE = """
 [Unit]
 Description={name}
-After=docker.service
-Requires=docker.service
 
 [Service]
 ExecStartPre=/usr/bin/docker pull {image}
+ExecStartPre=/bin/sh -c "docker inspect {name} >/dev/null 2>&1 && docker rm -f {name} || true"
 ExecStart=-/usr/bin/docker run --name {name} -P -e PORT={port} {image} {command}
 ExecStartPost=-/bin/sh -c "until docker inspect {name} >/dev/null 2>&1; do sleep 1; done"; \
     -/bin/sh -c "arping -Idocker0 -c1 `docker inspect -f '{{{{ .NetworkSettings.IPAddress }}}}' {name}`"


### PR DESCRIPTION
This was missed in 66660a4, which allows app containers to be
properly restarted on ungraceful host reboots. See the discussion
at #871 for more information.

Let's wait until we cut v0.8.0 to merge this PR, or else the controller will be rebuilt.
