### PR TITLE
fix(controller): set default release image

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -444,7 +444,7 @@ class Release(UuidAuditedModel):
     config = models.ForeignKey('Config')
     build = models.ForeignKey('Build')
     # NOTE: image contains combined build + config, ready to run
-    image = models.CharField(max_length=256)
+    image = models.CharField(max_length=256, default=settings.DEFAULT_BUILD)
 
     class Meta:
         get_latest_by = 'created'

--- a/controller/api/tests/test_release.py
+++ b/controller/api/tests/test_release.py
@@ -60,6 +60,7 @@ class ReleaseTest(TransactionTestCase):
         self.assertIn('config', response.data)
         self.assertIn('build', response.data)
         self.assertEquals(release1['version'], 1)
+        self.assertEquals(release1['image'], 'deis/helloworld')
         # check to see that a new release was created
         url = '/api/apps/{app_id}/releases/v2'.format(**locals())
         response = self.client.get(url)


### PR DESCRIPTION
If you scale an application with `deis scale cmd=1` before an
application has been pushed, it should deploy deis/helloworld.
However, the initial release (v1) does not have a image set for
the release, only the build. Setting the default to deis/helloworld
fixes the "scale before deploy" problem.

TESTING: rebuild the controller, then create an app and scale it:

```
$ deis create
$ deis scale cmd=1
```

You should see the helloworld app deployed to `<appname>.local.deisapp.com`.
