### PR TITLE
fix(fleetctl.sh): clean up unitfiles from the filesystem

### DIFF
--- a/controller/scheduler/fleetctl.sh
+++ b/controller/scheduler/fleetctl.sh
@@ -15,3 +15,8 @@ fi
 
 # run the fleetctl command remotely
 ssh $SSH_OPTIONS core@$FLEETW_HOST fleetctl $@
+
+# clean up
+if [[ $FLEETW_UNIT ]]; then
+  ssh $SSH_OPTIONS core@$FLEETW_HOST "rm -f /home/core/$FLEETW_UNIT"
+fi


### PR DESCRIPTION
Once we submit them to fleet, we don't need them anymore.

I know this was an easy-fix, but it annoyed me so I fixed it.

TESTING: rebuild the controller, then scale an app and confirm that no files are in /home/core

``` console
$ make -C controller stop build start
```

closes #878
