### PR TITLE
fix(controller): give cluster read-only access

### DIFF
--- a/controller/api/tests/test_cluster.py
+++ b/controller/api/tests/test_cluster.py
@@ -74,3 +74,12 @@ class ClusterTest(TestCase):
                 'hosts': 'host1,host2', 'auth': 'base64string', 'options': options}
         response = self.client.post(url, json.dumps(body), content_type='application/json')
         self.assertEqual(response.status_code, 403)
+
+    def test_user_read_access(self):
+        """
+        Test that a user has read-only access to the clusters endpoint
+        """
+        self.client.login(username='autotest2', password='password')
+        url = '/api/clusters'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -182,7 +182,7 @@ class ClusterViewSet(viewsets.ModelViewSet):
 
     model = models.Cluster
     serializer_class = serializers.ClusterSerializer
-    permission_classes = (permissions.IsAuthenticated, IsAdmin)
+    permission_classes = (permissions.IsAuthenticated, IsAdminOrSafeMethod)
     lookup_field = 'id'
 
     def pre_save(self, obj):


### PR DESCRIPTION
Users should be able to access and view a cluster's endpoints such
that it can find the domain name and other relevant data.

fixes #903

No manual testing required. The unit test does that already :)
