### PR TITLE
chore(*): rely on etcdctl in deis/base

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -46,10 +46,6 @@ RUN echo "%git    ALL=(ALL:ALL) NOPASSWD:/home/git/builder" >> /etc/sudoers
 RUN wget -q https://s3-us-west-2.amazonaws.com/deis/confd -O /usr/local/bin/confd
 RUN chmod +x /usr/local/bin/confd
 
-# install latest etcdctl including no-sync options
-RUN wget -q https://s3-us-west-2.amazonaws.com/deis/etcdctl.no-sync -O /usr/local/bin/etcdctl
-RUN chmod +x /usr/local/bin/etcdctl
-
 # add the current build context to /app
 ADD . /app
 RUN chown -R root:root /app

--- a/cache/Dockerfile
+++ b/cache/Dockerfile
@@ -7,10 +7,6 @@ RUN add-apt-repository ppa:chris-lea/redis-server -y
 RUN apt-get update
 RUN apt-get install -yq redis-server
 
-# install latest etcdctl including no-sync options
-RUN wget -q https://s3-us-west-2.amazonaws.com/deis/etcdctl.no-sync -O /usr/local/bin/etcdctl
-RUN chmod +x /usr/local/bin/etcdctl
-
 # add the current build context to /app
 ADD . /app
 

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -31,10 +31,6 @@ RUN pip install celery==3.1.11 \
 # install openssh-client for temporary fleetctl wrapper
 RUN apt-get install -yq openssh-client
 
-# install latest etcdctl including no-sync options
-RUN wget -q https://s3-us-west-2.amazonaws.com/deis/etcdctl.no-sync -O /usr/local/bin/etcdctl
-RUN chmod +x /usr/local/bin/etcdctl
-
 # clone the project into /app
 ADD . /app
 

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -8,10 +8,6 @@ RUN wget --quiet --no-check-certificate -O - https://www.postgresql.org/media/ke
 RUN apt-get update
 RUN apt-get install -yq postgresql-9.3 && /etc/init.d/postgresql stop
 
-# install latest etcdctl including no-sync options
-RUN wget -q https://s3-us-west-2.amazonaws.com/deis/etcdctl.no-sync -O /usr/local/bin/etcdctl
-RUN chmod +x /usr/local/bin/etcdctl
-
 # debug to remove
 RUN apt-get install -yq curl
 

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -22,10 +22,6 @@ RUN cd /docker-registry && git checkout 0.6.8
 RUN cp /docker-registry/config/boto.cfg /etc/boto.cfg
 RUN cd /docker-registry && pip install -r requirements.txt
 
-# install latest etcdctl including no-sync options
-RUN wget -q https://s3-us-west-2.amazonaws.com/deis/etcdctl.no-sync -O /usr/local/bin/etcdctl
-RUN chmod +x /usr/local/bin/etcdctl
-
 # create data volume
 RUN mkdir -p /data/repositories && chown -R registry:registry /data
 VOLUME /data

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -18,10 +18,6 @@ RUN ./configure --prefix=/var/lib/nginx --sbin-path=/usr/sbin/nginx --conf-path=
 RUN make
 RUN make install
 
-# install latest etcdctl including no-sync options
-RUN wget -q https://s3-us-west-2.amazonaws.com/deis/etcdctl.no-sync -O /usr/local/bin/etcdctl
-RUN chmod +x /usr/local/bin/etcdctl
-
 ADD . /app
 WORKDIR /app
 EXPOSE 80 2222


### PR DESCRIPTION
As of deis/base#4, etcdctl v0.4.2 includes the --no-sync option. We no longer need to install an etcdctl branch just to get this option.
