### PR TITLE
fix(Makefile): ignore status of data services in `make start`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,10 @@ start: check-fleet start-warning start-routers
 	@# registry logger cache database
 	$(call echo_yellow,"Waiting for deis-registry to start...")
 	$(FLEETCTL) start -no-block $(START_UNITS)
-	@until $(FLEETCTL) list-units | egrep -q "deis-registry.+(running|failed)"; \
+	@until $(FLEETCTL) list-units | egrep -q "deis-registry\..+(running|failed)"; \
 		do sleep 2; \
 			printf "\033[0;33mStatus:\033[0m "; $(FLEETCTL) list-units | \
-			grep "deis-registry" | awk '{printf "%-10s (%s)    \r", $$4, $$5}'; \
+			grep "deis-registry\." | awk '{printf "%-10s (%s)    \r", $$4, $$5}'; \
 			sleep 8; \
 		done
 	$(call check_for_errors)
@@ -96,10 +96,10 @@ start: check-fleet start-warning start-routers
 	@# controller
 	$(call echo_yellow,"Waiting for deis-controller to start...")
 	$(FLEETCTL) start -no-block controller/systemd/*
-	@until $(FLEETCTL) list-units | egrep -q "deis-controller.+(running|failed)"; \
+	@until $(FLEETCTL) list-units | egrep -q "deis-controller\..+(running|failed)"; \
 		do sleep 2; \
 			printf "\033[0;33mStatus:\033[0m "; $(FLEETCTL) list-units | \
-			grep "deis-controller" | awk '{printf "%-10s (%s)    \r", $$4, $$5}'; \
+			grep "deis-controller\." | awk '{printf "%-10s (%s)    \r", $$4, $$5}'; \
 			sleep 8; \
 		done
 	$(call check_for_errors)
@@ -107,10 +107,10 @@ start: check-fleet start-warning start-routers
 	@# builder
 	$(call echo_yellow,"Waiting for deis-builder to start...")
 	$(FLEETCTL) start -no-block builder/systemd/*.service
-	@until $(FLEETCTL) list-units | egrep -q "deis-builder.+(running|failed)"; \
+	@until $(FLEETCTL) list-units | egrep -q "deis-builder\..+(running|failed)"; \
 		do sleep 2; \
 			printf "\033[0;33mStatus:\033[0m "; $(FLEETCTL) list-units | \
-			grep "deis-builder" | awk '{printf "%-10s (%s)    \r", $$4, $$5}'; \
+			grep "deis-builder\." | awk '{printf "%-10s (%s)    \r", $$4, $$5}'; \
 			sleep 8; \
 		done
 	$(call check_for_errors)


### PR DESCRIPTION
The fleet status-matching regexes in the main Makefile didn't take
into account the addition of *-data.service jobs, and were therefore
reporting on both the status of deis-registry.service and
deis-registry-data.service. This commit appends a dot to each regex to
avoid matching the *-data.services.

TESTING: During `make run` or `make start` before this change, notice the overwritten characters in the `Status: activating (start-post)` lines of deis-registry that didn't happen when starting deis-router, since it has no data container. Or look at the [non-tty output here](http://ci.deis.io/view/pull-requests/job/test-smoke/75/console) in CI and notice output such as this:

```
fleetctl --strict-host-key-checking=false start -no-block registry/systemd/deis-registry.service logger/systemd/deis-logger.service cache/systemd/deis-cache.service database/systemd/deis-database.service
Triggered job deis-registry.service start
Triggered job deis-logger.service start
Triggered job deis-cache.service start
Triggered job deis-database.service start
[0;33mStatus:[0m active     (exited)    
activating (start-pre)    
[0;33mStatus:[0m active     (exited)    
activating (start-post)    
[0;33mStatus:[0m active     (exited)    
activating (start-post)    
```

After this change we should be polling only the 3 main services (deis-registry, deis-controller, deis-builder) and not conflating their output with that of deis-registry-data, deis-controller-data, and deis-builder-data. UI repaired.
