### PR TITLE
fix(ec2): add explicit 100GB root volume

### DIFF
--- a/contrib/ec2/deis.template
+++ b/contrib/ec2/deis.template
@@ -159,8 +159,13 @@
         "InstanceType": {"Ref": "InstanceType"},
         "KeyName": {"Ref": "KeyPair"},
         "SecurityGroups": [{"Ref": "CoreOSSecurityGroup"}, {"Ref": "DeisSecurityGroup"}],
-        "UserData" : { "Fn::Base64": { "Fn::Join": [ "", [ ] ] }
-        }
+        "UserData" : { "Fn::Base64": { "Fn::Join": [ "", [ ] ] } },
+        "BlockDeviceMappings" : [
+          {
+            "DeviceName" : "/dev/sda",
+            "Ebs" : { "VolumeSize" : "100" }
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
By default the m3 instances (of all types) use an 8GB root volume.  The SSD volume is unused and located at `/dev/xvdb`.  This PR changes the 8GB root volume to 100GB, providing enough storage for a basic Deis cluster.

Fixes #882.
