### PR TITLE
fix(Makefile): enable targets to work for non-Vagrant

### DIFF
--- a/builder/Makefile
+++ b/builder/Makefile
@@ -1,28 +1,27 @@
+include ../includes.mk
+
 build:
-	vagrant ssh -c 'cd share/builder && docker build -t deis/builder .'
+	$(call ssh_all,'cd share/builder && docker build -t deis/builder .')
 
-install:
-	vagrant ssh -c 'sudo systemctl enable /home/core/share/builder/systemd/*'
+install: check-fleet
+	$(FLEETCTL) load systemd/*
 
-uninstall: stop
-	vagrant ssh -c 'sudo systemctl disable /home/core/share/builder/systemd/*'
+uninstall: check-fleet stop
+	$(FLEETCTL) unload systemd/*
+	$(FLEETCTL) destroy systemd/*
 
-start:
-	vagrant ssh -c 'sudo systemctl start deis-builder.service'
+start: check-fleet
+	$(FLEETCTL) start -no-block systemd/*
 
-stop:
-	vagrant ssh -c 'sudo systemctl stop deis-builder.service'
+stop: check-fleet
+	$(FLEETCTL) stop -block-attempts=600 systemd/*
 
-restart:
-	vagrant ssh -c 'sudo systemctl restart deis-builder.service'
+restart: stop start
 
-logs:
-	vagrant ssh -c 'sudo journalctl -f -u deis-builder.service'
-
-run: install restart logs
+run: install start
 
 clean: uninstall
-	vagrant ssh -c 'sudo docker rm -f deis-builder'
+	$(call ssh_all,'sudo docker rm -f deis-builder')
 
 full-clean: clean
-	vagrant ssh -c 'sudo docker rmi deis/builder'
+	$(call ssh_all,'sudo docker rmi deis/builder')

--- a/cache/Makefile
+++ b/cache/Makefile
@@ -1,28 +1,27 @@
+include ../includes.mk
+
 build:
-	vagrant ssh -c 'cd share/cache && sudo docker build -t deis/cache .'
+	$(call ssh_all,'cd share/cache && sudo docker build -t deis/cache .')
 
-install:
-	vagrant ssh -c 'sudo systemctl enable /home/core/share/cache/systemd/*'
+install: check-fleet
+	$(FLEETCTL) load systemd/*
 
-uninstall: stop
-	vagrant ssh -c 'sudo systemctl disable /home/core/share/cache/systemd/*'
+uninstall: check-fleet stop
+	$(FLEETCTL) unload systemd/*
+	$(FLEETCTL) destroy systemd/*
 
-start:
-	vagrant ssh -c 'sudo systemctl start deis-cache.service'
+start: check-fleet
+	$(FLEETCTL) start -no-block systemd/*
 
-stop:
-	vagrant ssh -c 'sudo systemctl stop deis-cache.service'
+stop: check-fleet
+	$(FLEETCTL) stop -block-attempts=600 systemd/*
 
-restart:
-	vagrant ssh -c 'sudo systemctl restart deis-cache.service'
+restart: stop start
 
-logs:
-	vagrant ssh -c 'sudo journalctl -f -u deis-cache.service'
-
-run: install restart logs
+run: install start
 
 clean: uninstall
-	vagrant ssh -c 'sudo docker rm -f deis-cache'
+	$(call ssh_all,'sudo docker rm -f deis-cache')
 
 full-clean: clean
-	vagrant ssh -c 'sudo docker rmi deis/cache'
+	$(call ssh_all,'sudo docker rmi deis/cache')

--- a/contrib/ec2/README.md
+++ b/contrib/ec2/README.md
@@ -82,13 +82,21 @@ you configure your own DNS records using a domain you own. See [Configuring DNS]
 
 ## Use Deis!
 After that, register with Deis!
-```
+```console
 $ deis register deis.example.org:8000
 username: deis
 password:
 password (confirm):
 email: info@opdemand.com
 ```
+
+## Hack on Deis
+If you'd like to use this deployment to build Deis, you'll need to set `DEIS_HOSTS` to an array of your cluster hosts:
+```console
+$ export DEIS_HOSTS=1.2.3.4 1.2.3.5 1.2.3.6
+```
+
+This variable is used in the `make build` command.
 
 [aws-cli]: https://github.com/aws/aws-cli
 [template]: https://s3.amazonaws.com/coreos.com/dist/aws/coreos-alpha.template

--- a/contrib/rackspace/README.md
+++ b/contrib/rackspace/README.md
@@ -77,10 +77,18 @@ You'll need to configure DNS records so you can access applications hosted on De
 
 ### Use Deis!
 After that, register with Deis!
-```
+```console
 $ deis register deis.example.org:8000
 username: deis
 password:
 password (confirm):
 email: info@opdemand.com
 ```
+
+## Hack on Deis
+If you'd like to use this deployment to build Deis, you'll need to set `DEIS_HOSTS` to an array of your cluster hosts:
+```console
+$ export DEIS_HOSTS=10.21.12.1 10.21.12.2 10.21.12.3
+```
+
+This variable is used in the `make build` command.

--- a/database/Makefile
+++ b/database/Makefile
@@ -1,28 +1,27 @@
+include ../includes.mk
+
 build:
-	vagrant ssh -c 'cd share/database && sudo docker build -t deis/database .'
+	$(call ssh_all,'cd share/database && sudo docker build -t deis/database .')
 
-install:
-	vagrant ssh -c 'sudo systemctl enable /home/core/share/database/systemd/*'
+install: check-fleet
+	$(FLEETCTL) load systemd/*
 
-uninstall: stop
-	vagrant ssh -c 'sudo systemctl disable /home/core/share/database/systemd/*'
+uninstall: check-fleet stop
+	$(FLEETCTL) unload systemd/*
+	$(FLEETCTL) destroy systemd/*
 
-start:
-	vagrant ssh -c 'sudo systemctl start deis-database.service'
+start: check-fleet
+	$(FLEETCTL) start -no-block systemd/*
 
-stop:
-	vagrant ssh -c 'sudo systemctl stop deis-database.service'
+stop: check-fleet
+	$(FLEETCTL) stop -block-attempts=600 systemd/*
 
-restart:
-	vagrant ssh -c 'sudo systemctl restart deis-database.service'
+restart: stop start
 
-logs:
-	vagrant ssh -c 'sudo journalctl -f -u deis-database.service'
-
-run: install restart logs
+run: install start
 
 clean: uninstall
-	vagrant ssh -c 'sudo docker rm -f deis-database'
+	$(call ssh_all,'sudo docker rm -f deis-database')
 
 full-clean: clean
-	vagrant ssh -c 'sudo docker rmi deis/database'
+	$(call ssh_all,'sudo docker rmi deis/database')

--- a/includes.mk
+++ b/includes.mk
@@ -1,0 +1,46 @@
+ifndef FLEETCTL
+  FLEETCTL = fleetctl --strict-host-key-checking=false
+endif
+
+ifndef FLEETCTL_TUNNEL
+$(error You need to set FLEETCTL_TUNNEL to the IP address of a server in the cluster.)
+endif
+
+ifndef DEIS_NUM_INSTANCES
+  DEIS_NUM_INSTANCES = 1
+endif
+
+ifndef DEIS_HOSTS
+  DEIS_HOSTS = $(shell seq -f "172.17.8.%g" -s " " 100 1 `expr $(DEIS_NUM_INSTANCES) + 99` )
+endif
+
+ifndef DEIS_NUM_ROUTERS
+  DEIS_NUM_ROUTERS = 1
+endif
+
+ifndef DEIS_FIRST_ROUTER
+  DEIS_FIRST_ROUTER = 1
+endif
+
+DEIS_LAST_ROUTER = $(shell echo $(DEIS_FIRST_ROUTER)\+$(DEIS_NUM_ROUTERS)\-1 | bc)
+
+define ssh_all
+  for host in $(DEIS_HOSTS); do ssh -o LogLevel=FATAL -o Compression=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PasswordAuthentication=no core@$$host -t $(1); done
+endef
+
+define echo_cyan
+  @echo "\033[0;36m$(subst ",,$(1))\033[0m"
+endef
+
+define echo_yellow
+  @echo "\033[0;33m$(subst ",,$(1))\033[0m"
+endef
+
+ROUTER_UNITS = $(shell seq -f "deis-router.%g.service" -s " " $(DEIS_FIRST_ROUTER) 1 $(DEIS_LAST_ROUTER))
+
+check-fleet:
+  @LOCAL_VERSION=`$(FLEETCTL) -version`; \
+  REMOTE_VERSION=`ssh -o StrictHostKeyChecking=no core@$(subst :, -p ,$(FLEETCTL_TUNNEL)) fleetctl -version`; \
+  if [ "$$LOCAL_VERSION" != "$$REMOTE_VERSION" ]; then \
+      echo "Your fleetctl client version should match the server. Local version: $$LOCAL_VERSION, server version: $$REMOTE_VERSION. Uninstall your local version and install the latest build from https://github.com/coreos/fleet/releases"; exit 1; \
+  fi

--- a/logger/Makefile
+++ b/logger/Makefile
@@ -1,28 +1,27 @@
+include ../includes.mk
+
 build:
-	vagrant ssh -c 'cd share/logger && sudo docker build -t deis/logger .'
+	$(call ssh_all,'cd share/logger && sudo docker build -t deis/logger .')
 
-install:
-	vagrant ssh -c 'sudo systemctl enable /home/core/share/logger/systemd/*'
+install: check-fleet
+	$(FLEETCTL) load systemd/*
 
-uninstall: stop
-	vagrant ssh -c 'sudo systemctl disable /home/core/share/logger/systemd/*'
+uninstall: check-fleet stop
+	$(FLEETCTL) unload systemd/*
+	$(FLEETCTL) destroy systemd/*
 
-start:
-	vagrant ssh -c 'sudo systemctl start deis-logger.service'
+start: check-fleet
+	$(FLEETCTL) start -no-block systemd/*
 
-stop:
-	vagrant ssh -c 'sudo systemctl stop deis-logger.service'
+stop: check-fleet
+	$(FLEETCTL) stop -block-attempts=600 systemd/*
 
-restart:
-	vagrant ssh -c 'sudo systemctl restart deis-logger.service'
+restart: stop start
 
-logs:
-	vagrant ssh -c 'sudo journalctl -f -u deis-logger.service'
-
-run: install restart logs
+run: install start
 
 clean: uninstall
-	vagrant ssh -c 'sudo docker rm -f deis-logger'
+	$(call ssh_all,'sudo docker rm -f deis-logger')
 
 full-clean: clean
-	vagrant ssh -c 'sudo docker rmi deis/logger'
+	$(call ssh_all,'sudo docker rmi deis/logger')

--- a/registry/Makefile
+++ b/registry/Makefile
@@ -1,28 +1,27 @@
+include ../includes.mk
+
 build:
-	vagrant ssh -c 'cd share/registry && sudo docker build -t deis/registry .'
+	$(call ssh_all,'cd share/registry && sudo docker build -t deis/registry .')
 
-install:
-	vagrant ssh -c 'sudo systemctl enable /home/core/share/registry/systemd/*'
+install: check-fleet
+	$(FLEETCTL) load systemd/*
 
-uninstall: stop
-	vagrant ssh -c 'sudo systemctl disable /home/core/share/registry/systemd/*'
+uninstall: check-fleet stop
+	$(FLEETCTL) unload systemd/*
+	$(FLEETCTL) destroy systemd/*
 
-start:
-	vagrant ssh -c 'sudo systemctl start deis-registry.service'
+start: check-fleet
+	$(FLEETCTL) start -no-block systemd/*
 
-stop:
-	-vagrant ssh -c 'sudo systemctl stop deis-registry.service'
+stop: check-fleet
+	$(FLEETCTL) stop -block-attempts=600 systemd/*
 
-restart:
-	vagrant ssh -c 'sudo systemctl restart deis-registry.service'
+restart: stop start
 
-logs:
-	vagrant ssh -c 'sudo journalctl -f -u deis-registry.service'
-
-run: install restart logs
+run: install start
 
 clean: uninstall
-	vagrant ssh -c 'sudo docker rm -f deis-registry'
+	$(call ssh_all,'sudo docker rm -f deis-registry')
 
 full-clean: clean
-	vagrant ssh -c 'sudo docker rmi deis/registry'
+	$(call ssh_all,'sudo docker rmi deis/registry')

--- a/router/Makefile
+++ b/router/Makefile
@@ -1,28 +1,43 @@
+include ../includes.mk
+
 build:
-	vagrant ssh -c 'cd share/router && sudo docker build -t deis/router .'
+	$(call ssh_all,'cd share/router && sudo docker build -t deis/router .')
 
-install:
-	vagrant ssh -c 'sudo systemctl enable /home/core/share/router/systemd/*'
+install: check-fleet
+	@$(foreach R, $(ROUTER_UNITS), \
+		cp systemd/deis-router.service ./$(R) ; \
+		$(FLEETCTL) load ./$(R) ; \
+		rm -f ./$(R) ; \
+	)
 
-uninstall: stop
-	vagrant ssh -c 'sudo systemctl disable /home/core/share/router/systemd/*'
+uninstall: check-fleet stop
+	@$(foreach R, $(ROUTER_UNITS), \
+		cp systemd/deis-router.service ./$(R) ; \
+		$(FLEETCTL) unload ./$(R) ; \
+		$(FLEETCTL) destroy ./$(R) ; \
+		rm -f ./$(R) ; \
+	)
 
-start:
-	vagrant ssh -c 'sudo systemctl start deis-router.service'
+start: check-fleet
+	@$(foreach R, $(ROUTER_UNITS), \
+		cp systemd/deis-router.service ./$(R) ; \
+		$(FLEETCTL) start -no-block ./$(R) ; \
+		rm -f ./$(R) ; \
+	)
 
-stop:
-	vagrant ssh -c 'sudo systemctl stop deis-router.service'
+stop: check-fleet
+	@$(foreach R, $(ROUTER_UNITS), \
+		cp systemd/deis-router.service ./$(R) ; \
+		$(FLEETCTL) stop -block-attempts=600 ./$(R) ; \
+		rm -f ./$(R) ; \
+	)
 
-restart:
-	vagrant ssh -c 'sudo systemctl restart deis-router.service'
+restart: stop start
 
-logs:
-	vagrant ssh -c 'sudo journalctl -f -u deis-router.service'
-
-run: install restart logs
+run: install start
 
 clean: uninstall
-	vagrant ssh -c 'sudo docker rm -f deis-router'
+	$(call ssh_all,'sudo docker rm -f deis-router')
 
 full-clean: clean
-	vagrant ssh -c 'sudo docker rmi deis/router'
+	$(call ssh_all,'sudo docker rmi deis/router')


### PR DESCRIPTION
Adds DEIS_HOSTS, which is set automatically or can be overridden
for non-Vagrant platforms. This is used by ssh_all to determine
which hosts to SSH into - previously, we used `vagrant ssh`,
which obviously only works on Vagrant.

This also updates all the Makefiles to use fleet as appropriate,
and to pull / build / etc. on all DEIS_HOSTS.

TESTING: try the various make commands on Vagrant and Rackspace/EC2

replaces #998
closes #811
