### PR TITLE
fix(builder): do not check for a Procfile

### DIFF
--- a/builder/templates/builder
+++ b/builder/templates/builder
@@ -55,10 +55,9 @@ if __name__ == '__main__':
         rc = p.wait()
         if rc != 0:
             raise Exception('Could not extract git archive')
-        # check for Procfile
         dockerfile = os.path.join(temp_dir, 'Dockerfile')
-        procfile = os.path.join(temp_dir, 'Procfile')
-        if not os.path.exists(dockerfile) and os.path.exists(procfile):
+        # some applications do not have a Procfile, so only check for a Dockerfile
+        if not os.path.exists(dockerfile):
             if os.path.exists('/buildpacks'):
                 build_cmd = "docker run -i -a stdin -v {cache_dir}:/tmp/cache:rw -v /buildpacks:/tmp/buildpacks deis/slugbuilder".format(**locals())
             else:


### PR DESCRIPTION
Some applications do not have a Procfile present before a buildpack
compile step[1](https://github.com/bacongobbler/heroku-buildpack-jekyll/blob/master/bin/release). If a Dockerfile is not present, then the builder
should make the assumption that this app is a buildpack app.

Note that `bin/release` for most buildpacks are deprecated in favour of just injecting the Procfile into /app, so there should be a Procfile in the app root by the time `bin/compile` has run to completion.
