### PR TITLE
fix(router): Add configuration Ingress8000 in deis template for EC2

### DIFF
--- a/contrib/ec2/deis.template
+++ b/contrib/ec2/deis.template
@@ -114,6 +114,14 @@
         }
       }
     },
+    "Ingress8000": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupName": {"Ref": "DeisSecurityGroup"}, "IpProtocol": "tcp", "FromPort": "8000", "ToPort": "8000", "SourceSecurityGroupId": {
+          "Fn::GetAtt" : [ "DeisSecurityGroup", "GroupId" ]
+        }
+      }
+    },
     "Ingress5432": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {


### PR DESCRIPTION
Routers are unable to communicate with remote controllers missing AWS::EC2::SecurityGroupIngress configuration for port 8000.
