### PR TITLE
chore(coreos): upgrade to 379.3.0 and Docker 1.1.1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,12 +11,14 @@ else
   cpus = 1
 end
 
+COREOS_VERSION = "379.3.0"
+
 Vagrant.configure("2") do |config|
-  config.vm.box = "coreos-349.0.0"
-  config.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/349.0.0/coreos_production_vagrant.box"
+  config.vm.box = "coreos-#{COREOS_VERSION}"
+  config.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/#{COREOS_VERSION}/coreos_production_vagrant.box"
 
   config.vm.provider :vmware_fusion do |vb, override|
-    override.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/349.0.0/coreos_production_vagrant_vmware_fusion.box"
+    override.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/#{COREOS_VERSION}/coreos_production_vagrant_vmware_fusion.box"
   end
 
   config.vm.provider :virtualbox do |vb, override|

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -yq \
     openssh-server git \
     aufs-tools iptables lxc \
     curl \
-    lxc-docker-1.0.0
+    lxc-docker-1.1.1
 
 # configure ssh server
 RUN rm /etc/ssh/ssh_host_*

--- a/contrib/digitalocean/cloud-config.yml
+++ b/contrib/digitalocean/cloud-config.yml
@@ -15,7 +15,7 @@ coreos:
     - name: public.network
       content: |
         [Match]
-        Name=ens3
+        Name=eth0
 
         [Network]
         Address=PUBLIC_IP

--- a/contrib/digitalocean/coreos-setup-environment
+++ b/contrib/digitalocean/coreos-setup-environment
@@ -15,7 +15,7 @@ fi
 
 sed -i -e '/^COREOS_PUBLIC_IPV4=/d;/^COREOS_PRIVATE_IPV4=/d' $ENV
 
-COREOS_PUBLIC_IPV4=$(ip -4 -o addr show dev ens3 | awk '{ print $4; }' | cut -d / -f1)
+COREOS_PUBLIC_IPV4=$(ip -4 -o addr show dev eth0 | awk '{ print $4; }' | cut -d / -f1)
 COREOS_PRIVATE_IPV4=$(ip -4 -o addr show dev ens4v1 | awk '{ print $4; }' | cut -d / -f1)
 echo COREOS_PUBLIC_IPV4=$COREOS_PUBLIC_IPV4 >> $ENV
 echo COREOS_PRIVATE_IPV4=$COREOS_PRIVATE_IPV4 >> $ENV

--- a/contrib/digitalocean/update-coreos
+++ b/contrib/digitalocean/update-coreos
@@ -2,7 +2,7 @@
 
 set -e
 
-COREOS_VERSION=349.0.0
+COREOS_VERSION=379.3.0
 BASE_URL="http://storage.core-os.net/coreos/amd64-usr/$COREOS_VERSION"
 
 KERNEL="/boot/coreos/vmlinuz"

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -4,28 +4,28 @@
   "Mappings" : {
       "RegionMap" : {
           "ap-northeast-1" : {
-              "AMI" : "ami-253b7324"
+              "AMI" : "ami-d7dc8cd6"
           },
           "sa-east-1" : {
-              "AMI" : "ami-8fab0492"
+              "AMI" : "ami-0d329c10"
           },
           "ap-southeast-2" : {
-              "AMI" : "ami-9f0c68a5"
+              "AMI" : "ami-4d8fe877"
           },
           "ap-southeast-1" : {
-              "AMI" : "ami-ac1b44fe"
+              "AMI" : "ami-5695cc04"
           },
           "us-east-1" : {
-              "AMI" : "ami-820ff0ea"
+              "AMI" : "ami-3c66ab54"
           },
           "us-west-2" : {
-              "AMI" : "ami-7b8ff24b"
+              "AMI" : "ami-bbb9c08b"
           },
           "us-west-1" : {
-              "AMI" : "ami-ea5650af"
+              "AMI" : "ami-7d414238"
           },
           "eu-west-1" : {
-              "AMI" : "ami-a73bf2d0"
+              "AMI" : "ami-0573a472"
           }
       }
   },
@@ -182,7 +182,7 @@
         "UserData" : { "Fn::Base64": { "Fn::Join": [ "", [ ] ] } },
         "BlockDeviceMappings" : [
           {
-            "DeviceName" : "/dev/sda",
+            "DeviceName" : "/dev/xvda",
             "Ebs" : { "VolumeSize" : "100" }
           }
         ]


### PR DESCRIPTION
This also bumps Docker to 1.1.1

Depends on https://github.com/deis/base/pull/8, as etcd is now 0.4.5 in these images. 

NOTE: @robszumski said we won't get updated Rackspace images until the 23rd at the earliest, according to Rackspace... :(

TESTING: Choose a provisioner and deploy Deis like normal. If not on Vagrant, make sure you export `DEIS_HOSTS` so the Makefile can build builder remotely. Then, rebuild and restart the builder:

``` console
$ fleetctl stop deis-builder
$ make -C builder build
$ fleetctl start deis-builder
```

closes #1270 
closes #1331 
