### PR TITLE
fix(controller): start logger service after container

### DIFF
--- a/controller/scheduler/coreos.py
+++ b/controller/scheduler/coreos.py
@@ -90,8 +90,8 @@ class FleetClient(object):
         """
         print 'Starting {name}'.format(**locals())
         env = self.env.copy()
-        self._start_log(name, env)
         self._start_container(name, env)
+        self._start_log(name, env)
         self._start_announcer(name, env)
         self._wait_for_announcer(name, env)
 


### PR DESCRIPTION
Since we use `X-ConditionMachineOf={name}.service` in the logger
template, we were starting container and logger in the wrong
order. Found and fixed by @gabrtv.
