### PR TITLE
feat(controllers/Procfile) extend gunicorn timeout to 180 seconds

### DIFF
--- a/controller/Procfile
+++ b/controller/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn deis.wsgi -b 0.0.0.0:8000 -w 8 -n deis --log-level debug
+web: gunicorn deis.wsgi -b 0.0.0.0:8000 -w 8 -n deis --log-level debug -t 180


### PR DESCRIPTION
When performing some tasks that takes more than 30 seconds the
deis cli fails due timeout, extending to 3 minutes.
