### PR TITLE
tests(travis-ci): remove branch restrictions for test runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ language: python
 python:
   - "2.7"
 
-branches:
-  only:
-    - master
-    - release
-
 services:
   - postgresql
 


### PR DESCRIPTION
We previously restricted travis-ci.org builds to just the `master`
and `release` branches, but that isn't necessary. To help with
developing new integration tests, have Travis build any Deis branch.
