### PR TITLE
fix(client): print default string

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -1493,7 +1493,10 @@ class DeisClient(object):
         else:
             body = {}
         url = "/api/apps/{app}/releases/rollback".format(**locals())
-        sys.stdout.write('Rolling back to v{version}... '.format(**locals()))
+        if version:
+            sys.stdout.write('Rolling back to v{version}... '.format(**locals()))
+        else:
+            sys.stdout.write('Rolling back one release... ')
         sys.stdout.flush()
         try:
             progress = TextProgress()


### PR DESCRIPTION
When version is not specified in the arguments, you'd get a response:

```
$ deis rollback
Rolling back to vNone...
```

This makes it print a default string if no version is specified.
