### PR TITLE
fix(pip): update location of pip installer

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -qy
 RUN apt-get install -yq lxc-docker-0.10.0
 
 # install recent pip
-RUN wget -qO- https://raw.github.com/pypa/pip/1.5.4/contrib/get-pip.py | python -
+RUN wget -qO- https://raw.githubusercontent.com/pypa/pip/1.5.4/contrib/get-pip.py | python -
 
 # install hook dependencies
 RUN pip install pyyaml requests

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get install -yq python-dev libpq-dev libyaml-dev
 
 # install recent pip
-RUN wget -qO- https://raw.github.com/pypa/pip/1.5.4/contrib/get-pip.py | python -
+RUN wget -qO- https://raw.githubusercontent.com/pypa/pip/1.5.4/contrib/get-pip.py | python -
 
 # HACK: install git so we can install bacongobbler's fork of django-fsm
 RUN apt-get install -yq git

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get install -y git-core build-essential python-dev \
     libevent-dev python-openssl liblzma-dev wget
 
 # install recent pip
-RUN wget -qO- https://raw.github.com/pypa/pip/1.5.4/contrib/get-pip.py | python -
+RUN wget -qO- https://raw.githubusercontent.com/pypa/pip/1.5.4/contrib/get-pip.py | python -
 
 # create a registry user
 RUN useradd -s /bin/bash registry


### PR DESCRIPTION
raw.github.com URLs have moved to raw.githubusercontent.com, and
wget was seeing a 301 (Moved Permanently) under the covers. curl
does not automatically follow such a redirect, so the URL change
caused an error for deis/tester, but was benign here.
