### PR TITLE
refactor(systemd): clean up paths

### DIFF
--- a/builder/systemd/deis-builder.service
+++ b/builder/systemd/deis-builder.service
@@ -6,10 +6,10 @@ After=deis-controller.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/builder >/dev/null || /usr/bin/docker pull deis/builder"
-ExecStartPre=/bin/sh -c "/usr/bin/docker inspect deis-builder >/dev/null && /usr/bin/docker rm -f deis-builder || true"
-ExecStartPre=/bin/sh -c "/usr/bin/docker start deis-builder-data || /usr/bin/docker run --name deis-builder-data -v /var/lib/docker deis/base /bin/true"
-ExecStart=/bin/sh -c "docker run --name deis-builder -p 2222:22 -e PUBLISH=22 -e HOST=$COREOS_PRIVATE_IPV4 -e PORT=2222 --volumes-from deis-builder-data --privileged deis/builder"
+ExecStartPre=/bin/sh -c "docker history deis/builder >/dev/null || docker pull deis/builder"
+ExecStartPre=/bin/sh -c "docker inspect deis-builder >/dev/null && docker rm -f deis-builder || true"
+ExecStartPre=/bin/sh -c "docker start deis-builder-data || docker run --name deis-builder-data -v /var/lib/docker deis/base true"
+ExecStart=/usr/bin/docker run --name deis-builder -p 2222:22 -e PUBLISH=22 -e HOST=${COREOS_PRIVATE_IPV4} -e PORT=2222 --volumes-from deis-builder-data --privileged deis/builder
 ExecStartPost=/bin/sh -c "echo 'Waiting for builder on 2222/tcp...' && until cat </dev/null>/dev/tcp/$COREOS_PRIVATE_IPV4/2222; do sleep 1; done"
 ExecStop=/usr/bin/docker rm -f deis-builder
 

--- a/cache/systemd/deis-cache.service
+++ b/cache/systemd/deis-cache.service
@@ -4,9 +4,9 @@ Description=deis-cache
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/cache >/dev/null || /usr/bin/docker pull deis/cache"
-ExecStartPre=/bin/sh -c "/usr/bin/docker inspect deis-cache >/dev/null && /usr/bin/docker rm -f deis-cache || true"
-ExecStart=/bin/sh -c "docker run --name deis-cache -p 6379:6379 -e PUBLISH=6379 -e HOST=$COREOS_PRIVATE_IPV4 deis/cache"
+ExecStartPre=/bin/sh -c "docker history deis/cache >/dev/null || docker pull deis/cache"
+ExecStartPre=/bin/sh -c "docker inspect deis-cache >/dev/null && docker rm -f deis-cache || true"
+ExecStart=/usr/bin/docker run --name deis-cache -p 6379:6379 -e PUBLISH=6379 -e HOST=${COREOS_PRIVATE_IPV4} deis/cache
 ExecStop=/usr/bin/docker rm -f deis-cache
 
 [Install]

--- a/controller/scheduler/coreos.py
+++ b/controller/scheduler/coreos.py
@@ -199,10 +199,10 @@ Description={name}
 [Service]
 ExecStartPre=/usr/bin/docker pull {image}
 ExecStartPre=/bin/sh -c "docker inspect {name} >/dev/null 2>&1 && docker rm -f {name} || true"
-ExecStart=-/usr/bin/docker run --name {name} -P -e PORT={port} {image} {command}
-ExecStartPost=-/bin/sh -c "until docker inspect {name} >/dev/null 2>&1; do sleep 1; done"; \
-    -/bin/sh -c "arping -Idocker0 -c1 `docker inspect -f '{{{{ .NetworkSettings.IPAddress }}}}' {name}`"
-ExecStop=-/usr/bin/docker rm -f {name}
+ExecStart=/usr/bin/docker run --name {name} -P -e PORT={port} {image} {command}
+ExecStartPost=/bin/sh -c "until docker inspect {name} >/dev/null 2>&1; do sleep 1; done"; \
+    /bin/sh -c "arping -Idocker0 -c1 `docker inspect -f '{{{{ .NetworkSettings.IPAddress }}}}' {name}`"
+ExecStop=/usr/bin/docker rm -f {name}
 """
 
 ANNOUNCE_TEMPLATE = """

--- a/controller/systemd/deis-controller.service
+++ b/controller/systemd/deis-controller.service
@@ -6,9 +6,9 @@ After=deis-logger.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/controller >/dev/null || /usr/bin/docker pull deis/controller"
-ExecStartPre=/bin/sh -c "/usr/bin/docker inspect deis-controller >/dev/null && /usr/bin/docker rm -f deis-controller || true"
-ExecStart=/bin/sh -c "docker run --name deis-controller -p 8000:8000 -e PUBLISH=8000 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from=deis-logger deis/controller"
+ExecStartPre=/bin/sh -c "docker history deis/controller >/dev/null || docker pull deis/controller"
+ExecStartPre=/bin/sh -c "docker inspect deis-controller >/dev/null && docker rm -f deis-controller || true"
+ExecStart=/usr/bin/docker run --name deis-controller -p 8000:8000 -e PUBLISH=8000 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from=deis-logger deis/controller
 ExecStop=/usr/bin/docker rm -f deis-controller
 
 [Install]

