### PR TITLE
fix(Dockerfile): ensure `apt-get install` is prefixed by `update`

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,22 +1,20 @@
 FROM deis/base:latest
 MAINTAINER Gabriel Monroy <gabriel@opdemand.com>
 
-ENV DEBIAN_FRONTEND noninteractive
+# install docker-in-docker
+RUN echo "deb http://get.docker.io/ubuntu docker main" > /etc/apt/sources.list.d/docker.list
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+# install builder, docker, and hook dependencies
+RUN apt-get update && apt-get install -yq \
+    openssh-server git \
+    aufs-tools iptables lxc \
+    curl \
+    lxc-docker-1.0.0
 
-RUN apt-get update
-
-# install ssh server
-RUN apt-get install -yq openssh-server
+# configure ssh server
 RUN rm /etc/ssh/ssh_host_*
 RUN dpkg-reconfigure openssh-server
 RUN mkdir -p /var/run/sshd
-
-# install docker in docker deps
-RUN apt-get install -yq aufs-tools iptables ca-certificates lxc
-RUN echo "deb http://get.docker.io/ubuntu docker main" > /etc/apt/sources.list.d/docker.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
-RUN apt-get update -qy
-RUN apt-get install -yq lxc-docker-1.0.0
 
 # install recent pip
 RUN wget -qO- https://raw.githubusercontent.com/pypa/pip/1.5.5/contrib/get-pip.py | python -
@@ -24,22 +22,17 @@ RUN wget -qO- https://raw.githubusercontent.com/pypa/pip/1.5.5/contrib/get-pip.p
 # install hook dependencies
 RUN pip install pyyaml requests
 
-# install hook utilities
-RUN apt-get install -yq curl vim
-
 # install all i18n locales
 RUN ln -s /usr/share/i18n/SUPPORTED /var/lib/locales/supported.d/all && locale-gen
 
 # install git and configure gituser
 ENV GITHOME /home/git
 ENV GITUSER git
-RUN apt-get install -yq git
 RUN useradd -d $GITHOME $GITUSER
 RUN mkdir -p $GITHOME/.ssh && chown git:git $GITHOME/.ssh
 RUN chown -R $GITUSER:$GITUSER $GITHOME
 
 # let the git user run `sudo /home/git/builder` (not writeable)
-RUN apt-get install -yq sudo
 RUN echo "%git    ALL=(ALL:ALL) NOPASSWD:/home/git/builder" >> /etc/sudoers
 
 # add the current build context to /app

--- a/cache/Dockerfile
+++ b/cache/Dockerfile
@@ -4,8 +4,7 @@ MAINTAINER Gabriel Monroy <gabriel@opdemand.com>
 # install redis from OS package
 RUN apt-get update && apt-get install -yq python-software-properties
 RUN add-apt-repository ppa:chris-lea/redis-server -y
-RUN apt-get update
-RUN apt-get install -yq redis-server
+RUN apt-get update && apt-get install -yq redis-server
 
 # add the current build context to /app
 ADD . /app

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -2,17 +2,13 @@ FROM deis/base:latest
 MAINTAINER OpDemand <info@opdemand.com>
 
 # install required system packages
+# HACK: install git so we can install bacongobbler's fork of django-fsm
+# install openssh-client for temporary fleetctl wrapper
 RUN apt-get update && \
-    apt-get install -yq python-dev libpq-dev libyaml-dev
+    apt-get install -yq python-dev libpq-dev libyaml-dev git openssh-client
 
 # install recent pip
 RUN wget -qO- https://raw.githubusercontent.com/pypa/pip/1.5.5/contrib/get-pip.py | python -
-
-# HACK: install git so we can install bacongobbler's fork of django-fsm
-RUN apt-get install -yq git
-
-# install openssh-client for temporary fleetctl wrapper
-RUN apt-get install -yq openssh-client
 
 # add a deis user that has passwordless sudo (for now)
 RUN useradd deis --groups sudo --home-dir /app --shell /bin/bash

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -2,14 +2,9 @@ FROM deis/base:latest
 MAINTAINER Gabriel Monroy <gabriel@opdemand.com>
 
 # install 9.3 from postgresql.org repository
