### PR TITLE
docs(using_deis/using-buildpacks): fixing unexisting example example-ruby-sinatra git repository

### DIFF
--- a/docs/using_deis/manage-application.rst
+++ b/docs/using_deis/manage-application.rst
@@ -75,7 +75,7 @@ When working with an application that has been shared with you, clone the origin
 
 .. code-block:: console
 
-  $ git clone https://github.com/opdemand/example-java-jetty.git
+  $ git clone https://github.com/deis/example-java-jetty.git
   Cloning into 'example-java-jetty'... done
   $ cd example-java-jetty
   $ git remote add -f deis ssh://git@local.deisapp.com:2222/peachy-waxworks.git

--- a/docs/using_deis/using-buildpacks.rst
+++ b/docs/using_deis/using-buildpacks.rst
@@ -14,7 +14,7 @@ If you do not have an existing application, you can clone an example application
 
 .. code-block:: console
 
-    $ git clone https://github.com/opdemand/example-ruby-sinatra.git
+    $ git clone https://github.com/deis/example-ruby-sinatra.git
     $ cd example-ruby-sinatra
 
 Create an Application


### PR DESCRIPTION
fixing unexisting example example-ruby-sinatra git repository
