### PR TITLE
fix(builder): run builder as non-root

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -38,9 +38,8 @@ RUN useradd -d $GITHOME $GITUSER
 RUN mkdir -p $GITHOME/.ssh && chown git:git $GITHOME/.ssh
 RUN chown -R $GITUSER:$GITUSER $GITHOME
 
-# let the git user run `sudo /home/git/builder` (not writeable)
-RUN apt-get install -yq sudo
-RUN echo "%git    ALL=(ALL:ALL) NOPASSWD:/home/git/builder" >> /etc/sudoers
+# add git user to docker group
+RUN usermod -aG docker git
 
 # install custom confd
 RUN wget -q https://s3-us-west-2.amazonaws.com/deis/confd -O /usr/local/bin/confd

--- a/builder/templates/gitreceive
+++ b/builder/templates/gitreceive
@@ -32,8 +32,7 @@ EOF
     # if we're processing a receive-pack on an existing repo, run a build
     if [[ $SSH_ORIGINAL_COMMAND == git-receive-pack* ]] && \
        [[ -e $REPO_PATH/refs/heads/master ]]; then
-      # SECURITY: git user runs the builder as root (for docker access)
-      sudo $GITHOME/builder $RECEIVE_USER $RECEIVE_REPO >&2
+      $GITHOME/builder $RECEIVE_USER $RECEIVE_REPO >&2
     fi
     ;;
 


### PR DESCRIPTION
This was a security issue for running custom Dockerfiles in the builder.
This changes the running user to git.

fixes #568
