### PR TITLE
fix(systemd units): Fix docker containers being orphaned

### DIFF
--- a/builder/systemd/deis-builder.service
+++ b/builder/systemd/deis-builder.service
@@ -10,6 +10,7 @@ ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder`; docker h
 ExecStartPre=/bin/sh -c "docker inspect deis-builder >/dev/null && docker rm -f deis-builder || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker run --name deis-builder --rm -p 2223:22 -e PUBLISH=22 -e HOST=$COREOS_PRIVATE_IPV4 -e PORT=2223 --volumes-from deis-builder-data --privileged $IMAGE"
 ExecStartPost=/bin/sh -c "echo 'Waiting for builder on 2223/tcp...' && until cat </dev/null>/dev/tcp/$COREOS_PRIVATE_IPV4/2223; do sleep 1; done"
+ExecStopPost=/usr/bin/docker stop deis-builder
 
 [Install]
 WantedBy=multi-user.target

--- a/cache/systemd/deis-cache.service
+++ b/cache/systemd/deis-cache.service
@@ -7,6 +7,7 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-cache >/dev/null && docker rm -f deis-cache || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache` && docker run --name deis-cache --rm -p 6379:6379 -e PUBLISH=6379 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
+ExecStopPost=/usr/bin/docker stop deis-cache
 
 [Install]
 WantedBy=multi-user.target

--- a/controller/systemd/deis-controller.service
+++ b/controller/systemd/deis-controller.service
@@ -9,6 +9,7 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-controller >/dev/null && docker rm -f deis-controller || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker run --name deis-controller --rm -p 8000:8000 -e PUBLISH=8000 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from=deis-logger $IMAGE"
+ExecStopPost=/usr/bin/docker stop deis-controller
 
 [Install]
 WantedBy=multi-user.target

--- a/database/systemd/deis-database.service
+++ b/database/systemd/deis-database.service
@@ -10,6 +10,7 @@ ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database`; docker 
 ExecStartPre=/bin/sh -c "docker inspect deis-database >/dev/null && docker rm -f deis-database || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker run --name deis-database --rm -p 5432:5432 -e PUBLISH=5432 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-database-data $IMAGE"
 ExecStop=/bin/bash -c "nsenter --pid --uts --mount --ipc --net --target $(docker inspect --format='{{ .State.Pid }}' deis-database) sudo service postgresql stop"
+ExecStopPost=/usr/bin/docker stop deis-database
 
 [Install]
 WantedBy=multi-user.target

--- a/logger/systemd/deis-logger.service
+++ b/logger/systemd/deis-logger.service
@@ -9,6 +9,7 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-logger >/dev/null && docker rm -f deis-logger || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker run --name deis-logger --rm -p 514:514/udp -e PUBLISH=514 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-logger-data $IMAGE"
+ExecStopPost=/usr/bin/docker stop deis-logger
 
 [Install]
 WantedBy=multi-user.target

--- a/registry/systemd/deis-registry.service
+++ b/registry/systemd/deis-registry.service
@@ -10,6 +10,7 @@ ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry`; docker 
 ExecStartPre=/bin/sh -c "docker inspect deis-registry >/dev/null && docker rm -f deis-registry || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docker run --name deis-registry --rm -p 5000:5000 -e PUBLISH=5000 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-registry-data $IMAGE"
 ExecStartPost=/bin/sh -c "echo 'Waiting for listener on 5000/tcp...' && until cat </dev/null>/dev/tcp/$COREOS_PRIVATE_IPV4/5000; do sleep 1; done && docker pull deis/slugrunner:latest && docker tag deis/slugrunner $COREOS_PRIVATE_IPV4:5000/deis/slugrunner && docker push $COREOS_PRIVATE_IPV4:5000/deis/slugrunner"
+ExecStopPost=/usr/bin/docker stop deis-registry
 
 [Install]
 WantedBy=multi-user.target

--- a/router/systemd/deis-router.service
+++ b/router/systemd/deis-router.service
@@ -7,6 +7,7 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-router >/dev/null && docker rm -f deis-router || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router` && docker run --name deis-router --rm -p 80:80 -p 2222:2222 -e PUBLISH=80 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
+ExecStopPost=/usr/bin/docker stop deis-router
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Docker seems to orphan our containers after the fix in [6b452e](https://github.com/deis/deis/commit/6b452e), this reverts part of it and properly signals the docker containers to stop. Given that we run them with `--rm`, this also makes the ephemeral containers destroy their data off of the drives. The data containers are not affected by this and they persist.

This closes #1378
