### PR TITLE
feat(client): add apps:rename command

### DIFF
--- a/controller/api/tests/test_app.py
+++ b/controller/api/tests/test_app.py
@@ -50,7 +50,15 @@ class AppTest(TestCase):
         self.assertEqual(response.status_code, 200)
         body = {'id': 'new'}
         response = self.client.patch(url, json.dumps(body), content_type='application/json')
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 200)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 404)
+        app_id = 'new'
+        # verify that a new release was created
+        url = '/api/apps/{app_id}/releases'.format(**locals())
+        response = self.client.get(url, content_type='application/json')
+        self.assertEqual(response.data['count'], 2)
+        url = '/api/apps/{app_id}'.format(**locals())
         response = self.client.delete(url)
         self.assertEqual(response.status_code, 204)
 

--- a/controller/api/urls.py
+++ b/controller/api/urls.py
@@ -269,7 +269,11 @@ urlpatterns = patterns(
         views.AppPermsViewSet.as_view({'get': 'list', 'post': 'create'})),
     # apps base endpoint
     url(r'^apps/(?P<id>[-_\w]+)/?',
-        views.AppViewSet.as_view({'get': 'retrieve', 'delete': 'destroy'})),
+        views.AppViewSet.as_view({
+            'get': 'retrieve',
+            'delete': 'destroy',
+            'patch': 'partial_update',
+        })),
     url(r'^apps/?',
         views.AppViewSet.as_view({'get': 'list', 'post': 'create'})),
     # key

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -276,6 +276,13 @@ class AppViewSet(OwnerViewSet):
         if created:
             app.create()
 
+    def partial_update(self, request, *args, **kwargs):
+        app = get_object_or_404(models.App, id=kwargs['id'])
+        release = app.release_set.latest()
+        self.release = release.new(self.request.user)
+        app.deploy(self.release)
+        return super(AppViewSet, self).partial_update(request, *args, **kwargs)
+
     def scale(self, request, **kwargs):
         new_structure = {}
         try:

--- a/docs/developer/manage-application.rst
+++ b/docs/developer/manage-application.rst
@@ -73,6 +73,19 @@ Use ``deis run`` to execute commands against the deployed version of your applic
 Applications deployed on Deis `use one-off processes for admin tasks`_ like
 database migrations and other tasks that must run against the live application.
 
+Rename the Application
+----------------------
+
+Sometimes, we just don't like the name that the auto-generation script makes
+for us. We can use ``deis apps:rename`` to rename the application name to
+something more sensible.
+
+.. code-block:: console
+
+    $ deis rename african-swallow
+    Renaming app... done, new name is african-swallow
+    Git remote deis modified
+
 Share the Application
 ---------------------
 Use ``deis sharing:add`` to allow another Deis user to collaborate on your

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -52,13 +52,18 @@ namespace :tests do
   task :verify_app do
     run_command("curl -s http://testing.#{HOSTNAME} | grep -q 'Powered by Deis'")
   end
+  task :rename_app do
+    Dir.chdir(EXAMPLE_APP) do
+      run_command('deis rename app-renamed')
+    end
+  end
 end
 
 namespace :cleanup do
   task :all => ['destroy_app','destroy_cluster','remove_key','logout']
   task :destroy_app do
     Dir.chdir(EXAMPLE_APP) do
-      run_command('deis apps:destroy --app=testing --confirm=testing')
+      run_command('deis apps:destroy --app=app-renamed --confirm=app-renamed')
     end
   end
   task :destroy_cluster do


### PR DESCRIPTION
This allows users to modify their app names after having created
one.

There was a previous test in api/tests/test_app that checked
to ensure that the PATCH method was not allowed, so I repurposed
it to test appname changes.

The API call to modify app names is:

```
PATCH /api/apps/{appname} {new_name}
```

Which will return HTTP status 200, and the endpoint is no longer
available. You will be able to reach the app at /api/apps/{new_name}
moving forward.

TESTING: Since this affects practically every aspect of app
management, running the integration test suite is recommended:

```
$ vagrant up
$ make pull
$ cd test
$ bundle exec rake
```

fixes #475
