### PR TITLE
chore(client): update deis CLI binaries at S3 to v0.9.0

### DIFF
--- a/client/README.rst
+++ b/client/README.rst
@@ -77,9 +77,9 @@ Get Started
 If you don't have `Python`_ installed, you can download a binary executable
 version of the Deis client for Mac OS X, Windows, or Debian Linux:
 
-    - https://s3-us-west-2.amazonaws.com/opdemand/deis-osx-0.8.0.tgz
-    - https://s3-us-west-2.amazonaws.com/opdemand/deis-win32-0.8.0.zip
-    - https://s3-us-west-2.amazonaws.com/opdemand/deis-deb-wheezy-0.8.0.tgz
+    - https://s3-us-west-2.amazonaws.com/opdemand/deis-osx-0.9.0.tgz
+    - https://s3-us-west-2.amazonaws.com/opdemand/deis-win32-0.9.0.zip
+    - https://s3-us-west-2.amazonaws.com/opdemand/deis-deb-wheezy-0.9.0.tgz
 
 2. `Register a User`_:
 

--- a/docs/developer/install-client.rst
+++ b/docs/developer/install-client.rst
@@ -7,14 +7,14 @@ Install the Client
 ==================
 The Deis command-line interface (CLI), or client, allows you to interact
 with a Deis :ref:`Controller`. You must install the client to use Deis.
-    
+
 Download Binaries
 -----------------
 You can download a binary executable version of the Deis client for Mac OS X, Windows, or Debian Linux:
 
-    - https://s3-us-west-2.amazonaws.com/opdemand/deis-osx-0.8.0.tgz
-    - https://s3-us-west-2.amazonaws.com/opdemand/deis-win32-0.8.0.zip
-    - https://s3-us-west-2.amazonaws.com/opdemand/deis-deb-wheezy-0.8.0.tgz
+    - https://s3-us-west-2.amazonaws.com/opdemand/deis-osx-0.9.0.tgz
+    - https://s3-us-west-2.amazonaws.com/opdemand/deis-win32-0.9.0.zip
+    - https://s3-us-west-2.amazonaws.com/opdemand/deis-deb-wheezy-0.9.0.tgz
 
 Extract the ``deis`` binary and place it in your workstation path.
 
@@ -31,7 +31,7 @@ You can also install the latest Deis client using Python's pip_ package manager:
       ...
     Successfully installed deis
     Cleaning up...
-    
+
     $ deis
     Usage: deis <command> [<args>...]
 

--- a/docs/operations/register-admin-user.rst
+++ b/docs/operations/register-admin-user.rst
@@ -29,9 +29,9 @@ Install the latest Deis client using Python's pip_ package manager:
 If you don't have Python_ installed, you can download a binary executable
 version of the Deis client for Mac OS X, Windows, or Debian Linux:
 
-    - https://s3-us-west-2.amazonaws.com/opdemand/deis-osx-0.8.0.tgz
-    - https://s3-us-west-2.amazonaws.com/opdemand/deis-win32-0.8.0.zip
-    - https://s3-us-west-2.amazonaws.com/opdemand/deis-deb-wheezy-0.8.0.tgz
+    - https://s3-us-west-2.amazonaws.com/opdemand/deis-osx-0.9.0.tgz
+    - https://s3-us-west-2.amazonaws.com/opdemand/deis-win32-0.9.0.zip
+    - https://s3-us-west-2.amazonaws.com/opdemand/deis-deb-wheezy-0.9.0.tgz
 
 Register a User
 ---------------


### PR DESCRIPTION
TESTING: Verify that the download links are correct, unarchive and run the `deis` binary appropriate to your platform. Check `deis --version` and some basic commands.
