### PR TITLE
fix(Makefile): remove bashism in the main Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ install: check-fleet install-routers install-data-containers
 install-data-containers: check-fleet
 	@$(foreach T, $(DATA_CONTAINER_TEMPLATES), \
 		UNIT=`basename $(T)` ; \
-		if [[ `$(FLEETCTL) list-units | grep $$UNIT` ]]; then \
+		EXISTS=`$(FLEETCTL) list-units | grep $$UNIT` ; \
+		if [ "$$EXISTS" != "" ]; then \
 		  echo $$UNIT already loaded. Skipping... ; \
 		else \
 			cp $(T).template . ; \


### PR DESCRIPTION
Mac OSX's make has support for `[[`, Ubuntu's does not. This fix (as suggested and written up by @carmstrong in [a comment](https://github.com/deis/deis/pull/1380#issuecomment-49632570)) removed the  bashism in favor of a more compatible syntatic trick.
