### PR TITLE
fix(readthedocs): install CLI requirements explicitly

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -58,7 +58,7 @@ setup(name='deis',
       long_description=LONG_DESCRIPTION,
       install_requires=[
           'docopt==0.6.1', 'python-dateutil==2.2',
-          'PyYAML==3.10', 'requests==2.2.1'
+          'PyYAML==3.10', 'requests==2.2.1', 'urllib3==1.8.2'
       ],
       zip_safe=True,
       **KWARGS)

--- a/controller/dev_requirements.txt
+++ b/controller/dev_requirements.txt
@@ -3,6 +3,7 @@ docopt==0.6.1
 python-dateutil==2.2
 #PyYAML==3.10
 requests==2.2.1
+urllib3==1.8.2
 
 # PyInstaller builds client binaries
 PyInstaller==2.1

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -24,6 +24,10 @@ South==0.8.4
 
 # Deis client requirements
 docopt==0.6.1
+python-dateutil==2.2
+#PyYAML==3.10
+requests==2.2.1
+urllib3==1.8.2
 
 # Deis documentation requirements
 Sphinx>=1.2.2


### PR DESCRIPTION
Readthedocs.org began failing to generate our Python code autodocs
recently. Purging the build environment (use https://readthedocs.org/wipe/deis/latest/)
did not help. Their logs indicate Sphinx is confused by a version of
the requests library that happens to be installed in the system python.
This adds the client's requirements explicitly to the docs_requirements.txt
so that this broken version of requests is ignored.
