### PR TITLE
fix(scheduler/coreos): skip announcer containers for start, stop, destroy

### DIFF
--- a/controller/scheduler/mock.py
+++ b/controller/scheduler/mock.py
@@ -26,25 +26,25 @@ class MockSchedulerClient(object):
 
     # job api
 
-    def create(self, name, image, command):
+    def create(self, name, image, command, use_announcer):
         """
         Create a new job
         """
         return {'state': 'inactive'}
 
-    def start(self, name):
+    def start(self, name, use_announcer):
         """
         Start an idle job
         """
         return {'state': 'active'}
 
-    def stop(self, name):
+    def stop(self, name, use_announcer):
         """
         Stop a running job
         """
         return {'state': 'inactive'}
 
-    def destroy(self, name):
+    def destroy(self, name, use_announcer):
         """
         Destroy an existing job
         """


### PR DESCRIPTION
With #1269 we stopped creating announce containers except for web and cmd
types, but we still attempt to perform actions on them for start, stop,
and destroy. This commit adds logic to wrap all of these scheduler actions
in a conditional which skips (and logs) announce operations.

TESTING: rebuild the controller

``` console
$ make -C controller stop build start
```

Then, deploy an application which has either a cmd or web proctype, as
well as a non-standard type. I modified the Procfile for our
example-ruby-sinatra like so:

```
web: bundle exec ruby web.rb -p ${PORT:-5000}
clock: echo flava flavvvvvvv
```

Scale the app, start/stop processes, etc. You should see successful
operations for both, and note that the clock type has no announce
containers. The output of `deis ps` should always show them
as being up:

```
=== exotic-icehouse Processes

--- web:
web.1 up (v3)
web.2 up (v3)
web.3 up (v3)

--- clock:
clock.1 up (v3)
clock.2 up (v3)
clock.3 up (v3)
```

fixes #1273
closes #1275
