### PR TITLE
chore(docs): remove Postgres requirement

### DIFF
--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -17,7 +17,7 @@ django-guardian==1.1.1
 django-json-field==0.5.5
 djangorestframework==2.3.13
 gunicorn==18.0
-psycopg2==2.5.2
+#psycopg2==2.5.2
 python-etcd==0.3.0
 PyYAML==3.10
 South==0.8.4


### PR DESCRIPTION
We don't need psycopg2 to build the docs, so remove it. We shouldn't
have to install Postgres to build docs.
