### PR TITLE
fix(scheduler/coreos): have announce/log sidecars wait for app

### DIFF
--- a/controller/scheduler/coreos.py
+++ b/controller/scheduler/coreos.py
@@ -233,10 +233,10 @@ ANNOUNCE_TEMPLATE = """
 [Unit]
 Description={name} announce
 BindsTo={name}.service
+After={name}.service
 
 [Service]
 EnvironmentFile=/etc/environment
-ExecStartPre=/bin/sh -c "until docker inspect -f '{{{{range $i, $e := .HostConfig.PortBindings }}}}{{{{$p := index $e 0}}}}{{{{$p.HostPort}}}}{{{{end}}}}' {name} >/dev/null 2>&1; do sleep 2; done; port=$(docker inspect -f '{{{{range $i, $e := .HostConfig.PortBindings }}}}{{{{$p := index $e 0}}}}{{{{$p.HostPort}}}}{{{{end}}}}' {name}); if [[ -z $port ]]; then echo We have no port...; exit 1; fi; echo Waiting for $port/tcp...; until netstat -lnt | grep :$port >/dev/null; do sleep 1; done"
 ExecStart=/bin/sh -c "port=$(docker inspect -f '{{{{range $i, $e := .HostConfig.PortBindings }}}}{{{{$p := index $e 0}}}}{{{{$p.HostPort}}}}{{{{end}}}}' {name}); echo Connected to $COREOS_PRIVATE_IPV4:$port/tcp, publishing to etcd...; while netstat -lnt | grep :$port >/dev/null; do etcdctl set /deis/services/{app}/{name} $COREOS_PRIVATE_IPV4:$port --ttl 60 >/dev/null; sleep 45; done"
 ExecStop=/usr/bin/etcdctl rm --recursive /deis/services/{app}/{name}
 
@@ -248,9 +248,9 @@ LOG_TEMPLATE = """
 [Unit]
 Description={name} log
 BindsTo={name}.service
+After={name}.service
 
 [Service]
-ExecStartPre=/bin/sh -c "until docker inspect {name} >/dev/null 2>&1; do sleep 1; done"
 ExecStart=/bin/sh -c "docker logs -f {name} 2>&1 | logger -p local0.info -t {app}[{c_type}.{c_num}] --udp --server $(etcdctl get /deis/logs/host | cut -d ':' -f1) --port $(etcdctl get /deis/logs/port | cut -d ':' -f2)"
 
 [X-Fleet]


### PR DESCRIPTION
Currently, the announce and log containers can timeout on startup if
the app takes longer than the default systemd timeout to come up.

Instead, we now use systemd's After= to make sure the unit doesn't
try to come up until the app is running.

This alleviates an issue where we see the app unit running, but the
announce and logger units in a failed state.

TESTING: rebuild and restart the controller, then scale apps:

``` console
    $ make -C controller/ build restart
```
