### PR TITLE
fix(scheduler/coreos): bump wait_for_announcer timeout to 20minutes

### DIFF
--- a/controller/scheduler/coreos.py
+++ b/controller/scheduler/coreos.py
@@ -126,7 +126,8 @@ class FleetClient(object):
 
     def _wait_for_announcer(self, name, env):
         status = None
-        for _ in range(60):
+        # we bump to 20 minutes here to match the timeout on the router and in the app unit files
+        for _ in range(1200):
             status = subprocess.check_output(
                 "fleetctl.sh list-units | grep {name}-announce.service | awk '{{print $5}}'".format(**locals()),
                 shell=True, env=env).strip('\n')


### PR DESCRIPTION
This needs to match the timeout on both the announce template and the
router. This value is currently 20 minutes.
