### PR TITLE
fix(controller): ignore KeyError when purging user from etcd

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -618,7 +618,12 @@ def _etcd_purge_key(**kwargs):
 
 def _etcd_purge_user(**kwargs):
     username = kwargs['instance'].username
-    _etcd_client.delete('/deis/builder/users/{}'.format(username), dir=True, recursive=True)
+    try:
+        _etcd_client.delete(
+            '/deis/builder/users/{}'.format(username), dir=True, recursive=True)
+    except KeyError:
+        # If _etcd_publish_key() wasn't called, there is no user dir to delete.
+        pass
 
 
 def _etcd_publish_domains(**kwargs):


### PR DESCRIPTION
Fixes #1239.

TESTING: Run `docker logs -f deis-controller` to watch for errors (since this happens in a Django signal handler, the client doesn't see it.) Create a user with `deis register`, cancel the user with `deis auth:cancel` without uploading a key, then re-register the same username. Ensure everything worked and that no errors appeared in the controller log.

We have a controller unit test that covers this exactly, but since it's isolated it stops short of interacting with the builder, and therefore succeeds. We will add an integration/regression test to #1237 before we let it be merged.
