### PR TITLE
fix(test): specify machine IPs

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -25,5 +25,6 @@ $ bundle exec rake tests:create_cluster
 The test environment uses several environment variables, which can be set to customize the run:
 * `DEIS_TEST_AUTH_KEY` - SSH key used to register with the Deis controller -- will be generated if it doesn't exist (default: `~/.ssh/deis`)
 * `DEIS_TEST_KEY` - SSH key used to login to the controller machine (default: `~/.vagrant.d/insecure_private_key`)
-* `DEIS_TEST_HOST` - hostname which resolves to the controller host (default: `local.deisapp.com`)
+* `DEIS_TEST_HOSTNAME` - hostname which resolves to the controller host (default: `local.deisapp.com`)
+* `DEIS_TEST_HOSTS` - comma-separated list of IPs for nodes in the cluster -- should be internal IPs for cloud providers (default: `172.17.8.100`)
 * `DEIS_TEST_APP` - name of the Deis example app to use, which is cloned from GitHub (default: `example-ruby-sinatra`)

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -5,7 +5,8 @@ require 'rainbow/ext/string'
 
 AUTH_KEY = ENV['DEIS_TEST_KEY'] || '~/.ssh/deis'
 SSH_KEY = ENV['DEIS_TEST_SSH_KEY'] || '~/.vagrant.d/insecure_private_key'
-HOST = ENV['DEIS_TEST_HOST'] || 'local.deisapp.com'
+HOSTS = ENV['DEIS_TEST_HOSTS'] || '172.17.8.100'
+HOSTNAME = ENV['DEIS_TEST_HOSTNAME'] || 'local.deisapp.com'
 EXAMPLE_APP = ENV['DEIS_TEST_APP'] || 'example-ruby-sinatra'
 
 namespace :setup do
@@ -21,16 +22,16 @@ end
 namespace :tests do
   task :all => ['register','login','add_key','create_cluster','create_app','push_app','scale_app','verify_app']
   task :register do
-    run_command("deis register http://#{HOST}:8000 --username=test --email=test@test.co.nz --password=asdf1234")
+    run_command("deis register http://#{HOSTNAME}:8000 --username=test --email=test@test.co.nz --password=asdf1234")
   end
   task :login do
-    run_command("deis login http://#{HOST}:8000 --username=test --password=asdf1234")
+    run_command("deis login http://#{HOSTNAME}:8000 --username=test --password=asdf1234")
   end
   task :add_key do
     run_command("deis keys:add #{AUTH_KEY}.pub")
   end
   task :create_cluster do
-    run_command("deis init dev #{HOST} --hosts=#{HOST} --auth=#{SSH_KEY}")
+    run_command("deis init dev #{HOSTNAME} --hosts=#{HOSTS} --auth=#{SSH_KEY}")
   end
   task :create_app do
     run_command("cd #{EXAMPLE_APP} && deis apps:create testing")
@@ -42,7 +43,7 @@ namespace :tests do
     run_command("cd #{EXAMPLE_APP} && deis scale web=2")
   end
   task :verify_app do
-    run_command("curl -s http://testing.#{HOST} | grep -q 'Powered by Deis'")
+    run_command("curl -s http://testing.#{HOSTNAME} | grep -q 'Powered by Deis'")
   end
 end
 


### PR DESCRIPTION
The Rakefile breaks for cloud providers, as we used the HOST
for both the cluster domain and a list of hosts. Since etcd/fleet
now listen exclusively on the `private_ipv4` interface, connecting
on the public domain doesn't work.

This commit adds a new environment variable, `DEIS_TEST_HOSTS`,
to pass in the hosts to the creation of the cluster.
