### PR TITLE
docs(contributing): add skip ci tag

### DIFF
--- a/docs/contributing/standards.rst
+++ b/docs/contributing/standards.rst
@@ -307,3 +307,17 @@ Examples
     character size.
 
     closes #392
+
+Forcing no Build for TravisCI
+"""""""""""""""""""""""""""""
+
+If you're committing a PR that is just a small typo fix or a README change, you can force
+TravisCI to not build your commit by adding [skip ci] below the message body. For example:
+
+.. code-block:: console
+
+    fix(README): typo
+
+    It's spelled tomato, not tomatoe.
+
+    [skip ci]


### PR DESCRIPTION
You can skip a build on TravisCI by adding the skip ci tag to the commit message. This formalizes that process in the documentation.

ref: http://docs.travis-ci.com/user/how-to-skip-a-build/