--- a/database/systemd/deis-database.service
+++ b/database/systemd/deis-database.service
@@ -4,10 +4,10 @@ Description=deis-database
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/database >/dev/null || /usr/bin/docker pull deis/database"
-ExecStartPre=/bin/sh -c "/usr/bin/docker inspect deis-database >/dev/null && /usr/bin/docker rm -f deis-database || true"
-ExecStartPre=/bin/sh -c "/usr/bin/docker start deis-database-data || /usr/bin/docker run --name deis-database-data -v /var/lib/postgresql deis/base /bin/true"
-ExecStart=/bin/sh -c "docker run --name deis-database -p 5432:5432 -e PUBLISH=5432 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-database-data deis/database
+ExecStartPre=/bin/sh -c "docker history deis/database >/dev/null || docker pull deis/database"
+ExecStartPre=/bin/sh -c "docker inspect deis-database >/dev/null && docker rm -f deis-database || true"
+ExecStartPre=/bin/sh -c "docker start deis-database-data || docker run --name deis-database-data -v /var/lib/postgresql deis/base true"
+ExecStart=/usr/bin/docker run --name deis-database -p 5432:5432 -e PUBLISH=5432 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-database-data deis/database
 ExecStop=/usr/bin/docker rm -f deis-database
 
 [Install]

--- a/logger/systemd/deis-logger.service
+++ b/logger/systemd/deis-logger.service
@@ -4,10 +4,10 @@ Description=deis-logger
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/logger >/dev/null || /usr/bin/docker pull deis/logger"
-ExecStartPre=/bin/sh -c "/usr/bin/docker inspect deis-logger >/dev/null && /usr/bin/docker rm -f deis-logger || true"
-ExecStartPre=/bin/sh -c "/usr/bin/docker start deis-logger-data || /usr/bin/docker run --name deis-logger-data -v /var/log/deis deis/base /bin/true"
-ExecStart=/bin/sh -c "docker run --name deis-logger -p 514:514/udp -e PUBLISH=514 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-logger-data deis/logger"
+ExecStartPre=/bin/sh -c "docker history deis/logger >/dev/null || docker pull deis/logger"
+ExecStartPre=/bin/sh -c "docker inspect deis-logger >/dev/null && docker rm -f deis-logger || true"
+ExecStartPre=/bin/sh -c "docker start deis-logger-data || docker run --name deis-logger-data -v /var/log/deis deis/base true"
+ExecStart=/usr/bin/docker run --name deis-logger -p 514:514/udp -e PUBLISH=514 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-logger-data deis/logger
 ExecStop=/usr/bin/docker rm -f deis-logger
 
 [Install]

--- a/registry/systemd/deis-registry.service
+++ b/registry/systemd/deis-registry.service
@@ -4,10 +4,10 @@ Description=deis-registry
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/registry >/dev/null || /usr/bin/docker pull deis/registry"
-ExecStartPre=/bin/sh -c "/usr/bin/docker inspect deis-registry >/dev/null && /usr/bin/docker rm -f deis-registry || true"
-ExecStartPre=/bin/sh -c "/usr/bin/docker start deis-registry-data || /usr/bin/docker run --name deis-registry-data -v /data deis/base /bin/true"
-ExecStart=/bin/sh -c "docker run --name deis-registry -p 5000:5000 -e PUBLISH=5000 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-registry-data deis/registry"
+ExecStartPre=/bin/sh -c "docker history deis/registry >/dev/null || docker pull deis/registry"
+ExecStartPre=/bin/sh -c "docker inspect deis-registry >/dev/null && docker rm -f deis-registry || true"
+ExecStartPre=/bin/sh -c "docker start deis-registry-data || docker run --name deis-registry-data -v /data deis/base /bin/true"
+ExecStart=/usr/bin/docker run --name deis-registry -p 5000:5000 -e PUBLISH=5000 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-registry-data deis/registry
 ExecStartPost=/bin/sh -c "echo 'Waiting for listener on 5000/tcp...' && until cat </dev/null>/dev/tcp/$COREOS_PRIVATE_IPV4/5000; do sleep 1; done && docker pull deis/slugrunner:latest && docker tag deis/slugrunner $COREOS_PRIVATE_IPV4:5000/deis/slugrunner && docker push $COREOS_PRIVATE_IPV4:5000/deis/slugrunner"
 ExecStop=/usr/bin/docker rm -f deis-registry
 

--- a/router/systemd/deis-router.service
+++ b/router/systemd/deis-router.service
@@ -4,9 +4,9 @@ Description=deis-router
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "/usr/bin/docker history deis/router >/dev/null || /usr/bin/docker pull deis/router"
-ExecStartPre=/bin/sh -c "/usr/bin/docker inspect deis-router >/dev/null && /usr/bin/docker rm -f deis-router || true"
-ExecStart=/bin/sh -c "docker run --name deis-router -p 80:80 -e PUBLISH=80 -e HOST=$COREOS_PRIVATE_IPV4 deis/router"
+ExecStartPre=/bin/sh -c "docker history deis/router >/dev/null || docker pull deis/router"
+ExecStartPre=/bin/sh -c "docker inspect deis-router >/dev/null && docker rm -f deis-router || true"
+ExecStart=/usr/bin/docker run --name deis-router -p 80:80 -e PUBLISH=80 -e HOST=${COREOS_PRIVATE_IPV4} deis/router
 ExecStop=/usr/bin/docker rm -f deis-router
 
 [Install]


### PR DESCRIPTION
harcoded paths are not required in shell environments. I've also removed unnecessary uses of /bin/sh when we only require an environment variable, since systemd can reference environment variables through ${}.

ref: http://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStart=
