### PR TITLE
fix(controller): controller returns 204 when no logs instead of 404

### DIFF
--- a/controller/api/tests/test_app.py
+++ b/controller/api/tests/test_app.py
@@ -79,7 +79,7 @@ class AppTest(TestCase):
             os.remove(path)
         url = '/api/apps/{app_id}/logs'.format(**locals())
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 204)
         self.assertEqual(response.data, 'No logs for {}'.format(app_id))
         # write out some fake log data and try again
         with open(path, 'w') as f:

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -299,7 +299,7 @@ class AppViewSet(OwnerViewSet):
             logs = app.logs()
         except EnvironmentError:
             return Response("No logs for {}".format(app.id),
-                            status=status.HTTP_404_NOT_FOUND,
+                            status=status.HTTP_204_NO_CONTENT,
                             content_type='text/plain')
         return Response(logs, status=status.HTTP_200_OK,
                         content_type='text/plain')


### PR DESCRIPTION
This fixes #990

The controller now returns a 204 instead of a 404 if there are no logs.

(I've been working on getting an app running with deis and found the 404 status confusing). Didn't include tests because the fix is minor and there weren't any tests for `apps_logs` in the first place ;)
