### PR TITLE
fix(logger): add back message tag

### DIFF
--- a/logger/syslog/filehandler_test.go
+++ b/logger/syslog/filehandler_test.go
@@ -1,36 +1,36 @@
 package syslog
 
 import (
-    "testing"
-    "time"
+	"testing"
+	"time"
 )
 
-type TestLogger struct {}
+type TestLogger struct{}
 
-func (tl TestLogger) Print(...interface{}) {}
+func (tl TestLogger) Print(...interface{})                   {}
 func (tl TestLogger) Printf(format string, v ...interface{}) {}
-func (tl TestLogger) Println(...interface{}) {}
+func (tl TestLogger) Println(...interface{})                 {}
 
 func TestNewFileHandler(t *testing.T) {
-    fh := NewFileHandler("", 1, func (m *Message) bool {return true}, true)
-    if fh == nil {
-        t.Errorf("expected filehandler, got nil")
-    }
+	fh := NewFileHandler("", 1, func(m *Message) bool { return true }, true)
+	if fh == nil {
+		t.Errorf("expected filehandler, got nil")
+	}
 }
 
 func TestSetLogger(t *testing.T) {
-    tl := TestLogger{}
-    fh := NewFileHandler("", 1, func (m *Message) bool {return true}, true)
-    fh.SetLogger(tl)
-    if fh.l != tl {
-        t.Errorf("expected the logger to be set")
-    }
+	tl := TestLogger{}
+	fh := NewFileHandler("", 1, func(m *Message) bool { return true }, true)
+	fh.SetLogger(tl)
+	if fh.l != tl {
+		t.Errorf("expected the logger to be set")
+	}
 }
 
 func TestHandle(t *testing.T) {
-    fh := NewFileHandler("/tmp/test", 1, func (m *Message) bool {return true}, true)
-    handle := fh.Handle(&Message{time.Now(), nil, 0, 0, time.Now(), "localhost", "test", "message", "", ""})
-    if handle == nil {
-        t.Errorf("expected a handle, got nil")
-    }
+	fh := NewFileHandler("/tmp/test", 1, func(m *Message) bool { return true }, true)
+	handle := fh.Handle(&Message{time.Now(), nil, 0, 0, time.Now(), "localhost", "test", "message", "", ""})
+	if handle == nil {
+		t.Errorf("expected a handle, got nil")
+	}
 }

