### PR TITLE
fix(controller/procfiie): Removed Procfile as its not used anywhere

### DIFF
--- a/controller/Procfile
+++ b/controller/Procfile
@@ -1,1 +1,0 @@
-web: gunicorn deis.wsgi -b 0.0.0.0:8000 -w 8 -n deis --log-level debug


### PR DESCRIPTION
Tried building controller without the Procfile and it seems to run fine as we are not using Procfile as @bacongobbler pointed out.

closes #1292
