### PR TITLE
style(coreos): remove unused systemd template strings

### DIFF
--- a/controller/scheduler/coreos.py
+++ b/controller/scheduler/coreos.py
@@ -183,17 +183,6 @@ class FleetClient(object):
         rc = p.wait()
         return rc, p.stdout.read()
 
-    def run(self, name, image, command):
-        """
-        Run a one-off command
-        """
-        print 'Running {name}'.format(**locals())
-        output = subprocess.PIPE
-        p = subprocess.Popen('fleetrun.sh {command}'.format(**locals()), shell=True, env=self.env,
-                             stdout=output, stderr=subprocess.STDOUT)
-        rc = p.wait()
-        return rc, p.stdout.read()
-
     def attach(self, name):
         """
         Attach to a job's stdin, stdout and stderr


### PR DESCRIPTION
@gabrtv pointed out these systemd template strings are vestigial.
