### PR TITLE
fix(travis-ci): update logger makefile target to "test-unit"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   - make -C controller flake8
   - make -C controller coverage
   - make -C docs
-  - make -C logger test
+  - make -C logger test-unit
 
 after_success:
   - cd controller && coveralls


### PR DESCRIPTION
The "make test" target in logger now runs functional tests as well,
requiring Docker. This was not the intention at Travis-ci.org, where
we want just unit tests.
