### PR TITLE
fix(contrib): check that coreos/user-data has a discovery_url set

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,6 +49,11 @@ Vagrant.configure("2") do |config|
 
       # user-data bootstrapping
       config.vm.provision :file, :source => "contrib/coreos/user-data", :destination => "/tmp/vagrantfile-user-data"
+      # check that the CoreOS user-data file is valid
+      config.vm.provision :shell do |s|
+        s.path = "contrib/util/check-user-data.sh"
+        s.args = ["/tmp/vagrantfile-user-data", "#{DEIS_NUM_INSTANCES}"]
+      end
       config.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
     end
   end

--- a/contrib/ec2/provision-ec2-cluster.sh
+++ b/contrib/ec2/provision-ec2-cluster.sh
@@ -16,6 +16,13 @@ if ! which aws > /dev/null; then
   exit 1
 fi
 
+if [ -z "$DEIS_NUM_INSTANCES" ]; then
+    DEIS_NUM_INSTANCES=3
+fi
+
+# check that the CoreOS user-data file is valid
+$CONTRIB_DIR/util/check-user-data.sh
+
 # create an EC2 cloudformation stack based on CoreOS's default template
 aws cloudformation create-stack \
     --template-body "$(./gen-json.py)" \

--- a/contrib/rackspace/provision-rackspace-cluster.sh
+++ b/contrib/rackspace/provision-rackspace-cluster.sh
@@ -37,6 +37,9 @@ if [ -z "$DEIS_NUM_INSTANCES" ]; then
     DEIS_NUM_INSTANCES=3
 fi
 
+# check that the CoreOS user-data file is valid
+$CONTRIB_DIR/util/check-user-data.sh
+
 i=1 ; while [[ $i -le $DEIS_NUM_INSTANCES ]] ; do \
     echo_yellow "Provisioning deis-$i..."
     supernova production boot --image 24614284-19a9-4348-bee3-a504d7094d1b --flavor $FLAVOR --key-name $1 --user-data ../coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \

--- a/contrib/util/check-user-data.sh
+++ b/contrib/util/check-user-data.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+THIS_DIR=$(cd $(dirname $0); pwd) # absolute path
+CONTRIB_DIR=$(dirname $THIS_DIR)
+
+# Use the first command-line argument as the user-data path
+USER_DATA=${1:-$CONTRIB_DIR/coreos/user-data}
+# Use the second command-line argument as DEIS_NUM_INSTANCES
+NUM_INSTANCES=${2:-DEIS_NUM_INSTANCES}
+
+function parse_yaml {
+   local prefix=$2
+   local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+   sed -ne "s|^\($s\):|\1|" \
+        -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+      }
+   }'
+}
+
+if [[ $NUM_INSTANCES -ne 1 ]] ; then
+    parse_yaml $USER_DATA | grep -q coreos_etcd_discovery
+    if [[ $? -ne 0 ]]; then
+        echo "No etcd discovery URL set in $USER_DATA"
+        exit 1
+    fi
+fi


### PR DESCRIPTION
It is all-too-easy to forget to modify `contrib/coreos/user-data` to include a new etcd discovery URL. This adds a validation script `contrib/util/check-user-data.sh` that parses the user-data file as YAML and errors out if it doesn't find a `coreos_etcd_discovery` entry. This check is skipped if `DEIS_NUM_INSTANCES` is 1.

(This is the kind of logic that will be much more maintainable when added to a `deisctl` command-line tool. See #1018.)
