### PR TITLE
feat(router) Avoid nginx 502, 503, 504 errors

### DIFF
--- a/router/templates/nginx.conf
+++ b/router/templates/nginx.conf
@@ -81,6 +81,8 @@ http {
             proxy_send_timeout          1200s;
             proxy_read_timeout          1200s;
 
+            proxy_next_upstream         error timeout http_502 http_503 http_504;
+
             add_header                  X-Deis-Upstream $upstream_addr;
 
             proxy_pass                  http://{{ Base $service.Key }};


### PR DESCRIPTION
By default `proxy_next_upstream` only will try to use other server from upstream pool in case of `error` and `timeout`. But if for some reason the backend server fails (like if it dies) this tells nginx to try to process the request in other server.
So in case that one server fail the header `X-Deis-Upstream` will show the retries:

```
X-Deis-Upstream: 10.0.1.10:49240, 10.0.1.10:49238
```
