### PR TITLE
feat(user-data): add Docker index debugging service

### DIFF
--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -77,6 +77,19 @@ coreos:
       Type=oneshot
       ExecStartPre=/usr/bin/rm /etc/motd
       ExecStart=/usr/bin/ln -s /run/deis/motd /etc/motd
+  - name: docker-index-network-logging.service
+    command: reload
+    content: |
+      [Unit]
+      Description=Log Docker index requests.
+
+      [Service]
+      TimeoutSec=5m
+      Environment="USER=core"
+      ExecStartPre=/usr/bin/mkdir /dumps
+      ExecStartPre=/usr/bin/chmod -R ugo+rw /dumps
+      ExecStartPre=/usr/bin/toolbox yum install -y tcpdump
+      ExecStart=/usr/bin/toolbox tcpdump -C 10 -s 4096 -tttt -vv -W 50 -w /media/root/dumps/docker-index-logs.pcap port 443
 write_files:
   - path: /run/deis/motd
     content: " \e[31m* *    \e[34m*   \e[32m*****    \e[39mddddd   eeeeeee iiiiiii   ssss\n\e[31m*   *  \e[34m* *  \e[32m*   *     \e[39md   d   e    e    i     s    s\n \e[31m* *  \e[34m***** \e[32m*****     \e[39md    d  e         i    s\n\e[32m*****  \e[31m* *    \e[34m*       \e[39md     d e         i     s\n\e[32m*   * \e[31m*   *  \e[34m* *      \e[39md     d eee       i      sss\n\e[32m*****  \e[31m* *  \e[34m*****     \e[39md     d e         i         s\n  \e[34m*   \e[32m*****  \e[31m* *      \e[39md    d  e         i          s\n \e[34m* *  \e[32m*   * \e[31m*   *     \e[39md   d   e    e    i    s    s\n\e[34m***** \e[32m*****  \e[31m* *     \e[39mddddd   eeeeeee iiiiiii  ssss\n\n\e[39mWelcome to Deis\t\t\tPowered by Core\e[38;5;45mO\e[38;5;206mS\e[39m\n"


### PR DESCRIPTION
Defines a systemd service which will capture traffic on port 443.

Some notes:
- Capture files will grow to 10MB each before tcpdump creates a new file
- Only 50 capture files will exist before tcpdump will overwrite them
- These mean that only 500MB is the maximum storage used for network dumps
- We use the core user since the fedora image is stored as /var/lib/toolbox/$USER-fedora --
  this makes it so that we use the same image that is used when a user runs
  `toolbox` on a CoreOS machine.
- We use the `reload` action since we don't start this service automatically

TESTING: Run `sudo systemctl start docker-index-network-logging` and
wait for the service to start (first time will take a few minutes,
as the toolbox is pulling a Fedora image). Then, do a few `docker pull`s
on the CoreOS box and inspect the logs inside a `toolbox` shell:

``` console
$ tcpdump -tttt -r /media/root/dumps/docker-index-logs.pcap00 |less
```

The output will look something like:

``` console
2014-05-09 01:51:06.871078 IP 162.159.253.251.https > deis-1.59424: Flags [P.], seq 1947618:1949078, ack 821, win 65535, length 1460
2014-05-09 01:51:06.871078 IP deis-1.59424 > 162.159.253.251.https: Flags [.], ack 1949078, win 65535, length 0
2014-05-09 01:51:06.872202 IP 162.159.253.251.https > deis-1.59424: Flags [P.], seq 1949078:1950538, ack 821, win 65535, length 1460
2014-05-09 01:51:06.872218 IP deis-1.59424 > 162.159.253.251.https: Flags [.], ack 1950538, win 65535, length 0
```
