### PR TITLE
fix(router): bump timeouts to 20 minutes

### DIFF
--- a/router/templates/nginx.conf
+++ b/router/templates/nginx.conf
@@ -50,8 +50,8 @@ http {
             proxy_set_header            X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_redirect              off;
             proxy_connect_timeout       10;
-            proxy_send_timeout          30;
-            proxy_read_timeout          30;
+            proxy_send_timeout          300;
+            proxy_read_timeout          300;
 
             proxy_pass                  http://deis-controller;
         }


### PR DESCRIPTION
If you run a `deis scale` and it takes longer than 30 seconds to
deploy your app, the command will return a 503 from the router
because it timed out. bumping it to 20 minutes should resolve this
issue.
