### PR TITLE
fix(controller/scheduler): only announce 'web' and 'cmd' processes

### DIFF
--- a/controller/scheduler/coreos.py
+++ b/controller/scheduler/coreos.py
@@ -59,9 +59,9 @@ class FleetClient(object):
 
         # only announce web and cmd processes
         if command.lower() in ['web', 'cmd']:
-          self._create_announcer(name, image, command, ANNOUNCE_TEMPLATE, env)
+            self._create_announcer(name, image, command, ANNOUNCE_TEMPLATE, env)
         else:
-          logger.info '-- skipping announcer for '+name+ '('+command+')'
+            logger.info '-- skipping announcer for '+name+ '('+command+')'
 
     def _create_container(self, name, image, command, template, env):
         l = locals().copy()


### PR DESCRIPTION
Currently the nginx routers gets announced all types of processes.
This causes problems as both non-web and web processes are mixed
together by the router. The router should only be serving 'web'
processes for buildpacks or 'cmd' processes for dockerfiles.

This fix stops announcing any processes that does not have '.web'
or '.cmd'.

TODO: test coverage missing.

closes #1256
