### PR TITLE
fix(client): add "Referer" header to requests

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -147,6 +147,11 @@ class Session(requests.Session):
                 else:
                     kwargs['headers'] = {'X-CSRFToken': cookie.value}
                 break
+        url = args[1]
+        if 'headers' in kwargs:
+            kwargs['headers']['Referer'] = url
+        else:
+            kwargs['headers'] = {'Referer': url}
         response = super(Session, self).request(*args, **kwargs)
         self.cookies.save()
         return response


### PR DESCRIPTION
When running Deis behind an SSL-terminated endpoint, there are
issues with Django's CSRF protection. Adding a Referer header
is mandatory when using SSL with Django.

Reference: https://code.djangoproject.com/ticket/16870

fixes #1002
