### PR TITLE
chore(tests): update etcd versions in test-etcd Dockerfile

### DIFF
--- a/tests/etcdutils/Dockerfile
+++ b/tests/etcdutils/Dockerfile
@@ -6,12 +6,12 @@ RUN apt-get update -q && DEBIAN_FRONTEND=noninteractive apt-get install -qy wget
 RUN wget -qO- https://storage.googleapis.com/golang/go1.3.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:$PATH
 
-# Build etcd v0.4.3. Keep this in sync with Deis' CoreOS version.
-RUN git clone -b v0.4.3 -q https://github.com/coreos/etcd.git /opt/etcd
-RUN cd /opt/etcd && ./build
+# Build etcd v0.4.5. Keep this in sync with Deis' version.
+RUN git clone -q https://github.com/coreos/etcd.git /opt/etcd
+RUN cd /opt/etcd && git checkout -q v0.4.5 && ./build
 
-# Download latest stable etcdctl. Keep this in sync with Deis' CoreOS version.
-ADD https://s3-us-west-2.amazonaws.com/opdemand/etcdctl-v0.4.4 /usr/local/bin/etcdctl
+# Download latest stable etcdctl. Keep this in sync with Deis' version.
+ADD https://s3-us-west-2.amazonaws.com/opdemand/etcdctl-v0.4.5 /usr/local/bin/etcdctl
 RUN chmod +x /usr/local/bin/etcdctl
 
 EXPOSE 4001 7001


### PR DESCRIPTION
We should keep this in sync with the version in deis/base (which should generally match up with that in the CoreOS we're using). Currently that's v0.4.5.
