### PR TITLE
chore(builder): update docker to 0.11.1

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get install -yq aufs-tools iptables ca-certificates lxc
 RUN echo "deb http://get.docker.io/ubuntu docker main" > /etc/apt/sources.list.d/docker.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 RUN apt-get update -qy
-RUN apt-get install -yq lxc-docker-0.10.0
+RUN apt-get install -yq lxc-docker-0.11.1
 
 # install recent pip
 RUN wget -qO- https://raw.githubusercontent.com/pypa/pip/1.5.5/contrib/get-pip.py | python -


### PR DESCRIPTION
http://blog.docker.io/2014/05/docker-0-11-release-candidate-for-1-0/

Tested with several example apps on vagrant.

TESTING:
`make -C builder/ build stop run`
`cd test && rake`
(interactive testing)
