### PR TITLE
fix(ssh/timeout): Turn off use_dns setting from CoreOS and Deis-Builder

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -11,10 +11,11 @@ RUN apt-get update && apt-get install -yq \
     curl \
     lxc-docker-1.0.0
 
-# configure ssh server
-RUN rm /etc/ssh/ssh_host_*
-RUN dpkg-reconfigure openssh-server
-RUN mkdir -p /var/run/sshd
+# configure ssh server, turn off dns-lookup
+RUN rm /etc/ssh/ssh_host_* && \
+    dpkg-reconfigure openssh-server && \
+    mkdir -p /var/run/sshd && \
+    echo "UseDNS no" >> /etc/ssh/sshd_config
 
 # install recent pip
 RUN wget -qO- https://raw.githubusercontent.com/pypa/pip/1.5.5/contrib/get-pip.py | python -

--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -79,6 +79,14 @@ coreos:
       ExecStartPre=/usr/bin/rm /home/core/.bashrc
       ExecStart=/usr/bin/ln -s /run/deis/.bashrc /home/core/.bashrc
 write_files:
+  - path: /etc/ssh/sshd_config
+    permissions: 0600
+    owner: root:root
+    content: |
+      # Use most defaults for sshd configuration.
+      UsePrivilegeSeparation sandbox
+      Subsystem sftp internal-sftp
+      UseDNS no
   - path: /etc/deis-release
     content: |
       DEIS_RELEASE=latest


### PR DESCRIPTION
Currently the CoreOS and Deis-Builder uses the default setting for ssh which has use_dns turned on.
This causes unnecessary DNS lookups which slows down the SSH connection.

This PR turns off the UseDNS in the CoreOS User-data and on the Deis-Builder Dockerfile.

fixes #1358
