### PR TITLE
fix(Makefile): fix 'check-fleet' rule for $FLEETCTL_TUNNEL with explicit port.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ build:
 
 check-fleet:
 	@LOCAL_VERSION=`fleetctl -version`; \
-	REMOTE_VERSION=`ssh -o StrictHostKeyChecking=no core@$(FLEETCTL_TUNNEL) fleetctl -version`; \
+	REMOTE_VERSION=`ssh -o StrictHostKeyChecking=no core@$(subst :, -p ,$(FLEETCTL_TUNNEL)) fleetctl -version`; \
 	if [ "$$LOCAL_VERSION" != "$$REMOTE_VERSION" ]; then \
 			echo "Your fleetctl client version should match the server. Local version: $$LOCAL_VERSION, server version: $$REMOTE_VERSION. Uninstall your local version and install the latest build from https://github.com/coreos/fleet/releases"; exit 1; \
 	fi


### PR DESCRIPTION
Fixed the fleetctl version check in Makefile when $FLEETCTL_TUNNEL includes a port (eg. `FLEETCTL_TUNNEL=host:port` instead of `FLEETCTL_TUNNEL=host`).

``` sh
$ FLEETCTL_TUNNEL=127.0.0.1:4222 make check-fleet # breaks because of invalid generated ssh command-line
ssh: Could not resolve hostname 127.0.0.1:4222: Name or service not known
Your fleetctl client version should match the server. Local version: fleetctl version 0.3.0, server version: . Uninstall your local version and install the latest build from https://github.com/coreos/fleet/releases
make: *** [check-fleet] Error 1
$ git checkout fleetctl-version-check-with-port 
Switched to branch 'fleetctl-version-check-with-port'
$ FLEETCTL_TUNNEL=127.0.0.1:4222 make check-fleet # works as expected with explicit port
Your fleetctl client version should match the server. Local version: fleetctl version 0.3.0, server version: fleetctl version 0.2.0. Uninstall your local version and install the latest build from https://github.com/coreos/fleet/releases
make: *** [check-fleet] Error 1
$ FLEETCTL_TUNNEL=some.host make check-fleet # also works as expected with implicit port
ssh: Could not resolve hostname some.host: Name or service not known
Your fleetctl client version should match the server. Local version: fleetctl version 0.3.0, server version: . Uninstall your local version and install the latest build from https://github.com/coreos/fleet/releases
make: *** [check-fleet] Error 1
```
