### PR TITLE
fix(client): fixed issue with message when no cookies exist

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -360,7 +360,7 @@ class DeisClient(object):
         Dispatch an API request to the active Deis controller
         """
         func = getattr(self._session, method.lower())
-        controller = self._settings['controller']
+        controller = 'controller' in self._settings and self._settings['controller']
         if not controller:
             raise EnvironmentError(
                 'No active controller. Use `deis login` or `deis register` to get started.')


### PR DESCRIPTION
Fixed an issue where 'no active controller' message doesn't show if cookies don't already exist.

Relates to this issue: https://github.com/deis/deis/issues/325
