### PR TITLE
[WIP] fix(controller/supervisord): Supervisord to start deis-controller

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -27,8 +27,13 @@ RUN mkdir -p /templates && chown -R deis:deis /templates
 # create directory for logs
 RUN mkdir -p /var/log/deis && chown -R deis:deis /var/log/deis
 
+# Add supervisord in order to start the services
+RUN apt-get install -y supervisor && mkdir -p /var/log/supervisor
+ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
 # define execution environment
-CMD ["/app/bin/boot"]
+# CMD ["/app/bin/boot"]
+CMD ["/usr/bin/supervisord", "-n"]
 EXPOSE 8000
 
 # define work environment

--- a/controller/supervisord.conf
+++ b/controller/supervisord.conf
@@ -1,0 +1,14 @@
+[supervisord]
+nodaemon=true
+
+[program:celery]
+command=sudo -E -u deis celery worker --app=deis --loglevel=INFO --workdir=/app --pidfile=/tmp/celery.pid
+autorestart=true
+
+[program:gunicorn]
+command=sudo -E -u deis ./manage.py run_gunicorn -b 0.0.0.0 -w 8 -t 600 -n deis --log-level debug --pid=/tmp/gunicorn.pid --preload
+autorestart=true
+
+[program:confd]
+command=confd -node $ETCD -config-file /app/confd.toml
+autorestart=true


### PR DESCRIPTION
Currently the Deis Controller uses a bash file for startup. This doesn't deal with
issues when certain parts of the bash file breaks down. Instead this PR will aim to
work on building a [supervisord](supervisord.org) alternative that can monitor the processes (maybe 
using [superlance](http://superlance.readthedocs.org/en/latest/))

This is WIP and requires a lot of feedback. Trying to put together a supervisord.conf
file at first.

Closes #1306
