### PR TITLE
feat(builder): build apps from more than master

### DIFF
--- a/builder/templates/builder
+++ b/builder/templates/builder
@@ -17,12 +17,12 @@ import yaml
 
 
 def parse_args():
-    if len(sys.argv) < 2:
-        print('Usage: {} [user] [repo]'.format(sys.argv[0]))
+    if len(sys.argv) < 3:
+        print('Usage: {} [user] [repo] [branch]'.format(sys.argv[0]))
         sys.exit(1)
-    user, repo = sys.argv[1], sys.argv[2]
+    user, repo, branch = sys.argv[1], sys.argv[2], sys.argv[3]
     app = repo.split('.')[0]
-    return user, repo, app
+    return user, repo, branch, app
 
 
 DOCKERFILE_SHIM = """FROM deis/slugrunner
@@ -33,7 +33,7 @@ ENTRYPOINT ["/runner/init"]
 
 
 if __name__ == '__main__':
-    user, repo, app = parse_args()
+    user, repo, branch, app = parse_args()
     # define image names
     _id = uuid.uuid4().hex[:8]
     tmp_image = "{app}:temp_{_id}".format(**locals())
@@ -48,9 +48,9 @@ if __name__ == '__main__':
     try:
         # create temporary directory
         temp_dir = tempfile.mkdtemp(dir=build_dir)
-        # extract git master
+        # extract git branch
         p = subprocess.Popen(
-            'git archive master | tar -x -C {temp_dir}'.format(**locals()),
+            'git archive {branch} | tar -x -C {temp_dir}'.format(**locals()),
             shell=True, cwd=repo_dir)
         rc = p.wait()
         if rc != 0:
@@ -73,7 +73,7 @@ if __name__ == '__main__':
             else:
                 build_cmd = "docker run -i -a stdin {config_env} -v {cache_dir}:/tmp/cache:rw deis/slugbuilder".format(**locals())
             # run slugbuilder in the background
-            p = subprocess.Popen("git archive master | " + build_cmd, shell=True, cwd=repo_dir, stdout=subprocess.PIPE)
+            p = subprocess.Popen("git archive {branch} | ".format(**locals()) + build_cmd, shell=True, cwd=repo_dir, stdout=subprocess.PIPE)
             container = p.stdout.read().strip('\n')
             # attach to slugbuilder output
             p = subprocess.Popen('docker attach {container}'.format(**locals()), shell=True, cwd=temp_dir)
@@ -114,8 +114,8 @@ if __name__ == '__main__':
         body['receive_user'] = user
         body['receive_repo'] = app
         body['image'] = target_image
-        # use sha of master
-        with open(os.path.join(repo_dir, 'refs/heads/master')) as f:
+        # use sha of branch
+        with open(os.path.join(repo_dir, branch)) as f:
             body['sha'] = f.read().strip('\n')
         # extract the user-defined Procfile and any default_process_types
         procfile_dict = {}

--- a/builder/templates/gitreceive
+++ b/builder/templates/gitreceive
@@ -8,7 +8,7 @@ SELF=`which $0`
 case "$1" in
 
 # called by sshd on each `git push`
-  run) 
+  run)
     export RECEIVE_USER=$2
     export RECEIVE_FINGERPRINT=$3
     # ssh provides the original requested command in $SSH_ORIGINAL_COMMAND
@@ -22,43 +22,48 @@ case "$1" in
     fi
     cd $GITHOME
     PRERECEIVE_HOOK="$REPO_PATH/hooks/pre-receive"
-    # inject the hook below
+    # inject a pre-receive hook
     cat > $PRERECEIVE_HOOK <<EOF
 #!/bin/bash
-cat | $SELF hook
+cat | $SELF pre-receive
 EOF
     chmod +x $PRERECEIVE_HOOK
+    POSTRECEIVE_HOOK="$REPO_PATH/hooks/post-receive"
+    # inject a post-receive hook
+    cat > $POSTRECEIVE_HOOK <<EOF
+#!/bin/bash
+cat | $SELF post-receive
+EOF
+    chmod +x $POSTRECEIVE_HOOK
     git-shell -c "$SSH_ORIGINAL_COMMAND"
-    # if we're processing a receive-pack on an existing repo, run a build
-    if [[ $SSH_ORIGINAL_COMMAND == git-receive-pack* ]] && \
-       [[ -e $REPO_PATH/refs/heads/master ]]; then
-      # SECURITY: git user runs the builder as root (for docker access)
-      sudo $GITHOME/builder $RECEIVE_USER $RECEIVE_REPO >&2
-    fi
     ;;
 
-# used internally
-  hook)
+  pre-receive)
     while read oldrev newrev refname
     do
-      # Only run this script for the master branch. You can remove this 
-      # if block if you wish to run it for others as well.
-      if [[ $refname = "refs/heads/master" ]] ; then
- 
-        $GITHOME/receiver "$RECEIVE_REPO" "$newrev" "$RECEIVE_USER" "$RECEIVE_FINGERPRINT"  
- 
-        rc=$?
-        if [[ $rc != 0 ]] ; then
-          echo "      ERROR: failed on rev $newrev - push denied"
-          exit $rc
-        fi
+      $GITHOME/receiver "$RECEIVE_REPO" "$newrev" "$RECEIVE_USER" "$RECEIVE_FINGERPRINT"
+      rc=$?
+      if [[ $rc != 0 ]] ; then
+        echo "      ERROR: failed on rev $newrev - push denied"
+        exit $rc
       fi
     done
-    #exit 1 # for debugging
+    ;;
+
+  post-receive)
+    while read oldrev newrev refname
+    do
+      # builder assumes that we are running this script from $GITHOME
+      cd $GITHOME
+      # if we're processing a receive-pack on an existing repo, run a build
+      if [[ $SSH_ORIGINAL_COMMAND == git-receive-pack* ]]; then
+        # SECURITY: git user runs the builder as root (for docker access)
+        sudo $GITHOME/builder $RECEIVE_USER $RECEIVE_REPO $refname >&2
+      fi
+    done
     ;;
 
   *)
     echo "Usage: gitreceive <command> [options]"
     ;;
 esac
-


### PR DESCRIPTION
Previously, the builder would completely disregard any pushes from
a branch other than master. This moves the builder command into
a post-receive hook, such that we can reference the branch that
is being pushed to the repository and send that to the builder.

For some reason, this PR also gives us Heroku compatibility on
issue #736, so this PR kills two birds with one stone. Woo! :hand: 

TESTING: To test, we need to successfully push an app from a branch
other than master. To do that, run the following:

```
$ make -C builder build restart
$ cd /tmp
$ git clone https://github.com/opdemand/example-perl && cd example-perl
$ git checkout -b test-branch
$ deis create
$ git push deis test-branch
```

To test for the #736 ninja fix, try pushing again. You should see a
"Everything up-to-date" message displayed on your screen, and no
push should occur.

fixes #975, #736
