### PR TITLE
fix(docker): use btrfs inside builder

### DIFF
--- a/builder/bin/boot
+++ b/builder/bin/boot
@@ -43,7 +43,7 @@ CONFD_PID=$!
 test -e /var/run/docker.sock && rm -f /var/run/docker.sock
 
 # spawn a docker daemon to run builds
-docker -d --bip=172.19.42.1/16 &
+docker -d --storage-driver=btrfs --bip=172.19.42.1/16 &
 DOCKER_PID=$!
 
 # wait for docker to start


### PR DESCRIPTION
We have seen mixed usage of aufs and btrfs cause problems before. On
CoreOS, btrfs rules the day, so use that.

We hoped this would work around https://github.com/deis/deis/issues/882,
but no. Regardless, it should be changed soon.
