### PR TITLE
feat(contrib) Spin up an ELB

### DIFF
--- a/contrib/ec2/deis.template
+++ b/contrib/ec2/deis.template
@@ -208,9 +208,9 @@
           },
           {
             "InstancePort": "2222",
-            "InstanceProtocol": "HTTP",
+            "InstanceProtocol": "TCP",
             "LoadBalancerPort": "2222",
-            "Protocol": "HTTP"
+            "Protocol": "TCP"
           }
         ],
         "SecurityGroups": [


### PR DESCRIPTION
This still allows you to connect directly to the instances behind the ELB on port 80, 2222. We should think about moving away from that, and using the ELB as the entry point. This would greatly simplify the configuration differences between a VPC, and non-VPC environment. Right now, all the instances will be out of rotation until you finish a `make run`.

Thanks to @daanemanz for the guidance on CloudFormation.

Fixes #1139
