### PR TITLE
Add new t2 instance types for AWS EC2

### DIFF
--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -34,7 +34,7 @@
       "Description" : "EC2 instance type (m1.small, etc).",
       "Type" : "String",
       "Default" : "m3.large",
-      "AllowedValues" : [ "t1.micro","m1.small","m1.medium","m1.large","m1.xlarge", "m3.medium", "m3.large", "m3.xlarge", "m3.2xlarge", "m2.xlarge","m2.2xlarge","m2.4xlarge","c1.medium","c1.xlarge","cc1.4xlarge","cc2.8xlarge","cg1.4xlarge", "hi1.4xlarge", "hs1.8xlarge"],
+      "AllowedValues" : [ "t1.micro","t2.micro","t2.small","t2.medium","m1.small","m1.medium","m1.large","m1.xlarge", "m3.medium", "m3.large", "m3.xlarge", "m3.2xlarge", "m2.xlarge","m2.2xlarge","m2.4xlarge","c1.medium","c1.xlarge","cc1.4xlarge","cc2.8xlarge","cg1.4xlarge", "hi1.4xlarge", "hs1.8xlarge"],
       "ConstraintDescription" : "must be a valid EC2 instance type."
     },
     "ClusterSize": {


### PR DESCRIPTION
I think there are other instance types missing but I think t2.micro will be a common use-case for users trying out deis on the cheap (eg. me).
