### PR TITLE
feat(client): add --app option to apps:run

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -600,7 +600,9 @@ class DeisClient(object):
 
         Usage: deis apps:run <command>...
         """
-        app = self._session.app
+        app = args.get('--app')
+        if not app:
+            app = self._session.app
         body = {'command': ' '.join(sys.argv[2:])}
         response = self._dispatch('post',
                                   "/api/apps/{}/run".format(app),


### PR DESCRIPTION
All of the other apps commands have a --app option. This commit
introduces that option to the apps:run command as well.

fixes #722
