### PR TITLE
fix(systemd/*): specify tag in `docker run` commands as well

### DIFF
--- a/builder/systemd/deis-builder.service
+++ b/builder/systemd/deis-builder.service
@@ -7,7 +7,7 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "docker history deis/builder >/dev/null || docker pull deis/builder:latest"
 ExecStartPre=/bin/sh -c "docker inspect deis-builder >/dev/null && docker rm -f deis-builder || true"
 ExecStartPre=/bin/sh -c "docker inspect deis-builder-data >/dev/null 2>&1 || docker run --name deis-builder-data -v /var/lib/docker deis/base true"
-ExecStart=/usr/bin/docker run --name deis-builder -p 2223:22 -e PUBLISH=22 -e HOST=${COREOS_PRIVATE_IPV4} -e PORT=2223 --volumes-from deis-builder-data --privileged deis/builder
+ExecStart=/usr/bin/docker run --name deis-builder -p 2223:22 -e PUBLISH=22 -e HOST=${COREOS_PRIVATE_IPV4} -e PORT=2223 --volumes-from deis-builder-data --privileged deis/builder:latest
 ExecStartPost=/bin/sh -c "echo 'Waiting for builder on 2223/tcp...' && until cat </dev/null>/dev/tcp/$COREOS_PRIVATE_IPV4/2223; do sleep 1; done"
 ExecStop=/usr/bin/docker rm -f deis-builder
 

--- a/cache/systemd/deis-cache.service
+++ b/cache/systemd/deis-cache.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "docker history deis/cache >/dev/null || docker pull deis/cache:latest"
 ExecStartPre=/bin/sh -c "docker inspect deis-cache >/dev/null && docker rm -f deis-cache || true"
-ExecStart=/usr/bin/docker run --name deis-cache -p 6379:6379 -e PUBLISH=6379 -e HOST=${COREOS_PRIVATE_IPV4} deis/cache
+ExecStart=/usr/bin/docker run --name deis-cache -p 6379:6379 -e PUBLISH=6379 -e HOST=${COREOS_PRIVATE_IPV4} deis/cache:latest
 ExecStop=/usr/bin/docker rm -f deis-cache
 
 [Install]

--- a/controller/systemd/deis-controller.service
+++ b/controller/systemd/deis-controller.service
@@ -8,7 +8,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "docker history deis/controller >/dev/null || docker pull deis/controller:latest"
 ExecStartPre=/bin/sh -c "docker inspect deis-controller >/dev/null && docker rm -f deis-controller || true"
-ExecStart=/usr/bin/docker run --name deis-controller -p 8000:8000 -e PUBLISH=8000 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from=deis-logger deis/controller
+ExecStart=/usr/bin/docker run --name deis-controller -p 8000:8000 -e PUBLISH=8000 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from=deis-logger deis/controller:latest
 ExecStop=/usr/bin/docker rm -f deis-controller
 
 [Install]

--- a/database/systemd/deis-database.service
+++ b/database/systemd/deis-database.service
@@ -7,7 +7,7 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "docker history deis/database >/dev/null || docker pull deis/database:latest"
 ExecStartPre=/bin/sh -c "docker inspect deis-database >/dev/null && docker rm -f deis-database || true"
 ExecStartPre=/bin/sh -c "docker inspect deis-database-data >/dev/null 2>&1 || docker run --name deis-database-data -v /var/lib/postgresql deis/base true"
-ExecStart=/usr/bin/docker run --name deis-database -p 5432:5432 -e PUBLISH=5432 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-database-data deis/database
+ExecStart=/usr/bin/docker run --name deis-database -p 5432:5432 -e PUBLISH=5432 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-database-data deis/database:latest
 ExecStop=/usr/bin/docker rm -f deis-database
 
 [Install]

--- a/logger/systemd/deis-logger.service
+++ b/logger/systemd/deis-logger.service
@@ -7,7 +7,7 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "docker history deis/logger >/dev/null || docker pull deis/logger:latest"
 ExecStartPre=/bin/sh -c "docker inspect deis-logger >/dev/null && docker rm -f deis-logger || true"
 ExecStartPre=/bin/sh -c "docker inspect deis-logger-data >/dev/null 2>&1 || docker run --name deis-logger-data -v /var/log/deis deis/base true"
-ExecStart=/usr/bin/docker run --name deis-logger -p 514:514/udp -e PUBLISH=514 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-logger-data deis/logger
+ExecStart=/usr/bin/docker run --name deis-logger -p 514:514/udp -e PUBLISH=514 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-logger-data deis/logger:latest
 ExecStop=/usr/bin/docker rm -f deis-logger
 
 [Install]

--- a/registry/systemd/deis-registry.service
+++ b/registry/systemd/deis-registry.service
@@ -7,7 +7,7 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "docker history deis/registry >/dev/null || docker pull deis/registry:latest"
 ExecStartPre=/bin/sh -c "docker inspect deis-registry >/dev/null && docker rm -f deis-registry || true"
 ExecStartPre=/bin/sh -c "docker inspect deis-registry-data >/dev/null 2>&1 || docker run --name deis-registry-data -v /data deis/base /bin/true"
-ExecStart=/usr/bin/docker run --name deis-registry -p 5000:5000 -e PUBLISH=5000 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-registry-data deis/registry
+ExecStart=/usr/bin/docker run --name deis-registry -p 5000:5000 -e PUBLISH=5000 -e HOST=${COREOS_PRIVATE_IPV4} --volumes-from deis-registry-data deis/registry:latest
 ExecStartPost=/bin/sh -c "echo 'Waiting for listener on 5000/tcp...' && until cat </dev/null>/dev/tcp/$COREOS_PRIVATE_IPV4/5000; do sleep 1; done && docker pull deis/slugrunner:latest && docker tag deis/slugrunner $COREOS_PRIVATE_IPV4:5000/deis/slugrunner && docker push $COREOS_PRIVATE_IPV4:5000/deis/slugrunner"
 ExecStop=/usr/bin/docker rm -f deis-registry
 

--- a/router/systemd/deis-router.service
+++ b/router/systemd/deis-router.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "docker history deis/router >/dev/null || docker pull deis/router:latest"
 ExecStartPre=/bin/sh -c "docker inspect deis-router >/dev/null && docker rm -f deis-router || true"
-ExecStart=/usr/bin/docker run --name deis-router -p 80:80 -p 2222:2222 -e PUBLISH=80 -e HOST=${COREOS_PRIVATE_IPV4} deis/router
+ExecStart=/usr/bin/docker run --name deis-router -p 80:80 -p 2222:2222 -e PUBLISH=80 -e HOST=${COREOS_PRIVATE_IPV4} deis/router:latest
 ExecStop=/usr/bin/docker rm -f deis-router
 
 [Install]


### PR DESCRIPTION
While Deis systemd unit files specify the docker image tag in the
`docker pull` ExecPreStart command, they omit it in their `docker run`
command. This inadvertently pulls down _all_ tagged images for the
docker container, wasting bandwidth. This is most evident when testing
on the v0.9.1 branch; on master it is effectively masked by the
semantics of the ":latest" tag.

I have tested this as well as a locally modified version replacing :latest
with :v0.9.1, works as intended.
