### PR TITLE
fix(*): etcdctl and docker history commands eat error output

### DIFF
--- a/builder/bin/boot
+++ b/builder/bin/boot
@@ -17,7 +17,7 @@ export ETCD_TTL=${ETCD_TTL:-10}
 export STORAGE_DRIVER=${STORAGE_DRIVER:-btrfs}
 
 # wait for etcd to be available
-until etcdctl --no-sync -C $ETCD ls >/dev/null; do
+until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do
 	echo "waiting for etcd at $ETCD..."
 	sleep $(($ETCD_TTL/2))  # sleep for half the TTL
 done

--- a/builder/systemd/deis-builder.service
+++ b/builder/systemd/deis-builder.service
@@ -6,8 +6,8 @@ After=deis-builder-data.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-builder >/dev/null && docker rm -f deis-builder || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder`; docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-builder >/dev/null 2>&1 && docker rm -f deis-builder || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker run --name deis-builder --rm -p 2223:22 -e PUBLISH=22 -e HOST=$COREOS_PRIVATE_IPV4 -e PORT=2223 --volumes-from deis-builder-data --privileged $IMAGE"
 ExecStartPost=/bin/sh -c "echo 'Waiting for builder on 2223/tcp...' && until cat </dev/null>/dev/tcp/$COREOS_PRIVATE_IPV4/2223; do sleep 1; done"
 ExecStopPost=/usr/bin/docker stop deis-builder

--- a/cache/bin/boot
+++ b/cache/bin/boot
@@ -16,7 +16,7 @@ export ETCD_PATH=${ETCD_PATH:-/deis/cache}
 export ETCD_TTL=${ETCD_TTL:-10}
 
 # wait for etcd to be available
-until etcdctl --no-sync -C $ETCD ls >/dev/null; do
+until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do
 	echo "waiting for etcd at $ETCD..."
 	sleep $(($ETCD_TTL/2))  # sleep for half the TTL
 done

--- a/cache/systemd/deis-cache.service
+++ b/cache/systemd/deis-cache.service
@@ -4,8 +4,8 @@ Description=deis-cache
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-cache >/dev/null && docker rm -f deis-cache || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache`; docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-cache >/dev/null 2>&1 && docker rm -f deis-cache || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache` && docker run --name deis-cache --rm -p 6379:6379 -e PUBLISH=6379 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStopPost=/usr/bin/docker stop deis-cache
 

--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -96,11 +96,11 @@ write_files:
     content: |
       #!/bin/bash
       # usage: get_image <component_path>
-      IMAGE=`etcdctl get $1/image`
+      IMAGE=`etcdctl get $1/image 2>/dev/null`
 
       # if no image was set in etcd, we use the default plus the release string
       if [ $? -ne 0 ]; then
-        RELEASE=`etcdctl get /deis/release`
+        RELEASE=`etcdctl get /deis/release 2>/dev/null`
 
         # if no release was set in etcd, use the default provisioned with the server
         if [ $? -ne 0 ]; then

--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -16,7 +16,7 @@ export ETCD_PATH=${ETCD_PATH:-/deis/controller}
 export ETCD_TTL=${ETCD_TTL:-10}
 
 # wait for etcd to be available
-until etcdctl --no-sync -C $ETCD ls >/dev/null; do
+until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do
 	echo "waiting for etcd at $ETCD..."
 	sleep $(($ETCD_TTL/2))  # sleep for half the TTL
 done

--- a/controller/systemd/deis-controller.service
+++ b/controller/systemd/deis-controller.service
@@ -6,8 +6,8 @@ After=deis-logger.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-controller >/dev/null && docker rm -f deis-controller || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller`; docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-controller >/dev/null 2>&1 && docker rm -f deis-controller || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker run --name deis-controller --rm -p 8000:8000 -e PUBLISH=8000 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from=deis-logger $IMAGE"
 ExecStopPost=/usr/bin/docker stop deis-controller
 

--- a/database/bin/boot
+++ b/database/bin/boot
@@ -23,7 +23,7 @@ if [[ ! -d /var/lib/postgresql/9.3/main ]]; then
 fi
 
 # wait for etcd to be available
-until etcdctl --no-sync -C $ETCD ls >/dev/null; do
+until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do
 	echo "waiting for etcd at $ETCD..."
 	sleep $(($ETCD_TTL/2))  # sleep for half the TTL
 done

