### PR TITLE
fix(confd): services check for valid config before reloading

### DIFF
--- a/controller/bin/check
+++ b/controller/bin/check
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Check that the configuration for deis-controller is valid.
+#
+
+if [[ -f /templates/confd_settings.py ]] ; then
+    set -e
+
+    # check that "<no value>" isn't in the templated file
+    grep -q -v "<no value>" /templates/confd_settings.py
+
+    THIS_DIR=$(cd $(dirname $0); pwd) # absolute path
+    PARENT_DIR=$(dirname $THIS_DIR)
+
+    # check the Django configuration file compatibility
+    $PARENT_DIR/manage.py check > /dev/null
+
+    # validate the Django models
+    $PARENT_DIR/manage.py validate > /dev/null
+fi

--- a/controller/conf.d/confd_settings.toml
+++ b/controller/conf.d/confd_settings.toml
@@ -11,5 +11,5 @@ keys = [
   "/deis/registry",
   "/deis/domains",
 ]
-check_cmd = "test -e {{ .src }}"
+check_cmd = "/app/bin/check"
 reload_cmd = "/app/bin/reload"

--- a/database/bin/check
+++ b/database/bin/check
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Check that the configuration for deis-database is valid.
+#
+
+set -e
+
+# check that "<no value>" isn't in the templated files
+if [[ -f /etc/postgresql/9.3/main/postgresql.conf ]] ; then
+    grep -q -v "<no value>" /etc/postgresql/9.3/main/postgresql.conf
+fi
+if [[ -f /etc/postgresql/9.3/main/pg_hba.conf ]] ; then
+    grep -q -v "<no value>" /etc/postgresql/9.3/main/pg_hba.conf
+fi
+if [[ -f /usr/local/bin/reload ]] ; then
+    grep -q -v "<no value>" /usr/local/bin/reload
+fi

--- a/database/conf.d/pg_hba.conf.toml
+++ b/database/conf.d/pg_hba.conf.toml
@@ -7,3 +7,5 @@ mode  = "0640"
 keys = [
   "/deis/database",
 ]
+check_cmd = "/app/bin/check"
+reload_cmd = "/usr/local/bin/reload"

--- a/database/conf.d/postgresql.conf.toml
+++ b/database/conf.d/postgresql.conf.toml
@@ -7,3 +7,5 @@ mode  = "0644"
 keys = [
   "/deis/database",
 ]
+check_cmd = "/app/bin/check"
+reload_cmd = "/usr/local/bin/reload"

--- a/database/conf.d/reload.toml
+++ b/database/conf.d/reload.toml
@@ -7,5 +7,5 @@ mode  = "0755"
 keys = [
   "/deis/database",
 ]
-check_cmd = "netstat -lnt | awk '$6 == \"LISTEN\" && $4 ~ \".5432\"' "
+check_cmd = "/app/bin/check"
 reload_cmd = "/usr/local/bin/reload"

--- a/registry/bin/check
+++ b/registry/bin/check
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Check that the configuration for deis-registry is valid.
+#
+
+if [[ -f /docker-registry/config/config.yml ]] ; then
+    set -e
+
+    # check that "<no value>" isn't in the templated file
+    grep -q -v "<no value>" /docker-registry/config/config.yml
+fi

--- a/registry/bin/reload
+++ b/registry/bin/reload
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Send SIGHUP to gunicorn in general, since we didn't launch it with `--pid`
+pkill -HUP -u registry gunicorn

--- a/registry/conf.d/config.toml
+++ b/registry/conf.d/config.toml
@@ -7,3 +7,5 @@ mode  = "0644"
 keys = [
   "/deis/registry",
 ]
+check_cmd = "/app/bin/check"
+reload_cmd = "/app/bin/reload"


### PR DESCRIPTION
Adds a check_cmd to controller, database, and registry that will prevent their processes from reloading if configuration files are invalid. This is already in place for deis-router, logger does not use confd templating, and builder does not have a process that needs reloading. (Cache runs Redis in the foreground, and Redis ignores SIGHUP completely, so it's problematic.)

TESTING: Build controller, database, and registry. Test that `make uninstall` and `make run` work and that stopping and starting individual components does not cause others to fail with invalid configuration.
