### PR TITLE
fix(registry): use confd templated config

### DIFF
--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -28,7 +28,7 @@ RUN pip install /docker-registry/depends/docker-registry-core
 # Install registry
 RUN pip install file:///docker-registry#egg=docker-registry[bugsnag]
 
-ENV DOCKER_REGISTRY_CONFIG /docker-registry/config/config_sample.yml
+ENV DOCKER_REGISTRY_CONFIG /docker-registry/config/config.yml
 ENV SETTINGS_FLAVOR dev
 
 # create data volume

--- a/registry/templates/config.yml
+++ b/registry/templates/config.yml
@@ -1,26 +1,62 @@
 # The `common' part is automatically included (and possibly overriden by all
 # other flavors)
-common:
-    # Bucket for storage
-    boto_bucket: REPLACEME
+common: &common
+    # Default log level is info
+    loglevel: _env:LOGLEVEL:info
+    # By default, the registry acts standalone (eg: doesn't query the index)
+    standalone: _env:STANDALONE:true
+    # The default endpoint to use (if NOT standalone) is index.docker.io
+    index_endpoint: _env:INDEX_ENDPOINT:https://index.docker.io
+    # Storage redirect is disabled
+    storage_redirect: _env:STORAGE_REDIRECT
+    # Token auth is enabled (if NOT standalone)
+    disable_token_auth: _env:DISABLE_TOKEN_AUTH
+    # No priv key
+    privileged_key: _env:PRIVILEGED_KEY
+    # No search backend
+    search_backend: _env:SEARCH_BACKEND
+    # SQLite search backend
+    sqlalchemy_index_database: _env:SQLALCHEMY_INDEX_DATABASE:sqlite:////tmp/docker-registry.db
 
-    # Google Cloud Storage Configuration
-    # See:
-    # https://developers.google.com/storage/docs/reference/v1/getting-startedv1#keys
-    # for details on access and secret keys.
-    gs_access_key: REPLACEME
-    gs_secret_key: REPLACEME
-    gs_secure: REPLACEME
+    # Mirroring is not enabled
+    mirroring:
+        source: _env:MIRROR_SOURCE # https://registry-1.docker.io
+        source_index: _env:MIRROR_SOURCE_INDEX # https://index.docker.io
+        tags_cache_ttl: _env:MIRROR_TAGS_CACHE_TTL:172800 # seconds
 
-    # Set a random string here
-    secret_key: {{ .deis_registry_secretKey }}
+    # cache:
+    #     host: _env:CACHE_REDIS_HOST:localhost
+    #     port: _env:CACHE_REDIS_PORT:6379
+    #     db: 0
+    #     password: _env:CACHE_REDIS_PASSWORD
 
+    # Enabling LRU cache for small files
+    # This speeds up read/write on small files
+    # when using a remote storage backend (like S3).
+    # cache_lru:
+    #     host: _env:CACHE_LRU_REDIS_HOST:localhost
+    #     port: _env:CACHE_LRU_REDIS_PORT:6379
+    #     db: 0
+    #     password: _env:CACHE_LRU_REDIS_PASSWORD
+
+    # Enabling these options makes the Registry send an email on each code Exception
+    email_exceptions:
+        smtp_host: _env:SMTP_HOST
+        smtp_port: _env:SMTP_PORT:25
+        smtp_login: _env:SMTP_LOGIN
+        smtp_password: _env:SMTP_PASSWORD
+        smtp_secure: _env:SMTP_SECURE:false
+        from_addr: _env:SMTP_FROM_ADDR:docker-registry@localdomain.local
+        to_addr: _env:SMTP_TO_ADDR:noise+dockerregistry@localdomain.local
+
+    # Enable bugsnag (set the API key)
+    bugsnag: _env:BUGSNAG
 
 # This is the default configuration when no flavor is specified
 dev:
+    <<: *common
     storage: local
     storage_path: /data
-    loglevel: info
 
 {{ if .deis_registry_s3accessKey }}
 # To specify another flavor, set the environment variable SETTINGS_FLAVOR


### PR DESCRIPTION
A regression from #1190 was introduced where the config file used
was the sample that came from dotcloud/docker-registry instead of
using the confd templated config we use today. Updating the file
to upstream's changes with the common flavor as well as changing
the reference to the file in the Dockerfile fixes this regression.
