### PR TITLE
fix(client): adjust indentation in keys_add function

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -1225,8 +1225,9 @@ class DeisClient(object):
         else:
             # check the specified key format
             selected_key = self._parse_key(path)
-            if not selected_key:
-                return
+        if not selected_key:
+            print("usage: deis keys:add [<key>]")
+            return
         # Upload the key to Deis
         body = {
             'id': selected_key.id,


### PR DESCRIPTION
While running deis keys:add , if there are no keys the client is printing No SSH public keys found and throwing an error .
Adjusted the indendation , So if client dont find the public keys prints No SSH public keys and prints usage deis keys:add [<keys>]
