### PR TITLE
fix(controller/registry): add old config vars

### DIFF
--- a/controller/registry/private.py
+++ b/controller/registry/private.py
@@ -151,7 +151,7 @@ def _construct_env(env, config):
         if k in config:
             # update values defined by config
             v = config.pop(k)
-            new_env.append("{}={}".format(k, v))
+        new_env.append("{}={}".format(k, v))
     # add other config ENV items
     for k, v in config.items():
         new_env.append("{}={}".format(k, v))


### PR DESCRIPTION
In child images, we weren't dumping the old config variables from previous images. This would fester and would run into issues such as environment variables going missing. Adding them back solves this issue.

closes #1326