-RUN apt-get -yq install wget ca-certificates
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN wget --quiet --no-check-certificate -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN apt-get update
-RUN apt-get install -yq postgresql-9.3 && /etc/init.d/postgresql stop
-
-# debug to remove
-RUN apt-get install -yq curl
+RUN apt-get update && apt-get install -yq postgresql-9.3 && /etc/init.d/postgresql stop
 
 # add the current build context to /app
 ADD . /app

--- a/logger/Dockerfile
+++ b/logger/Dockerfile
@@ -2,8 +2,7 @@ FROM deis/base:latest
 MAINTAINER Gabriel Monroy <gabriel@opdemand.com>
 
 # install go runtime
-RUN wget -O /tmp/go1.2.1.linux-amd64.tar.gz -q https://go.googlecode.com/files/go1.2.1.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf /tmp/go1.2.1.linux-amd64.tar.gz
+RUN wget -qO- https://storage.googleapis.com/golang/go1.2.2.linux-amd64.tar.gz | tar -C /usr/local -xz
 
 # prepare go environment
 RUN mkdir -p /go

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -2,9 +2,8 @@ FROM deis/base:latest
 MAINTAINER Gabriel Monroy <gabriel@opdemand.com>
 
 # install required packages (copied from dotcloud/docker-registry Dockerfile)
-RUN sed -i 's/main$/main universe/' /etc/apt/sources.list 
-RUN apt-get update
-RUN apt-get install -y git-core build-essential python-dev \
+RUN sed -i 's/main$/main universe/' /etc/apt/sources.list
+RUN apt-get update && apt-get install -y git-core build-essential python-dev \
     libevent-dev python-openssl liblzma-dev wget
 
 # install recent pip

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,22 +1,20 @@
-FROM deis/base
+FROM deis/base:latest
 MAINTAINER Gabriel Monroy <gabriel@opdemand.com>
 
-RUN apt-get update
-RUN apt-get install -yq patch libpcre3 libpcre3-dev libssl-dev libgeoip-dev
+RUN apt-get update && \
+    apt-get install -yq patch libpcre3 libpcre3-dev libssl-dev libgeoip-dev
 
 RUN wget -q http://nginx.org/download/nginx-1.6.0.tar.gz -O /tmp/nginx-1.6.0.tar.gz
 RUN wget -q https://github.com/yaoweibin/nginx_tcp_proxy_module/archive/v0.4.5.tar.gz -O /tmp/tcp-proxy.tar.gz
 
 WORKDIR /tmp
-
 RUN tar -xzf nginx-1.6.0.tar.gz
 RUN tar -xzf tcp-proxy.tar.gz
 
 WORKDIR /tmp/nginx-1.6.0
 RUN patch -p1 < /tmp/nginx_tcp_proxy_module-0.4.5/tcp.patch
 RUN ./configure --prefix=/var/lib/nginx --sbin-path=/usr/sbin/nginx --conf-path=/etc/nginx/nginx.conf --http-log-path=/var/log/nginx/access.log --error-log-path=/var/log/nginx/error.log --lock-path=/var/lock/nginx.lock --pid-path=/run/nginx.pid --http-client-body-temp-path=/var/lib/nginx/body --http-fastcgi-temp-path=/var/lib/nginx/fastcgi --http-proxy-temp-path=/var/lib/nginx/proxy --http-scgi-temp-path=/var/lib/nginx/scgi --http-uwsgi-temp-path=/var/lib/nginx/uwsgi --with-debug --with-pcre-jit --with-ipv6 --with-http_ssl_module --with-http_stub_status_module --with-http_realip_module --with-http_auth_request_module --with-http_addition_module --with-http_dav_module --with-http_geoip_module --with-http_gzip_static_module --with-http_spdy_module --with-http_sub_module --with-mail --with-mail_ssl_module --add-module=/tmp/nginx_tcp_proxy_module-0.4.5
-RUN make
-RUN make install
+RUN make && make install
 
 ADD . /app
 WORKDIR /app


### PR DESCRIPTION
Since Dockerfile layers are cached, having `apt-get update` as a separate
command creates the potential for a subsequent `apt-get install` to fail.
Best practices (other than "install from source") seem to be to make
both commands into a one-liner.

This PR ensures we don't `apt-get install` as its own command anywhere,
removes the installation of some packages that were already in deis/base,
and removes a redundant ENV DEBIAN_FRONTEND statement.

See also #1246 for discussion.
