### PR TITLE
fix(coreOS): tcp timeout to prevent intermediary firewalls/loadbalancers...

### DIFF
--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -88,7 +88,11 @@ coreos:
       Type=oneshot
       ExecStartPre=/usr/bin/rm /home/core/.bashrc
       ExecStart=/usr/bin/ln -s /run/deis/.bashrc /home/core/.bashrc
+  - name: systemd-sysctl.service
+    command: restart
 write_files:
+  - path: /etc/sysctl.d/shorter-tcpkeepalive.conf
+    content: net.ipv4.tcp_keepalive_time=45
   - path: /etc/deis-release
     content: |
       DEIS_RELEASE=latest


### PR DESCRIPTION
The default tcp-keepalive on CoreOS is 7200seconds (2 hours), which is standard across linux.
This will change that to 45 seconds so that we send a tcp-keepalive packet through the connection
to prevent the intermediary from dropping the connection.

We saw occurances of this in the deis-builder when it makes a post request (#1275) to controller during
'launching...'.

NOTE: The cluster needs to be redeployed for this to work.

For Existing Clusters: Please follow these steps:
1. Login to each of the instances and run the following
       `sudo su -`
       create a new file called `/etc/sysctl.d/shorter-tcpkeepalive.conf` with this content:       `net.ipv4.tcp_keepalive_time = 45`
       `exit`
2. Restart the service:
       `sudo systemctl restart systemd-sysctl.service`

TODO: Add tests to check the tcp timeout is working.
