### PR TITLE
fix(docker): refresh ARP entry each time a container comes up

### DIFF
--- a/controller/scheduler/coreos.py
+++ b/controller/scheduler/coreos.py
@@ -212,6 +212,8 @@ Requires=docker.service
 [Service]
 ExecStartPre=/usr/bin/docker pull {image}
 ExecStart=-/usr/bin/docker run --name {name} -P -e PORT={port} {image} {command}
+ExecStartPost=-/bin/sh -c "until docker inspect {name} >/dev/null 2>&1; do sleep 1; done"; \
+    -/bin/sh -c "arping -Idocker0 -c1 `docker inspect -f '{{{{ .NetworkSettings.IPAddress }}}}' {name}`"
 ExecStop=-/usr/bin/docker rm -f {name}
 """
 


### PR DESCRIPTION
Deis app containers sometimes run into https://github.com/dotcloud/docker/issues/4827. As @gabrtv noted there, the Docker proxy isn't answering an ARP request in a timely fashion, possibly because it reused an IP address and retained a stale MAC address in its cache. There is an outstanding patch that may address this in Docker 0.11.0 that we will test.

This hack/fix adds ExecStartPost commands to Deis app container systemd units, such that the host will send a fresh ARP request using `arping` (included in CoreOS) once `docker inspect` gives up the container's IP address. I can demonstrate empirically that this works around the issue: no more timeouts or 504s.
