### PR TITLE
docs(client): the big docstring refactor

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -1099,7 +1099,7 @@ class DeisClient(object):
         """
         Sets environment variables for an application.
 
-        Usage: deis config:set <var>=<value>... [options]
+        Usage: deis config:set <var>=<value> [<var>=<value>...] [options]
 
         Arguments:
           <var>


### PR DESCRIPTION
This refactors the client docstrings such that they provide more useful information to the user. Please note that I also refactored how `clusters:create` is parsed as part of a nitpicking (breaking backwards compatibility for the command), but I can easily revert that if the change is unnecessary. This PR should be completely backwards compatible, save the `clusters:create` change.
