### PR TITLE
docs(*): update docs for local3.deisapp.com, local5.deisapp.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ If you're on Ubuntu, you need to install the nfs-kernel-server package as it's r
 ## Additional setup for a multi-node cluster
 If you'd like to spin up more than one VM to test an entire cluster, there are a few additional prerequisites:
 * Edit [contrib/coreos/user-data](contrib/coreos/user-data) and add a unique discovery URL generated from `https://discovery.etcd.io/new`
-* Set `DEIS_NUM_INSTANCES` to the desired size of your cluster: ```$ export DEIS_NUM_INSTANCES=3```
+* Set `DEIS_NUM_INSTANCES` to the desired size of your cluster (typically 3 or 5): ```$ export DEIS_NUM_INSTANCES=3```
+* Instead of `local.deisapp.com`, use either `local3.deisapp.com` or `local5.deisapp.com` as your hostname for accessing the cluster
 
 Note that for scheduling to work properly, clusters must consist of at least 3 nodes and always have an odd number of members.
 For more information, see [optimal etcd cluster size](https://github.com/coreos/etcd/blob/master/Documentation/optimal-cluster-size.md).
 
-Deis clusters of less than 3 nodes are unsupported for anything other than local development. A painless 3+ node development environment is a priority.
+Deis clusters of less than 3 nodes are unsupported for anything other than local development.
 
 ## Boot CoreOS
 
@@ -81,7 +82,7 @@ Use `make run` to start all Deis containers and attach to their log output. This
 $ make run
 ```
 
-Your Vagrant VM is accessible at `local.deisapp.com`. For clusters with more than one node, see our guide to [Configuring DNS](http://docs.deis.io/en/latest/operations/configure-dns/).
+Your Vagrant VM is accessible at `local.deisapp.com` (or `local3.deisapp.com`/`local5.deisapp.com`). For clusters on other platforms (EC2, Rackspace, bare metal, etc.), see our guide to [Configuring DNS](http://docs.deis.io/en/latest/operations/configure-dns/).
 
 ## Testing the cluster
 Integration tests and corresponding documentation can be found under the `test/` folder.

--- a/docs/operations/configure-dns.rst
+++ b/docs/operations/configure-dns.rst
@@ -6,10 +6,10 @@
 Configure DNS
 -------------
 
-For local one-node Vagrant clusters, we've created the DNS record ``local.deisapp.com`` which resolves to the IP of the first VM, 172.17.8.100.
-You can use ``local.deisapp.com`` to both log into the controller and to access applications that you've deployed (they will be subdomains of ``local.deisapp.com``, like ``happy-unicorn.local.deisapp.com``). So, no further DNS configuration is necessary.
+For local clusters, we've created the DNS record ``local.deisapp.com`` which resolves to the IP of the first VM, 172.17.8.100.
+You can use ``local.deisapp.com`` to both log into the controller and to access applications that you've deployed (they will be subdomains of ``local.deisapp.com``, like ``happy-unicorn.local.deisapp.com``). Similarly, you can use ``local3.deisapp.com`` or ``local5.deisapp.com`` for 3- and 5-node clusters, respectively. No DNS configuration is necessary for local clusters.
 
-For a non-local one-node cluster, we schedule and launch one router, and deis-router and deis-controller will run on the same host. So, both DNS records can be configured to point to this one machine.
+For Deis clusters hosted elsewhere (EC2, Rackspace, bare metal, etc.), DNS records will need to be created to point to the cluster. For a one-node cluster, we schedule and launch one router, and deis-router and deis-controller will run on the same host. So, both DNS records specified below can be configured to point to this one machine.
 
 On a multi-node cluster, however, there are probably multiple routers, and the controller will likely be scheduled on a separate machine. As mentioned in :ref:`configure-load-balancers`, a load balancer is recommended in this scenario.
 
@@ -22,4 +22,4 @@ The DNS records for Deis should be configured as such:
 * ``deis.example.org`` should resolve to the IP of the machine that runs ``deis-controller``
 * ``*.deis.example.org`` (a wildcard DNS entry) should point to the load balancer (or the same machine for 1-node Vagrant, or any single instance of ``deis-router`` if one likes to live life on the edge)
 
-These records are necessary for all deployments of Deis (EC2, Rackspace, bare metal, multi-node Vagrant) except for a local, one-node Vagrant setup, which can use ``local.deisapp.com``.
+These records are necessary for all deployments of Deis (EC2, Rackspace, bare metal, etc.). Local clusters can use the hostnames ``local.deisapp.com``, ``local3.deisapp.com``, or ``local5.deiaspp.com``.


### PR DESCRIPTION
We've created the convenience records for local3.deisapp.com and
local5.deisapp.com, so local clusters no longer have to manage
DNS whatsoever.

closes #747 