--- a/database/systemd/deis-database.service
+++ b/database/systemd/deis-database.service
@@ -6,8 +6,8 @@ After=deis-database-data.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-database >/dev/null && docker rm -f deis-database || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database`; docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-database >/dev/null 2>&1 && docker rm -f deis-database || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker run --name deis-database --rm -p 5432:5432 -e PUBLISH=5432 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-database-data $IMAGE"
 ExecStop=/bin/bash -c "nsenter --pid --uts --mount --ipc --net --target $(docker inspect --format='{{ .State.Pid }}' deis-database) sudo service postgresql stop"
 ExecStopPost=/usr/bin/docker stop deis-database

--- a/logger/systemd/deis-logger.service
+++ b/logger/systemd/deis-logger.service
@@ -6,8 +6,8 @@ After=deis-logger-data.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-logger >/dev/null && docker rm -f deis-logger || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger`; docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-logger >/dev/null 2>&1 && docker rm -f deis-logger || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker run --name deis-logger --rm -p 514:514/udp -e PUBLISH=514 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-logger-data $IMAGE"
 ExecStopPost=/usr/bin/docker stop deis-logger
 

--- a/registry/bin/boot
+++ b/registry/bin/boot
@@ -19,7 +19,7 @@ export ETCD_TTL=${ETCD_TTL:-10}
 export REGISTRY_PORT=${PORT:-5000}
 
 # wait for etcd to be available
-until etcdctl --no-sync -C $ETCD ls >/dev/null; do
+until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do
 	echo "waiting for etcd at $ETCD..."
 	sleep $(($ETCD_TTL/2))  # sleep for half the TTL
 done

--- a/registry/systemd/deis-registry.service
+++ b/registry/systemd/deis-registry.service
@@ -6,8 +6,8 @@ After=deis-registry-data.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-registry >/dev/null && docker rm -f deis-registry || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry`; docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-registry >/dev/null 2>&1 && docker rm -f deis-registry || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docker run --name deis-registry --rm -p 5000:5000 -e PUBLISH=5000 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-registry-data $IMAGE"
 ExecStartPost=/bin/sh -c "echo 'Waiting for listener on 5000/tcp...' && until cat </dev/null>/dev/tcp/$COREOS_PRIVATE_IPV4/5000; do sleep 1; done && docker pull deis/slugrunner:latest && docker tag deis/slugrunner $COREOS_PRIVATE_IPV4:5000/deis/slugrunner && docker push $COREOS_PRIVATE_IPV4:5000/deis/slugrunner"
 ExecStopPost=/usr/bin/docker stop deis-registry

--- a/router/bin/boot
+++ b/router/bin/boot
@@ -16,7 +16,7 @@ export ETCD_PATH=${ETCD_PATH:-/deis/router/$HOST}
 export ETCD_TTL=${ETCD_TTL:-10}
 
 # wait for etcd to be available
-until etcdctl --no-sync -C $ETCD ls >/dev/null; do
+until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do
     echo "waiting for etcd at $ETCD..."
     sleep $(($ETCD_TTL/2))  # sleep for half the TTL
 done

--- a/router/systemd/deis-router.service
+++ b/router/systemd/deis-router.service
@@ -4,8 +4,8 @@ Description=deis-router
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-router >/dev/null && docker rm -f deis-router || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router`; docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-router >/dev/null 2>&1 && docker rm -f deis-router || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router` && docker run --name deis-router --rm -p 80:80 -p 2222:2222 -e PUBLISH=80 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStopPost=/usr/bin/docker stop deis-router
 


### PR DESCRIPTION
These errors are benign, but confusing to new users.

TESTING: reprovision a cluster (due to changes in cloud config), build
components from source, `make run`, and ensure that there are no
confusing errors in the output

``` console
$ vagrant destroy -f && vagrant up
$ make build run
```

```
$ fleetctl status deis-router.1
< snipped... >
Jul 23 19:18:53 deis-1 systemd[1]: Starting deis-router...
Jul 23 19:18:54 deis-1 systemd[1]: Started deis-router.
Jul 23 19:19:06 deis-1 sh[4546]: router: waiting for confd to write initial templates...
Jul 23 19:19:11 deis-1 sh[4546]: Starting Nginx...
Jul 23 19:19:11 deis-1 sh[4546]: deis-router running...
```

closes #1399
