### PR TITLE
fix(Makefile): remove redundant command parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ install-data-containers: check-fleet
 			cp $(T).template . ; \
 			NEW_FILENAME=`ls *.template | sed 's/\.template//g'`; \
 			mv *.template $$NEW_FILENAME ; \
-			MACHINE_ID=`$(FLEETCTL) list-machines --no-legend --full list-machines | awk 'BEGIN { OFS="\t"; srand() } { print rand(), $$1 }' | sort -n | cut -f2- | head -1` ; \
+			MACHINE_ID=`$(FLEETCTL) list-machines --no-legend --full | awk 'BEGIN { OFS="\t"; srand() } { print rand(), $$1 }' | sort -n | cut -f2- | head -1` ; \
 			sed -e "s/CHANGEME/$$MACHINE_ID/" $$NEW_FILENAME > $$NEW_FILENAME.bak ; \
 			rm -f $$NEW_FILENAME ; \
 			mv $$NEW_FILENAME.bak $$NEW_FILENAME ; \


### PR DESCRIPTION
Fixes a benign typo in the Makefile.

``` console
gradishar:deis matt$ fleetctl list-machines --no-legend --full list-machines
6c3c799c74cf4a4aac39004149b50cf9    172.17.8.102    -
c32f3d6d37b54c7e8059755952cce476    172.17.8.104    -
c41100bfb86b4c2580e7c6089eabae48    172.17.8.103    -
e43e5bd63a2a4b608cec52928be076c8    172.17.8.101    -
gradishar:deis matt$ fleetctl list-machines --no-legend --full
6c3c799c74cf4a4aac39004149b50cf9    172.17.8.102    -
c32f3d6d37b54c7e8059755952cce476    172.17.8.104    -
c41100bfb86b4c2580e7c6089eabae48    172.17.8.103    -
e43e5bd63a2a4b608cec52928be076c8    172.17.8.101    -
```
