### PR TITLE
docs(bare-metal): filled in bare metal section in provision doc

### DIFF
--- a/docs/operations/configure-dns.rst
+++ b/docs/operations/configure-dns.rst
@@ -22,4 +22,4 @@ The DNS records for Deis should be configured as such:
 * ``deis.example.org`` should resolve to the IP of the machine that runs ``deis-controller``
 * ``*.deis.example.org`` (a wildcard DNS entry) should point to the load balancer (or the same machine for 1-node Vagrant, or any single instance of ``deis-router`` if one likes to live life on the edge)
 
-These records are necessary for all deployments of Deis (EC2, Rackspace, multi-node Vagrant) except for a local, one-node Vagrant setup, which can use ``local.deisapp.com``.
+These records are necessary for all deployments of Deis (EC2, Rackspace, bare metal, multi-node Vagrant) except for a local, one-node Vagrant setup, which can use ``local.deisapp.com``.

--- a/docs/operations/provision-controller.rst
+++ b/docs/operations/provision-controller.rst
@@ -33,6 +33,13 @@ provision a multi-node Deis cluster on Rackspace_ cloud.
 Please see `contrib/rackspace`_ for details on using Deis on
 Rackspace cloud.
 
+Bare Metal
+----------
+The `contrib/bare-metal` section of the Deis project includes documentation in
+README.md to help with provisioning a multi-node cluster on your own hardware.
+
+Please see `contrib/bare-metal`_ for details on using Deis on bare metal.
+
 Vagrant
 -------
 The root of the Deis project includes documentation in README.md, a
@@ -47,6 +54,6 @@ Please see README.md_ for details on using Deis with Vagrant.
 .. _`contrib/ec2`: https://github.com/deis/deis/tree/master/contrib/ec2
 .. _Rackspace: https://github.com/deis/deis/tree/master/contrib/rackspace#readme
 .. _`contrib/rackspace`: https://github.com/deis/deis/tree/master/contrib/rackspace
+.. _`contrib/bare-metal`: https://github.com/deis/deis/tree/master/contrib/bare-metal
 .. _Vagrant: http://www.vagrantup.com/
 .. _README.md: https://github.com/deis/deis/tree/master/README.md
-


### PR DESCRIPTION
We need a docs.deis.io anchor for bare metal to reference from deis.io.
