### PR TITLE
fix(builder): allow filesystems other than btrfs

### DIFF
--- a/builder/bin/boot
+++ b/builder/bin/boot
@@ -14,6 +14,7 @@ export ETCD_PORT=${ETCD_PORT:-4001}
 export ETCD="$HOST:$ETCD_PORT"
 export ETCD_PATH=${ETCD_PATH:-/deis/builder}
 export ETCD_TTL=${ETCD_TTL:-10}
+export STORAGE_DRIVER=${STORAGE_DRIVER:-btrfs}
 
 # wait for etcd to be available
 until etcdctl --no-sync -C $ETCD ls >/dev/null; do
@@ -44,7 +45,7 @@ CONFD_PID=$!
 test -e /var/run/docker.sock && rm -f /var/run/docker.sock
 
 # spawn a docker daemon to run builds
-docker -d --storage-driver=btrfs --bip=172.19.42.1/16 &
+docker -d --storage-driver=$STORAGE_DRIVER --bip=172.19.42.1/16 &
 DOCKER_PID=$!
 
 # wait for docker to start


### PR DESCRIPTION
When running functional tests (in the component-tests branch currently) for deis/builder, Docker reports an error about being unable to init the btrfs filesystem, since the host filesystem isn't btrfs as we expect on CoreOS. The builder component should be able to run outside that environment. This change keeps the default at btrfs but allows `STORAGE_DRIVER` to be set to aufs if needed.

TESTING: Build and start the deis/builder component on an Ubuntu box or other non-btrfs filesystem and ensure that it comes up without reporting errors. We will also demonstrate this fix soon at http://ci.deis.io.
