### PR TITLE
 fix(builder): ssh timeout to prevent intermediary firewalls/loadbalancers from dropping connection    

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -18,6 +18,9 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F9
 RUN apt-get update -qy
 RUN apt-get install -yq lxc-docker-1.0.0
 
+# 45 seconds ssh client keepalive, for intermediary firewalls/loadbalancers.
+RUN echo ClientAliveInterval 45 >> /etc/ssh/sshd_config
+
 # install recent pip
 RUN wget -qO- https://raw.githubusercontent.com/pypa/pip/1.5.5/contrib/get-pip.py | python -
 

--- a/docs/installing_deis/configure-load-balancers.rst
+++ b/docs/installing_deis/configure-load-balancers.rst
@@ -30,10 +30,9 @@ port 80 on all nodes in the Deis cluster. The health check endpoint returns an H
 the load balancer to serve trafic to whichever hosts happen to be running the deis-router component
 at any moment.
 
-.. note::
+SSH Keepalive Setting
+---------------------
 
-  Elastic load balancers on EC2 appear to have a default timeout of 60 seconds, which will disrupt
-  a ``git push`` when using Deis. Users can request an increased timeout from Amazon. More details
-  are in this AWS `support thread`_.
-
-.. _`support thread`: https://forums.aws.amazon.com/thread.jspa?messageID=423862
+Most Loadbalancers/Firewalls have a minimum timeout of 60 seconds. (eg AWS ELB has it at 60 seconds).
+The Deis-Builder is configured to have a SSH Keepalive every 45 seconds so the connection is kept open
+while the Builder is busy building things which can sometimes take a longer time.

--- a/spec/builder/deis_builder_spec.go
+++ b/spec/builder/deis_builder_spec.go
@@ -1,0 +1,30 @@
+package deis_builder_spec
+
+import (
+    . "/path/to/makefile"
+    . "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("SSH ClientAliveInterval 45", func() {
+  Context("When an intermediary is configured at 30 seconds timeout", func() {
+    /*
+      vagrant_firewall := setup_vagrant_firewall()
+      deis_cluster_behind_firewall := setup_deis_cluster_behind_firewall()
+      output_of_making_deis_builder_call := run_deis_builder_call()
+    */
+    It("should timeout with <error>", func() {
+      Expect(output_of_making_deis_builder_call).To(Fail)
+    })
+  })
+  Context("When an intermediary is configured at 60 seconds timeout", func() {
+    /*
+      vagrant_firewall := setup_vagrant_firewall()
+      deis_cluster_behind_firewall := setup_deis_cluster_behind_firewall()
+      output_of_making_deis_builder_call := run_deis_builder_call()
+    */
+
+    It("should be able to run a deis-builder push successfully", func() {
+      Expect(output_of_making_deis_builder_call).To(Pass)
+    })
+  })
+})


### PR DESCRIPTION
Currently the Deis-builder loses connection to cilents sometimes when there
are intermediaries that monitors the connection and drops it after a certain
interval (eg AWS Load Balancers have a 5 min timeout) while the Builder is
busy with some activities such as tarring a file etc.

This will ensure a ssh-keepalive is sent every minute to keep the connection
open.

TODO: Tests needs to be created with mock Firewalls in the middle that are
configured to drop connection as specific intervals, and we need to demonstrate
that the builder does not lose connection past those period when connected
to by a client.

Fixes #1046, #1195
