### PR TITLE
fix(client): KeyError on cookie retrieval

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -368,7 +368,7 @@ class DeisClient(object):
         Dispatch an API request to the active Deis controller
         """
         func = getattr(self._session, method.lower())
-        controller = self._settings['controller']
+        controller = self._settings.get('controller')
         if not controller:
             raise EnvironmentError(
                 'No active controller. Use `deis login` or `deis register` to get started.')


### PR DESCRIPTION
Fixed an issue where 'no active controller' message didn't show if
cookies didn't already exist.

replaces #1254 
