### PR TITLE
fix(controller): add source release version

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -454,7 +454,7 @@ class Release(UuidAuditedModel):
     def __str__(self):
         return "{0}-v{1}".format(self.app.id, self.version)
 
-    def new(self, user, config=None, build=None, summary=None):
+    def new(self, user, config=None, build=None, summary=None, source_version=None):
         """
         Create a new application release using the provided Build and Config
         on behalf of a user.
@@ -465,6 +465,10 @@ class Release(UuidAuditedModel):
             config = self.config
         if not build:
             build = self.build
+        if not source_version:
+            source_version = 'latest'
+        else:
+            source_version = 'v{}'.format(source_version)
         # prepare release tag
         new_version = self.version + 1
         tag = 'v{}'.format(new_version)
@@ -475,7 +479,10 @@ class Release(UuidAuditedModel):
             build=build, version=new_version, image=image, summary=summary)
         # publish release to registry as new docker image
         repository_path = self.app.id
-        publish_release(repository_path, config.values, tag)
+        publish_release(repository_path,
+                        config.values,
+                        tag,
+                        source_tag=source_version)
         return release
 
     def previous(self):

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -424,7 +424,11 @@ class AppReleaseViewSet(BaseAppViewSet):
         summary = "{} rolled back to v{}".format(request.user, version)
         prev = app.release_set.get(version=version)
         new_release = release.new(
-            request.user, build=prev.build, config=prev.config, summary=summary)
+            request.user,
+            build=prev.build,
+            config=prev.config,
+            summary=summary,
+            source_version=version)
         app.deploy(new_release)
         msg = "Rolled back to v{}".format(version)
         return Response(msg, status=status.HTTP_201_CREATED)

--- a/controller/registry/mock.py
+++ b/controller/registry/mock.py
@@ -1,5 +1,5 @@
 
-def publish_release(repository_path, config, tag):
+def publish_release(repository_path, config, tag, source_tag='latest'):
     """
     Publish a new release as a Docker image
 


### PR DESCRIPTION
When rolling back releases, the controller would publish a new
release, which meant that the app image would get a version
bump and a new tag on the registry would be created. However,
the tag that was created on the registry was based off the 'latest'
tag. This allows rollbacks to change the source tag to another
version so that the new tag will be based off the release requested.

fixes #1072
