### PR TITLE
feat(*): allow custom component images

### DIFF
--- a/builder/systemd/deis-builder.service
+++ b/builder/systemd/deis-builder.service
@@ -4,10 +4,10 @@ Description=deis-builder
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker history deis/builder >/dev/null || docker pull deis/builder:latest"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-builder >/dev/null && docker rm -f deis-builder || true"
 ExecStartPre=/bin/sh -c "docker inspect deis-builder-data >/dev/null 2>&1 || docker run --name deis-builder-data -v /var/lib/docker deis/base true"
-ExecStart=/usr/bin/docker run --name deis-builder --rm -p 2223:22 -e PUBLISH=22 -e HOST=${COREOS_PRIVATE_IPV4} -e PORT=2223 --volumes-from deis-builder-data --privileged deis/builder
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker run --name deis-builder --rm -p 2223:22 -e PUBLISH=22 -e HOST=$COREOS_PRIVATE_IPV4 -e PORT=2223 --volumes-from deis-builder-data --privileged $IMAGE"
 ExecStartPost=/bin/sh -c "echo 'Waiting for builder on 2223/tcp...' && until cat </dev/null>/dev/tcp/$COREOS_PRIVATE_IPV4/2223; do sleep 1; done"
 
 [Install]

--- a/cache/systemd/deis-cache.service
+++ b/cache/systemd/deis-cache.service
@@ -4,9 +4,9 @@ Description=deis-cache
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker history deis/cache >/dev/null || docker pull deis/cache:latest"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-cache >/dev/null && docker rm -f deis-cache || true"
-ExecStart=/usr/bin/docker run --name deis-cache --rm -p 6379:6379 -e PUBLISH=6379 -e HOST=${COREOS_PRIVATE_IPV4} deis/cache
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache` && docker run --name deis-cache --rm -p 6379:6379 -e PUBLISH=6379 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -89,6 +89,9 @@ coreos:
       ExecStartPre=/usr/bin/rm /home/core/.bashrc
       ExecStart=/usr/bin/ln -s /run/deis/.bashrc /home/core/.bashrc
 write_files:
+  - path: /etc/deis-release
+    content: |
+      DEIS_RELEASE=latest
   - path: /run/deis/motd
     content: " \e[31m* *    \e[34m*   \e[32m*****    \e[39mddddd   eeeeeee iiiiiii   ssss\n\e[31m*   *  \e[34m* *  \e[32m*   *     \e[39md   d   e    e    i     s    s\n \e[31m* *  \e[34m***** \e[32m*****     \e[39md    d  e         i    s\n\e[32m*****  \e[31m* *    \e[34m*       \e[39md     d e         i     s\n\e[32m*   * \e[31m*   *  \e[34m* *      \e[39md     d eee       i      sss\n\e[32m*****  \e[31m* *  \e[34m*****     \e[39md     d e         i         s\n  \e[34m*   \e[32m*****  \e[31m* *      \e[39md    d  e         i          s\n \e[34m* *  \e[32m*   * \e[31m*   *     \e[39md   d   e    e    i    s    s\n\e[34m***** \e[32m*****  \e[31m* *     \e[39mddddd   eeeeeee iiiiiii  ssss\n\n\e[39mWelcome to Deis\t\t\tPowered by Core\e[38;5;45mO\e[38;5;206mS\e[39m\n"
   - path: /run/deis/.bashrc
@@ -98,3 +101,25 @@ write_files:
       function nse() {
         sudo nsenter --pid --uts --mount --ipc --net --target $(docker inspect --format="{{ .State.Pid }}" $1)
       }
+  - path: /run/deis/bin/get_image
+    permissions: 0755
+    content: |
+      #!/bin/bash
+      # usage: get_image <component_path>
+      IMAGE=`etcdctl get $1/image`
+
+      # if no image was set in etcd, we use the default plus the release string
+      if [ $? -ne 0 ]; then
+        RELEASE=`etcdctl get /deis/release`
+
+        # if no release was set in etcd, use the default provisioned with the server
+        if [ $? -ne 0 ]; then
+          source /etc/deis-release
+          RELEASE=$DEIS_RELEASE
+        fi
+
+        IMAGE=$1:$RELEASE
+      fi
+
+      # remove leading slash
+      echo ${IMAGE#/}

--- a/controller/systemd/deis-controller.service
+++ b/controller/systemd/deis-controller.service
@@ -6,9 +6,9 @@ After=deis-logger.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker history deis/controller >/dev/null || docker pull deis/controller:latest"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-controller >/dev/null && docker rm -f deis-controller || true"
-ExecStart=/usr/bin/docker run --name deis-controller --rm -p 8000:8000 -e PUBLISH=8000 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from=deis-logger deis/controller
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker run --name deis-controller --rm -p 8000:8000 -e PUBLISH=8000 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from=deis-logger $IMAGE"
 
 [Install]
 WantedBy=multi-user.target

--- a/database/systemd/deis-database.service
+++ b/database/systemd/deis-database.service
@@ -4,10 +4,10 @@ Description=deis-database
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker history deis/database >/dev/null || docker pull deis/database:latest"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-database >/dev/null && docker rm -f deis-database || true"
 ExecStartPre=/bin/sh -c "docker inspect deis-database-data >/dev/null 2>&1 || docker run --name deis-database-data -v /var/lib/postgresql deis/base true"
-ExecStart=/usr/bin/docker run --name deis-database --rm -p 5432:5432 -e PUBLISH=5432 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-database-data deis/database
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker run --name deis-database --rm -p 5432:5432 -e PUBLISH=5432 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-database-data $IMAGE"
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/contributing/releases.rst
+++ b/docs/contributing/releases.rst
@@ -30,8 +30,7 @@ github.com/deis/deis Repo
     * ``git add CHANGELOG.md && git commit -m "Updated CHANGELOG.md."``
 - Merge git master into release branch locally
     * ``git checkout release && git merge master``
-- Grep the codebase for "docker pull" and replace all instances of ":latest"
-  with ":vX.Y.Z"
+- Edit contrib/coreos/user-data and update ``DEIS_RELEASE`` to ":vX.Y.Z"
 - At the Docker Index, create a tagged image build ":vX.Y.Z" for every component
     * The UI for this is well-hidden: go to https://index.docker.io/builds/ and
       click "Edit".

--- a/logger/systemd/deis-logger.service
+++ b/logger/systemd/deis-logger.service
@@ -4,10 +4,10 @@ Description=deis-logger
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker history deis/logger >/dev/null || docker pull deis/logger:latest"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-logger >/dev/null && docker rm -f deis-logger || true"
 ExecStartPre=/bin/sh -c "docker inspect deis-logger-data >/dev/null 2>&1 || docker run --name deis-logger-data -v /var/log/deis deis/base true"
-ExecStart=/usr/bin/docker run --name deis-logger --rm -p 514:514/udp -e PUBLISH=514 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-logger-data deis/logger
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker run --name deis-logger --rm -p 514:514/udp -e PUBLISH=514 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-logger-data $IMAGE"
 
 [Install]
 WantedBy=multi-user.target

--- a/registry/systemd/deis-registry.service
+++ b/registry/systemd/deis-registry.service
@@ -4,10 +4,10 @@ Description=deis-registry
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker history deis/registry >/dev/null || docker pull deis/registry:latest"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-registry >/dev/null && docker rm -f deis-registry || true"
 ExecStartPre=/bin/sh -c "docker inspect deis-registry-data >/dev/null 2>&1 || docker run --name deis-registry-data -v /data deis/base /bin/true"
-ExecStart=/usr/bin/docker run --name deis-registry --rm -p 5000:5000 -e PUBLISH=5000 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-registry-data deis/registry
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docker run --name deis-registry --rm -p 5000:5000 -e PUBLISH=5000 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-registry-data $IMAGE"
 ExecStartPost=/bin/sh -c "echo 'Waiting for listener on 5000/tcp...' && until cat </dev/null>/dev/tcp/$COREOS_PRIVATE_IPV4/5000; do sleep 1; done && docker pull deis/slugrunner:latest && docker tag deis/slugrunner $COREOS_PRIVATE_IPV4:5000/deis/slugrunner && docker push $COREOS_PRIVATE_IPV4:5000/deis/slugrunner"
 
 [Install]

--- a/router/systemd/deis-router.service
+++ b/router/systemd/deis-router.service
@@ -4,9 +4,9 @@ Description=deis-router
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker history deis/router >/dev/null || docker pull deis/router:latest"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-router >/dev/null && docker rm -f deis-router || true"
-ExecStart=/usr/bin/docker run --name deis-router --rm -p 80:80 -p 2222:2222 -e PUBLISH=80 -e HOST=${COREOS_PRIVATE_IPV4} deis/router
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router` && docker run --name deis-router --rm -p 80:80 -p 2222:2222 -e PUBLISH=80 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Pull image names for Deis components from etcd, defaulting to the
stock Deis component images. This enables users to supply their own
router, for instance, simply by setting an etcd key:

