### PR TITLE
docs(pip install): add --upgrade to `pip install deis`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Your Vagrant VM is accessible at `local.deisapp.com` (or `local3.deisapp.com`/`l
 Integration tests and corresponding documentation can be found under the `test/` folder.
 
 ## Install the Deis Client
-If you're using the latest Deis release, use `pip install deis` to install the latest [Deis Client](https://pypi.python.org/pypi/deis/) or download [pre-compiled binaries](https://github.com/deis/deis/tree/master/client#get-started).
+If you're using the latest Deis release, use `pip install --upgrade deis` to install the latest [Deis Client](https://pypi.python.org/pypi/deis/) or download [pre-compiled binaries](https://github.com/deis/deis/tree/master/client#get-started).
 
 If you're working off master, precompiled binaries are likely out of date. You should either symlink the python file directly or build a local copy of the client:
 

--- a/docs/developer/install-client.rst
+++ b/docs/developer/install-client.rst
@@ -24,9 +24,9 @@ You can also install the latest Deis client using Python's pip_ package manager:
 
 .. code-block:: console
 
-    $ sudo pip install deis
+    $ sudo pip install --upgrade deis
     Downloading/unpacking deis
-      Downloading deis-0.8.0.tar.gz
+      Downloading deis-0.9.0.tar.gz
       Running setup.py egg_info for package deis
       ...
     Successfully installed deis

--- a/docs/operations/register-admin-user.rst
+++ b/docs/operations/register-admin-user.rst
@@ -16,9 +16,9 @@ Install the latest Deis client using Python's pip_ package manager:
 
 .. code-block:: console
 
-    $ pip install deis
+    $ pip install -upgrade deis
     Downloading/unpacking deis
-      Downloading deis-0.8.0.tar.gz
+      Downloading deis-0.9.0.tar.gz
       Running setup.py egg_info for package deis
       ...
     Successfully installed deis


### PR DESCRIPTION
This flag is safe to use as a default, and would avoid the problem
reported on IRC where an existing deis client stays out-of-date if
you follow our instructions exactly.
