### PR TITLE
fix(client): `deis run` no longer requires remote

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -579,12 +579,12 @@ class DeisClient(object):
         """
         Run a command inside an ephemeral app container
 
-        Usage: deis apps:run <command>...
+        Usage: deis apps:run [--app=<app> --] <command>...
         """
         app = args.get('--app')
         if not app:
             app = self._session.app
-        body = {'command': ' '.join(sys.argv[2:])}
+        body = {'command': ' '.join(args.get('<command>'))}
         response = self._dispatch('post',
                                   "/api/apps/{}/run".format(app),
                                   json.dumps(body))
@@ -1611,11 +1611,10 @@ def main():
         method = getattr(cli, cmd)
     else:
         raise DocoptExit('Found no matching command, try `deis help`')
-    # re-parse docopt with the relevant docstring unless it needs sys.argv
-    if cmd not in ('apps_run',):
-        docstring = trim(getattr(cli, cmd).__doc__)
-        if 'Usage: ' in docstring:
-            args.update(docopt(docstring))
+    # re-parse docopt with the relevant docstring
+    docstring = trim(getattr(cli, cmd).__doc__)
+    if 'Usage: ' in docstring:
+        args.update(docopt(docstring))
     # dispatch the CLI command
     _dispatch_cmd(method, args)
 


### PR DESCRIPTION
TESTING: try to run a command outside of the git repository:

```
$ cd ..
$ deis run --app=foo ls
```

If you're running a command that contains an option flag like `ls -al`, you can specify the `--`
option beforehand:

```
$ deis run --app=foo -- ls -al
```

fixes #1086
