### PR TITLE
fix(builder): relay output from `docker push` to bust timeouts

### DIFF
--- a/builder/templates/builder
+++ b/builder/templates/builder
@@ -104,8 +104,7 @@ if __name__ == '__main__':
         # push the image, output to /dev/null
         print('-----> Pushing image to private registry')
         sys.stdout.flush(), sys.stderr.flush()
-        p = subprocess.Popen('docker push {target_image}'.format(**locals()), shell=True,
-                              stdout=open(os.devnull, 'w'), stderr=open(os.devnull, 'w'))
+        p = subprocess.Popen('docker push {target_image}'.format(**locals()), shell=True)
         rc = p.wait()
         if rc != 0:
             raise Exception('Could not push Docker image')


### PR DESCRIPTION
Currently, long `git push`es can cause a timeout for certain
load balancers (including ELB) because we are not writing anything
to the socket while the builder is pushing to the registry.

This is the easy fix which relays the output received from the registry
during the `docker push` to the git client.
