### PR TITLE
feat(builder): cache progrium/cedarish image

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -35,6 +35,11 @@ RUN chown -R $GITUSER:$GITUSER $GITHOME
 # let the git user run `sudo /home/git/builder` (not writeable)
 RUN echo "%git    ALL=(ALL:ALL) NOPASSWD:/home/git/builder" >> /etc/sudoers
 
+# HACK: import progrium/cedarish as a tarball
+# see https://github.com/deis/deis/issues/1027
+RUN wget -O /progrium_cedarish.tar --progress=dot:giga \
+        https://s3-us-west-2.amazonaws.com/opdemand/progrium_cedarish_2014.05.27.tar
+
 # add the current build context to /app
 ADD . /app
 RUN chown -R root:root /app

--- a/builder/bin/boot
+++ b/builder/bin/boot
@@ -53,6 +53,10 @@ while [[ ! -e /var/run/docker.sock ]]; do
   sleep 1
 done
 
+# HACK: load progrium/cedarish tarball for faster boot times
+# see https://github.com/deis/deis/issues/1027
+docker load -i /progrium_cedarish.tar
+
 # pull required images
 docker pull deis/slugbuilder:latest
 docker pull deis/slugrunner:latest


### PR DESCRIPTION
This will reduce boot time significantly by making the images
for progrium/cedarish (the image that both deis/slugrunner and
deis/slugbuilder rely on) loaded into the docker daemon before the
deis/slug\* images are pulled from the registry.

fixes #1027