--- a/logger/syslog/message.go
+++ b/logger/syslog/message.go
@@ -36,9 +36,10 @@ func (m *Message) NetSrc() string {
 func (m *Message) String() string {
 	timeLayout := "2006-01-02 15:04:05"
 	return fmt.Sprintf(
-		"%s %s %s",
+		"%s %s %s%s",
 		m.Time.Format(timeLayout),
 		m.Hostname,
+		m.Tag,
 		m.Content,
 	)
 }

--- a/logger/syslog/message_test.go
+++ b/logger/syslog/message_test.go
@@ -1,80 +1,80 @@
 package syslog
 
 import (
-    "net"
-    "testing"
-    "time"
+	"net"
+	"testing"
+	"time"
 )
 
 func TestMessageNetSrc(t *testing.T) {
-    tcpAddress, err := net.ResolveTCPAddr("tcp", "localhost:1234")
+	tcpAddress, err := net.ResolveTCPAddr("tcp", "localhost:1234")
 
-    if err != nil {
-        t.Errorf("could not resolve TCP address")
-    }
+	if err != nil {
+		t.Errorf("could not resolve TCP address")
+	}
 
-    m := &Message{time.Now(), tcpAddress, 0, 0, time.Now(), "", "", "", "", ""}
-    if m.NetSrc() != "127.0.0.1" {
-        t.Errorf("expected 127.0.0.1, got ", m.NetSrc())
-    }
+	m := &Message{time.Now(), tcpAddress, 0, 0, time.Now(), "", "", "", "", ""}
+	if m.NetSrc() != "127.0.0.1" {
+		t.Errorf("expected 127.0.0.1, got ", m.NetSrc())
+	}
 
-    udpAddress, err := net.ResolveUDPAddr("udp", "localhost:1234")
+	udpAddress, err := net.ResolveUDPAddr("udp", "localhost:1234")
 
-    if err != nil {
-        t.Errorf("could not resolve UDP address")
-    }
+	if err != nil {
+		t.Errorf("could not resolve UDP address")
+	}
 
-    m.Source = udpAddress
-    if m.NetSrc() != "127.0.0.1" {
-        t.Errorf("expected 127.0.0.1, got ", m.NetSrc())
-    }
+	m.Source = udpAddress
+	if m.NetSrc() != "127.0.0.1" {
+		t.Errorf("expected 127.0.0.1, got ", m.NetSrc())
+	}
 
-    unixAddress, err := net.ResolveUnixAddr("unix", "/tmp/str")
+	unixAddress, err := net.ResolveUnixAddr("unix", "/tmp/str")
 
-    if err != nil {
-        t.Errorf("could not resolve unix address")
-    }
+	if err != nil {
+		t.Errorf("could not resolve unix address")
+	}
 
-    m.Source = unixAddress
-    if m.NetSrc() != "/tmp/str" {
-        t.Errorf("expected /tmp/str, got ", m.NetSrc())
-    }
+	m.Source = unixAddress
+	if m.NetSrc() != "/tmp/str" {
+		t.Errorf("expected /tmp/str, got ", m.NetSrc())
+	}
 
-    unknownAddress, err := net.ResolveIPAddr("ip4", "localhost")
+	unknownAddress, err := net.ResolveIPAddr("ip4", "localhost")
 
-    if err != nil {
-        t.Errorf("could not resolve unknown address")
-    }
+	if err != nil {
+		t.Errorf("could not resolve unknown address")
+	}
 
-    m.Source = unknownAddress
-    if m.NetSrc() != "127.0.0.1" {
-        t.Errorf("expected 127.0.0.1, got ", m.NetSrc())
-    }
+	m.Source = unknownAddress
+	if m.NetSrc() != "127.0.0.1" {
+		t.Errorf("expected 127.0.0.1, got ", m.NetSrc())
+	}
 }
 
 func TestMessageFormat(t *testing.T) {
-    tcpAddress, err := net.ResolveTCPAddr("tcp", "localhost:1234")
+	tcpAddress, err := net.ResolveTCPAddr("tcp", "localhost:1234")
 
-    if err != nil {
-        t.Errorf("could not resolve TCP address")
-    }
+	if err != nil {
+		t.Errorf("could not resolve TCP address")
+	}
 
-    m := &Message{
-        time.Now(),
-        tcpAddress,
-        0,
-        0,
-        time.Now(),
-        "localhost",
-        "TEST",
-        "hello world",
-        "",
-        "",
-    }
+	m := &Message{
+		time.Now(),
+		tcpAddress,
+		0,
+		0,
+		time.Now(),
+		"localhost",
+		"TEST",
+		"hello world",
+		"",
+		"",
+	}
 
-    timeLayout := "2006-01-02 15:04:05"
-    expectedOutput := m.Time.Format(timeLayout) + " localhost hello world"
-    if m.String() != expectedOutput {
-        t.Errorf("expected '" + expectedOutput + "', got '" + m.String() + "'.")
-    }
+	timeLayout := "2006-01-02 15:04:05"
+	expectedOutput := m.Time.Format(timeLayout) + " localhost TESThello world"
+	if m.String() != expectedOutput {
+		t.Errorf("expected '" + expectedOutput + "', got '" + m.String() + "'.")
+	}
 }

--- a/logger/syslog/priority_test.go
+++ b/logger/syslog/priority_test.go
@@ -1,27 +1,27 @@
 package syslog
 
 import (
-    "testing"
+	"testing"
 )
 
 func TestFacilityToString(t *testing.T) {
-    var fac Facility = 100
-    if fac.String() != "unknown" {
-        t.Errorf("facility != unknown; got %s", fac.String())
-    }
-    fac = 20
-    if fac.String() != "local4" {
-        t.Errorf("facility != local4; got %s", fac.String())
-    }
+	var fac Facility = 100
+	if fac.String() != "unknown" {
+		t.Errorf("facility != unknown; got %s", fac.String())
+	}
+	fac = 20
+	if fac.String() != "local4" {
+		t.Errorf("facility != local4; got %s", fac.String())
+	}
 }
 
 func TestSeverityToString(t *testing.T) {
-    var sev Severity = 100
-    if sev.String() != "unknown" {
-        t.Errorf("severity != unknown; got %s", sev.String())
-    }
-    sev = 5
-    if sev.String() != "notice" {
-        t.Errorf("severity != local4; got %s", sev.String())
-    }
+	var sev Severity = 100
+	if sev.String() != "unknown" {
+		t.Errorf("severity != unknown; got %s", sev.String())
+	}
+	sev = 5
+	if sev.String() != "notice" {
+		t.Errorf("severity != local4; got %s", sev.String())
+	}
 }


### PR DESCRIPTION
without the tag, the first word from the logs was missing.

Without this change:

```
2014-07-23 16:29:05 oblong-duckling[worker.1]:  world
```

with this change:

```
2014-07-23 16:38:19 oblong-duckling[worker.1]: hello world
```

closes #1400

I also formatted the logger module correctly with `go fmt`.
