### PR TITLE
Make sure the output of fleetctl list-units stays constant across versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@
 
 include includes.mk
 
+list-units = list-units --fields unit,state,load,active,sub,desc,machine
+
 define check_for_errors
-	@if $(FLEETCTL) list-units -no-legend | awk '(($$2 == "launched") && ($$5 == "failed"))' | egrep -q "deis-.+service"; then \
+	@if $(FLEETCTL) $(list-units) -no-legend | awk '(($$2 == "launched") && ($$5 == "failed"))' | egrep -q "deis-.+service"; then \
 		echo "\033[0;31mOne or more services failed! Check which services by running 'make status'\033[0m" ; \
 		echo "\033[0;31mYou can get detailed output with 'fleetctl status deis-servicename.service'\033[0m" ; \
 		echo "\033[0;31mThis usually indicates an error with Deis - please open an issue on GitHub or ask for help in IRC\033[0m" ; \
@@ -14,7 +16,7 @@ define check_for_errors
 endef
 
 define deis_units
-	$(shell $(FLEETCTL) list-units -no-legend=true | \
+	$(shell $(FLEETCTL) $(list-units) -no-legend=true | \
 	  awk '($$2 ~ "$(1)" && ($$4 ~ "$(2)"))' | \
 	  sed -n 's/\(deis-.*\.service\).*/\1/p' | tr '\n' ' ')
 endef
@@ -48,7 +50,7 @@ install: check-fleet install-routers install-data-containers
 install-data-containers: check-fleet
 	@$(foreach T, $(DATA_CONTAINER_TEMPLATES), \
 		UNIT=`basename $(T)` ; \
-		if [[ `$(FLEETCTL) list-units | grep $$UNIT` ]]; then \
+		if [[ `$(FLEETCTL) $(list-units) | grep $$UNIT` ]]; then \
 		  echo $$UNIT already loaded. Skipping... ; \
 		else \
 			cp $(T).template . ; \
@@ -85,9 +87,9 @@ start: check-fleet start-warning start-routers
 	@# registry logger cache database
 	$(call echo_yellow,"Waiting for deis-registry to start...")
 	$(FLEETCTL) start -no-block $(START_UNITS)
-	@until $(FLEETCTL) list-units | egrep -q "deis-registry.+(running|failed)"; \
+	@until $(FLEETCTL) $(list-units) | egrep -q "deis-registry.+(running|failed)"; \
 		do sleep 2; \
-			printf "\033[0;33mStatus:\033[0m "; $(FLEETCTL) list-units | \
+			printf "\033[0;33mStatus:\033[0m "; $(FLEETCTL) $(list-units) | \
 			grep "deis-registry" | awk '{printf "%-10s (%s)    \r", $$4, $$5}'; \
 			sleep 8; \
 		done
@@ -96,9 +98,9 @@ start: check-fleet start-warning start-routers
 	@# controller
 	$(call echo_yellow,"Waiting for deis-controller to start...")
 	$(FLEETCTL) start -no-block controller/systemd/*
-	@until $(FLEETCTL) list-units | egrep -q "deis-controller.+(running|failed)"; \
+	@until $(FLEETCTL) $(list-units) | egrep -q "deis-controller.+(running|failed)"; \
 		do sleep 2; \
-			printf "\033[0;33mStatus:\033[0m "; $(FLEETCTL) list-units | \
+			printf "\033[0;33mStatus:\033[0m "; $(FLEETCTL) $(list-units) | \
 			grep "deis-controller" | awk '{printf "%-10s (%s)    \r", $$4, $$5}'; \
 			sleep 8; \
 		done
@@ -107,9 +109,9 @@ start: check-fleet start-warning start-routers
 	@# builder
 	$(call echo_yellow,"Waiting for deis-builder to start...")
 	$(FLEETCTL) start -no-block builder/systemd/*.service
-	@until $(FLEETCTL) list-units | egrep -q "deis-builder.+(running|failed)"; \
+	@until $(FLEETCTL) $(list-units) | egrep -q "deis-builder.+(running|failed)"; \
 		do sleep 2; \
-			printf "\033[0;33mStatus:\033[0m "; $(FLEETCTL) list-units | \
+			printf "\033[0;33mStatus:\033[0m "; $(FLEETCTL) $(list-units) | \
 			grep "deis-builder" | awk '{printf "%-10s (%s)    \r", $$4, $$5}'; \
 			sleep 8; \
 		done
@@ -120,9 +122,9 @@ start: check-fleet start-warning start-routers
 start-routers: check-fleet start-warning
 	$(call echo_yellow,"Waiting for 1 of $(DEIS_NUM_ROUTERS) deis-routers to start...")
 	$(foreach R,$(ROUTER_UNITS),$(FLEETCTL) start -no-block $(R);)
-	@until $(FLEETCTL) list-units | egrep -q "deis-router.+(running)"; \
+	@until $(FLEETCTL) $(list-units) | egrep -q "deis-router.+(running)"; \
 		do sleep 2; \
-			printf "\033[0;33mStatus:\033[0m "; $(FLEETCTL) list-units | \
+			printf "\033[0;33mStatus:\033[0m "; $(FLEETCTL) $(list-units) | \
 			grep "deis-router" | head -n 1 | \
 			awk '{printf "%-10s (%s)    \r", $$4, $$5}'; \
 			sleep 8; \
@@ -133,7 +135,7 @@ start-warning:
 	$(call echo_cyan,"Deis components may take a long time to start the first time they are initialized.")
 
 status: check-fleet
-	$(FLEETCTL) list-units
+	$(FLEETCTL) $(list-units)
 
 stop: check-fleet
 	$(FLEETCTL) stop -block-attempts=600 $(strip $(call deis_units,launched,active))


### PR DESCRIPTION
It seems that somewhere between fleetctl version 0.3.x to 0.5.0 the output format of fleetctl list-units was changed. Since this Makefile is depends on the output format, I've added --fields flag to make sure the output stays fixed across versions (as much as possible).
