### PR TITLE
fix(controller): Determine registry address during start

### DIFF
--- a/builder/templates/builder
+++ b/builder/templates/builder
@@ -45,6 +45,7 @@ if __name__ == '__main__':
     # define image names
     tmp_image = "{app}:git-{short_sha}".format(**locals())
     target_image = "{{ .deis_registry_host }}:{{ .deis_registry_port }}/{app}".format(**locals())
+    image_reference = "{app}".format(**locals())
     for d in (cache_dir, build_dir):
         if not os.path.exists(d):
             os.mkdir(d)
@@ -117,7 +118,7 @@ if __name__ == '__main__':
         body['sha'] = sha
         body['receive_user'] = user
         body['receive_repo'] = app
-        body['image'] = target_image
+        body['image'] = image_reference
         # use sha of branch
         with open(os.path.join(repo_dir, branch)) as f:
             body['sha'] = f.read().strip('\n')

--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -60,3 +60,21 @@ write_files:
 
       # remove leading slash
       echo ${IMAGE#/}
+  - path: /run/deis/bin/determine_registry
+    permissions: 0755
+    content: |
+      #!/bin/bash
+      # usage: determine_registry <build_image>
+      REGISTRY_HOST=`etcdctl get /deis/registry/host 2>/dev/null`
+      if [ $? -ne 0 ]; then
+        echo "Can't find registry host in /deis/registry/host."
+        exit 1
+      fi
+
+      REGISTRY_PORT=`etcdctl get /deis/registry/port 2>/dev/null`
+      if [ $? -ne 0 ]; then
+        echo "Can't find registry port in /deis/registry/port."
+        exit 1
+      fi
+
+      echo $REGISTRY_HOST:$REGISTRY_PORT/$1

--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -469,8 +469,7 @@ class Release(UuidAuditedModel):
         new_version = self.version + 1
         tag = 'v{}'.format(new_version)
         release_image = '{}:{}'.format(self.app.id, tag)
-        target_image = '{}:{}/{}'.format(
-            settings.REGISTRY_HOST, settings.REGISTRY_PORT, self.app.id)
+        target_image = '{}'.format(self.app.id)
         # create new release and auto-increment version
         release = Release.objects.create(
             owner=user, app=self.app, config=config,

--- a/controller/api/tests/test_hooks.py
+++ b/controller/api/tests/test_hooks.py
@@ -116,7 +116,7 @@ class HookTest(TransactionTestCase):
         url = '/api/hooks/builds'.format(**locals())
         body = {'receive_user': 'autotest',
                 'receive_repo': app_id,
-                'image': 'registry.local:5000/{app_id}:v2'.format(**locals())}
+                'image': '{app_id}:v2'.format(**locals())}
         # post the build without a session
         self.assertIsNone(self.client.logout())
         response = self.client.post(url, json.dumps(body), content_type='application/json')
@@ -142,7 +142,7 @@ class HookTest(TransactionTestCase):
         SHA = 'ecdff91c57a0b9ab82e89634df87e293d259a3aa'
         body = {'receive_user': 'autotest',
                 'receive_repo': app_id,
-                'image': 'registry.local:5000/{app_id}:v2'.format(**locals()),
+                'image': '{app_id}:v2'.format(**locals()),
                 'sha': SHA,
                 'procfile': PROCFILE}
         # post the build without a session
@@ -191,7 +191,7 @@ class HookTest(TransactionTestCase):
         """
         body = {'receive_user': 'autotest',
                 'receive_repo': app_id,
-                'image': 'registry.local:5000/{app_id}:v2'.format(**locals()),
+                'image': '{app_id}:v2'.format(**locals()),
                 'sha': SHA,
                 'dockerfile': DOCKERFILE}
         # post the build without a session

--- a/controller/scheduler/coreos.py
+++ b/controller/scheduler/coreos.py
@@ -222,9 +222,9 @@ CONTAINER_TEMPLATE = """
 Description={name}
 
 [Service]
-ExecStartPre=/usr/bin/docker pull {image}
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/determine_registry {image}`; docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect {name} >/dev/null 2>&1 && docker rm -f {name} || true"
-ExecStart=/bin/sh -c "port=$(docker inspect -f '{{{{range $k, $v := .ContainerConfig.ExposedPorts }}}}{{{{$k}}}}{{{{end}}}}' {image} | cut -d/ -f1) ; docker run --name {name} -P -e PORT=$port {image} {command}"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/determine_registry {image}`; port=$(docker inspect -f '{{{{range $k, $v := .ContainerConfig.ExposedPorts }}}}{{{{$k}}}}{{{{end}}}}' $IMAGE | cut -d/ -f1) ; docker run --name {name} -P -e PORT=$port $IMAGE {command}"
 ExecStop=/usr/bin/docker rm -f {name}
 TimeoutStartSec=20m
 """


### PR DESCRIPTION
Before this change re-deploying apps failed when the registry was re-scheduled to a different instance in the cluster.

Fixes #1128
- [x] Store just the image name and tag in the build model
- [x] Prefix the image reference before fleet pulls the image
- [x] Prefix the image reference before controller pushes config changes to the registry
- [x] Allow to migrate from existing releases
- [x] Don't block #1412