/deis/{component}/image

Also, the Deis release version is now stored in /etc/deis-release.
This is by default appended when getting the image names for Deis
components, but can be overridden if set in etcd at /deis/release.

TESTING: first, make sure you can provision Deis just as before - nothing needs to change.
Then, get a little funky:

``` console
dev $ make -C router/ full-clean
coreos $ etcdctl set /deis/router/image "carmstrong/router:latest"
dev $ make install-routers start-routers
dev $ curl -I http://172.17.8.100/chris-is-cool
HTTP/1.1 200 OK
Server: nginx/1.6.0
Date: Thu, 05 Jun 2014 00:19:45 GMT
Content-Type: text/plain
Content-Length: 0
Connection: keep-alive
```

You can also override the release:

``` console
dev $ make uninstall
coreos $ etcdctl set /deis/release v0.9.1
dev $ make run
```

And test a private registry:

``` console
dev $ make -C router/ full-clean
coreos $ etcdctl set /deis/router/image phife.atribecalledchris.com:5000/router:latest
dev $ make install-routers start-routers
dev $ curl -I http://172.17.8.100/chris-is-cool
HTTP/1.1 200 OK
Server: nginx/1.6.0
Date: Thu, 05 Jun 2014 00:19:45 GMT
Content-Type: text/plain
Content-Length: 0
Connection: keep-alive
```

closes #1023 
