### PR TITLE
fix(test): don't fail if already registered, and pause for builder

### DIFF
--- a/test/Rakefile
+++ b/test/Rakefile
@@ -22,7 +22,7 @@ end
 namespace :tests do
   task :all => ['register','login','add_key','create_cluster','create_app','push_app','scale_app','verify_app']
   task :register do
-    run_command("deis register http://#{HOSTNAME}:8000 --username=test --email=test@test.co.nz --password=asdf1234")
+    run_command("deis register http://#{HOSTNAME}:8000 --username=test --email=test@test.co.nz --password=asdf1234 || true")
   end
   task :login do
     run_command("deis login http://#{HOSTNAME}:8000 --username=test --password=asdf1234")
@@ -34,13 +34,20 @@ namespace :tests do
     run_command("deis init dev #{HOSTNAME} --hosts=#{HOSTS} --auth=#{SSH_KEY}")
   end
   task :create_app do
-    run_command("cd #{EXAMPLE_APP} && deis apps:create testing")
+    Dir.chdir(EXAMPLE_APP) do
+      sleep 6  # give builder git time to wake up
+      run_command('deis apps:create testing')
+    end
   end
   task :push_app do
-    run_command("cd #{EXAMPLE_APP} && git push deis master")
+    Dir.chdir(EXAMPLE_APP) do
+      run_command('git push deis master')
+    end
   end
   task :scale_app do
-    run_command("cd #{EXAMPLE_APP} && deis scale web=2")
+    Dir.chdir(EXAMPLE_APP) do
+      run_command('deis scale web=2')
+    end
   end
   task :verify_app do
     run_command("curl -s http://testing.#{HOSTNAME} | grep -q 'Powered by Deis'")
@@ -50,7 +57,9 @@ end
 namespace :cleanup do
   task :all => ['destroy_app','destroy_cluster','remove_key','logout']
   task :destroy_app do
-    run_command("cd #{EXAMPLE_APP} && deis apps:destroy --app=testing --confirm=testing")
+    Dir.chdir(EXAMPLE_APP) do
+      run_command('deis apps:destroy --app=testing --confirm=testing')
+    end
   end
   task :destroy_cluster do
     run_command("deis clusters:destroy dev --confirm=dev")


### PR DESCRIPTION
Adding a `sleep` call avoids an occasional error when we fire off
`deis create` before the builder is ready, and `|| true` allows the
test to be repeated when the _test_ user is already registered.
