### PR TITLE
fix(docker): always use ":latest" tag in docker pull

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ install-routers: check-fleet
 	)
 
 pull:
-	$(call ssh_all,'for c in $(ALL_COMPONENTS); do docker pull deis/$$c; done')
-	$(call ssh_all,'docker pull deis/slugrunner')
+	$(call ssh_all,'for c in $(ALL_COMPONENTS); do docker pull deis/$$c:latest; done')
+	$(call ssh_all,'docker pull deis/slugrunner:latest')
 
 restart: stop start
 

--- a/builder/systemd/deis-builder.service
+++ b/builder/systemd/deis-builder.service
@@ -6,7 +6,7 @@ After=deis-controller.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker history deis/builder >/dev/null || docker pull deis/builder"
+ExecStartPre=/bin/sh -c "docker history deis/builder >/dev/null || docker pull deis/builder:latest"
 ExecStartPre=/bin/sh -c "docker inspect deis-builder >/dev/null && docker rm -f deis-builder || true"
 ExecStartPre=/bin/sh -c "docker inspect deis-builder-data >/dev/null 2>&1 || docker run --name deis-builder-data -v /var/lib/docker deis/base true"
 ExecStart=/usr/bin/docker run --name deis-builder -p 2222:22 -e PUBLISH=22 -e HOST=${COREOS_PRIVATE_IPV4} -e PORT=2222 --volumes-from deis-builder-data --privileged deis/builder

--- a/cache/systemd/deis-cache.service
+++ b/cache/systemd/deis-cache.service
@@ -4,7 +4,7 @@ Description=deis-cache
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker history deis/cache >/dev/null || docker pull deis/cache"
+ExecStartPre=/bin/sh -c "docker history deis/cache >/dev/null || docker pull deis/cache:latest"
 ExecStartPre=/bin/sh -c "docker inspect deis-cache >/dev/null && docker rm -f deis-cache || true"
 ExecStart=/usr/bin/docker run --name deis-cache -p 6379:6379 -e PUBLISH=6379 -e HOST=${COREOS_PRIVATE_IPV4} deis/cache
 ExecStop=/usr/bin/docker rm -f deis-cache

--- a/controller/systemd/deis-controller.service
+++ b/controller/systemd/deis-controller.service
@@ -6,7 +6,7 @@ After=deis-logger.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker history deis/controller >/dev/null || docker pull deis/controller"
+ExecStartPre=/bin/sh -c "docker history deis/controller >/dev/null || docker pull deis/controller:latest"
 ExecStartPre=/bin/sh -c "docker inspect deis-controller >/dev/null && docker rm -f deis-controller || true"
 ExecStart=/usr/bin/docker run --name deis-controller -p 8000:8000 -e PUBLISH=8000 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from=deis-logger deis/controller
 ExecStop=/usr/bin/docker rm -f deis-controller

--- a/database/systemd/deis-database.service
+++ b/database/systemd/deis-database.service
@@ -4,7 +4,7 @@ Description=deis-database
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker history deis/database >/dev/null || docker pull deis/database"
+ExecStartPre=/bin/sh -c "docker history deis/database >/dev/null || docker pull deis/database:latest"
 ExecStartPre=/bin/sh -c "docker inspect deis-database >/dev/null && docker rm -f deis-database || true"
 ExecStartPre=/bin/sh -c "docker inspect deis-database-data >/dev/null 2>&1 || docker run --name deis-database-data -v /var/lib/postgresql deis/base true"
 ExecStart=/usr/bin/docker run --name deis-database -p 5432:5432 -e PUBLISH=5432 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-database-data deis/database

--- a/docs/contributing/localdev.rst
+++ b/docs/contributing/localdev.rst
@@ -69,7 +69,7 @@ changes.
 
     $ make pull
     vagrant ssh -c 'for c in registry logger database cache controller \
-      builder router; do docker pull deis/$c; done'
+      builder router; do docker pull deis/$c:latest; done'
     Pulling repository deis/registry
     d2c347aa26dd: Pulling dependent layers
     511136ea3c5a: Download complete

--- a/logger/systemd/deis-logger.service
+++ b/logger/systemd/deis-logger.service
@@ -4,7 +4,7 @@ Description=deis-logger
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker history deis/logger >/dev/null || docker pull deis/logger"
+ExecStartPre=/bin/sh -c "docker history deis/logger >/dev/null || docker pull deis/logger:latest"
 ExecStartPre=/bin/sh -c "docker inspect deis-logger >/dev/null && docker rm -f deis-logger || true"
 ExecStartPre=/bin/sh -c "docker inspect deis-logger-data >/dev/null 2>&1 || docker run --name deis-logger-data -v /var/log/deis deis/base true"
 ExecStart=/usr/bin/docker run --name deis-logger -p 514:514/udp -e PUBLISH=514 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-logger-data deis/logger

--- a/registry/systemd/deis-registry.service
+++ b/registry/systemd/deis-registry.service
@@ -4,7 +4,7 @@ Description=deis-registry
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker history deis/registry >/dev/null || docker pull deis/registry"
+ExecStartPre=/bin/sh -c "docker history deis/registry >/dev/null || docker pull deis/registry:latest"
 ExecStartPre=/bin/sh -c "docker inspect deis-registry >/dev/null && docker rm -f deis-registry || true"
 ExecStartPre=/bin/sh -c "docker inspect deis-registry-data >/dev/null 2>&1 || docker run --name deis-registry-data -v /data deis/base /bin/true"
 ExecStart=/usr/bin/docker run --name deis-registry -p 5000:5000 -e PUBLISH=5000 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-registry-data deis/registry

--- a/router/systemd/deis-router.service
+++ b/router/systemd/deis-router.service
@@ -4,7 +4,7 @@ Description=deis-router
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker history deis/router >/dev/null || docker pull deis/router"
+ExecStartPre=/bin/sh -c "docker history deis/router >/dev/null || docker pull deis/router:latest"
 ExecStartPre=/bin/sh -c "docker inspect deis-router >/dev/null && docker rm -f deis-router || true"
 ExecStart=/usr/bin/docker run --name deis-router -p 80:80 -e PUBLISH=80 -e HOST=${COREOS_PRIVATE_IPV4} deis/router
 ExecStop=/usr/bin/docker rm -f deis-router


### PR DESCRIPTION
Now that the Docker Index allows tagged builds directly from GitHub
project tags, we will version Deis components properly as
**deis/controller:v0.9.0** rather than **deisreleases/controller-v0.9.0**.
At that point, doing a plain "docker pull deis/controller" will pull
down all tagged images when we only wanted one, so this change
prevents users from wasting more time on already slow download operations.
Being explicit about the docker image tag also facilitates our
release process.
