### PR TITLE
[WIP] fix(controller): restart celery or gunicorn in reload script

### DIFF
--- a/controller/bin/reload
+++ b/controller/bin/reload
@@ -1,9 +1,19 @@
 #!/bin/bash
 
-# gracefully reload celery
-kill -HUP $(cat /tmp/celery.pid)
+if [[ -f /tmp/celery.pid ]] ; then
+    # gracefully reload celery
+    kill -HUP $(cat /tmp/celery.pid)
+else
+    # spawn celery worker in the background
+    sudo -E -u deis celery worker --app=deis --loglevel=INFO --workdir=/app --pidfile=/tmp/celery.pid &
+fi
 
-# gracefully reload gunicorn
-kill -HUP $(cat /tmp/gunicorn.pid)
+if [[ -f /tmp/gunicorn.pid ]] ; then
+    # gracefully reload gunicorn
+    kill -HUP $(cat /tmp/gunicorn.pid)
+else
+    # spawn a gunicorn server in the foreground
+    sudo -E -u deis ./manage.py run_gunicorn -b 0.0.0.0 -w 8 -t 600 -n deis --log-level debug --pid=/tmp/gunicorn.pid --preload &
+fi
 
 exit 0


### PR DESCRIPTION
Previously the /app/bin/reload script invoked by confd assumed that
pidfiles for celery and gunicorn always exist, which is not true in
some failure cases. This only sends them a SIGHUP if they are running,
and restarts them otherwise.

Fixes #1100.

TESTING: Rebuild and restart the controller, then `nsenter` deis-controller and try killing either process set and running /app/bin/reload, restarting deis-builder and other containers, and seeing that the controller actually reloads and that celery and gunicorn process continue to run.
