### PR TITLE
fix(*): fix etcd_safe_set to not override values

### DIFF
--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -24,17 +24,15 @@ done
 # wait until etcd has discarded potentially stale values
 sleep $(($ETCD_TTL+1))
 
-function etcd_safe_set {
-  if ! etcdctl --no-sync -C $ETCD get $ETCD_PATH/$1 >/dev/null 2>&1; then
-    etcdctl --no-sync -C $ETCD set $ETCD_PATH/$1 $2 >/dev/null
-  fi
+function etcd_set_default {
+  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
 }
 
-etcd_safe_set protocol ${DEIS_PROTOCOL:-http}
-etcd_safe_set secretKey ${DEIS_SECRET_KEY:-`openssl rand -base64 64 | tr -d '\n'`}
-etcd_safe_set builderKey ${DEIS_BUILDER_KEY:-`openssl rand -base64 64 | tr -d '\n'`}
-etcd_safe_set registrationEnabled 1
-etcd_safe_set webEnabled 0
+etcd_set_default protocol ${DEIS_PROTOCOL:-http}
+etcd_set_default secretKey ${DEIS_SECRET_KEY:-`openssl rand -base64 64 | tr -d '\n'`}
+etcd_set_default builderKey ${DEIS_BUILDER_KEY:-`openssl rand -base64 64 | tr -d '\n'`}
+etcd_set_default registrationEnabled 1
+etcd_set_default webEnabled 0
 
 # wait for confd to run once and install initial templates
 until confd -onetime -node $ETCD -config-file /app/confd.toml 2>/dev/null; do

--- a/database/bin/boot
+++ b/database/bin/boot
@@ -31,18 +31,16 @@ done
 # wait until etcd has discarded potentially stale values
 sleep $(($ETCD_TTL+1))
 
-function etcd_safe_set {
-  if ! etcdctl --no-sync -C $ETCD get $ETCD_PATH/$1 >/dev/null 2>&1; then
-    etcdctl --no-sync -C $ETCD set $ETCD_PATH/$1 $2 >/dev/null
-  fi
+function etcd_set_default {
+  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
 }
 
-etcd_safe_set engine postgresql_psycopg2
-etcd_safe_set adminUser ${PG_ADMIN_USER:-postgres}
-etcd_safe_set adminPass ${PG_ADMIN_PASS:-changeme123}
-etcd_safe_set user ${PG_USER_NAME:-deis}
-etcd_safe_set password ${PG_USER_PASS:-changeme123}
-etcd_safe_set name ${PG_USER_DB:-deis}
+etcd_set_default engine postgresql_psycopg2
+etcd_set_default adminUser ${PG_ADMIN_USER:-postgres}
+etcd_set_default adminPass ${PG_ADMIN_PASS:-changeme123}
+etcd_set_default user ${PG_USER_NAME:-deis}
+etcd_set_default password ${PG_USER_PASS:-changeme123}
+etcd_set_default name ${PG_USER_DB:-deis}
 
 # wait for confd to run once and install initial templates
 until confd -onetime -node $ETCD -config-file /app/confd.toml; do

--- a/registry/bin/boot
+++ b/registry/bin/boot
@@ -27,15 +27,13 @@ done
 # wait until etcd has discarded potentially stale values
 sleep $(($ETCD_TTL+1))
 
-function etcd_safe_set {
-  if ! etcdctl --no-sync -C $ETCD get $ETCD_PATH/$1 >/dev/null 2>&1; then
-    etcdctl --no-sync -C $ETCD set $ETCD_PATH/$1 $2 >/dev/null
-  fi
+function etcd_set_default {
+  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
 }
 
 # seed initial service configuration if necessary
-etcd_safe_set protocol http
-etcd_safe_set secretKey ${REGISTRY_SECRET_KEY:-`openssl rand -base64 64 | tr -d '\n'`}
+etcd_set_default protocol http
+etcd_set_default secretKey ${REGISTRY_SECRET_KEY:-`openssl rand -base64 64 | tr -d '\n'`}
 
 # wait for confd to run once and install initial templates
 until confd -onetime -node $ETCD -config-file /app/confd.toml; do

--- a/router/bin/boot
+++ b/router/bin/boot
@@ -28,24 +28,22 @@ function etcd_safe_mkdir {
   etcdctl --no-sync -C $ETCD mkdir $1 >/dev/null 2>&1 || true
 }
 
-function etcd_safe_set {
-  if ! etcdctl --no-sync -C $ETCD get $ETCD_PATH/$1 >/dev/null 2>&1; then
-    etcdctl --no-sync -C $ETCD set $ETCD_PATH/$1 $2 >/dev/null
-  fi
+function etcd_set_default {
+  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
 }
 
 etcd_safe_mkdir /deis/controller
 etcd_safe_mkdir /deis/services
 etcd_safe_mkdir /deis/domains
 etcd_safe_mkdir /deis/builder
-etcd_safe_set port ${PORT:-80}
-etcd_safe_set gzip on
-etcd_safe_set gzipHttpVersion 1.0
-etcd_safe_set gzipCompLevel 2
-etcd_safe_set gzipProxied any
-etcd_safe_set gzipVary on
-etcd_safe_set gzipDisable "\"msie6\""
-etcd_safe_set gzipTypes "application/x-javascript, application/xhtml+xml, application/xml, application/xml+rss, application/json, text/css, text/javascript, text/plain, text/xml"
+etcd_set_default port ${PORT:-80}
+etcd_set_default gzip on
+etcd_set_default gzipHttpVersion 1.0
+etcd_set_default gzipCompLevel 2
+etcd_set_default gzipProxied any
+etcd_set_default gzipVary on
+etcd_set_default gzipDisable "\"msie6\""
+etcd_set_default gzipTypes "application/x-javascript, application/xhtml+xml, application/xml, application/xml+rss, application/json, text/css, text/javascript, text/plain, text/xml"
 
 # wait for confd to run once and install initial templates
 until confd -onetime -node $ETCD -config-file /app/confd.toml >/dev/null 2>/dev/null; do


### PR DESCRIPTION
Refactors etcd_safe_set so it doesn't overwrite custom settings.

TESTING: rebuild and restart components, setting a non-default
custom value

``` console
dev $ make uninstall
dev $ vagrant rsync && make build
dev $ vagrant ssh
coreos $ etcdctl set /deis/controller/webEnabled 1
dev $ make run
```

Make sure the settings have taken effect.

Changes proposed by @aledbf

fixes #1210
