### PR TITLE
fix(contrib): revert seed hosts for CDN workaround

### DIFF
--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -77,15 +77,6 @@ coreos:
       Type=oneshot
       ExecStartPre=/usr/bin/rm /etc/motd
       ExecStart=/usr/bin/ln -s /run/deis/motd /etc/motd
-  - name: cdn-workaround.service
-    command: start
-    content: |
-      [Unit]
-      Description=workaround for dotcloud/docker#2461
-
-      [Service]
-      Type=oneshot
-      ExecStart=/bin/sh -c "grep -s cdn-registry-1.docker.io /etc/hosts || echo '54.224.119.89 cdn-registry-1.docker.io' >> /etc/hosts"
 write_files:
   - path: /run/deis/motd
     content: " \e[31m* *    \e[34m*   \e[32m*****    \e[39mddddd   eeeeeee iiiiiii   ssss\n\e[31m*   *  \e[34m* *  \e[32m*   *     \e[39md   d   e    e    i     s    s\n \e[31m* *  \e[34m***** \e[32m*****     \e[39md    d  e         i    s\n\e[32m*****  \e[31m* *    \e[34m*       \e[39md     d e         i     s\n\e[32m*   * \e[31m*   *  \e[34m* *      \e[39md     d eee       i      sss\n\e[32m*****  \e[31m* *  \e[34m*****     \e[39md     d e         i         s\n  \e[34m*   \e[32m*****  \e[31m* *      \e[39md    d  e         i          s\n \e[34m* *  \e[32m*   * \e[31m*   *     \e[39md   d   e    e    i    s    s\n\e[34m***** \e[32m*****  \e[31m* *     \e[39mddddd   eeeeeee iiiiiii  ssss\n\n\e[39mWelcome to Deis\t\t\tPowered by Core\e[38;5;45mO\e[38;5;206mS\e[39m\n"


### PR DESCRIPTION
Download speeds are back and responsive as usual.

This reverts commit d3dfa376d86ffcbbbcab8211edb161b4cfde2d72.
