### PR TITLE
fix(controller): restore App.destroy() and call delete()

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -134,6 +134,9 @@ class App(UuidAuditedModel):
             self.save()
             self.scale()
 
+    def destroy(self, *args, **kwargs):
+        return self.delete(*args, **kwargs)
+
     def scale(self, **kwargs):
         """Scale containers up or down to match requested."""
         requested_containers = self.structure.copy()

--- a/controller/api/tests/test_cluster.py
+++ b/controller/api/tests/test_cluster.py
@@ -45,6 +45,12 @@ class ClusterTest(TestCase):
         response = self.client.get('/api/clusters')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
+        # ensure we can delete the cluster with an app
+        # see https://github.com/deis/deis/issues/927
+        url = '/api/apps'
+        body = {'cluster': 'autotest'}
+        response = self.client.post(url, json.dumps(body), content_type='application/json')
+        self.assertEqual(response.status_code, 201)
         url = '/api/clusters/{cluster_id}'.format(**locals())
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
The change in https://github.com/deis/deis/pull/839 didn't account for Django REST framework methods that indirectly call destroy().
Includes a regression test.

Fixes #927.
