### PR TITLE
fix(scheduler/container): Ephemeral Containers for Applications

### DIFF
--- a/builder/templates/builder
+++ b/builder/templates/builder
@@ -72,9 +72,9 @@ if __name__ == '__main__':
         # some applications do not have a Procfile, so only check for a Dockerfile
         if not os.path.exists(dockerfile):
             if os.path.exists('/buildpacks'):
-                build_cmd = "docker run -i -a stdin {config_env} -v {cache_dir}:/tmp/cache:rw -v /buildpacks:/tmp/buildpacks deis/slugbuilder".format(**locals())
+                build_cmd = "docker run --rm -i -a stdin {config_env} -v {cache_dir}:/tmp/cache:rw -v /buildpacks:/tmp/buildpacks deis/slugbuilder".format(**locals())
             else:
-                build_cmd = "docker run -i -a stdin {config_env} -v {cache_dir}:/tmp/cache:rw deis/slugbuilder".format(**locals())
+                build_cmd = "docker run --rm -i -a stdin {config_env} -v {cache_dir}:/tmp/cache:rw deis/slugbuilder".format(**locals())
             # run slugbuilder in the background
             p = subprocess.Popen("git archive {branch} | ".format(**locals()) + build_cmd, shell=True, cwd=repo_dir, stdout=subprocess.PIPE)
             container = p.stdout.read().strip('\n')

--- a/controller/scheduler/coreos.py
+++ b/controller/scheduler/coreos.py
@@ -224,8 +224,7 @@ Description={name}
 [Service]
 ExecStartPre=/usr/bin/docker pull {image}
 ExecStartPre=/bin/sh -c "docker inspect {name} >/dev/null 2>&1 && docker rm -f {name} || true"
-ExecStart=/bin/sh -c "port=$(docker inspect -f '{{{{range $k, $v := .ContainerConfig.ExposedPorts }}}}{{{{$k}}}}{{{{end}}}}' {image} | cut -d/ -f1) ; docker run --name {name} -P -e PORT=$port {image} {command}"
-ExecStop=/usr/bin/docker rm -f {name}
+ExecStart=/bin/sh -c "port=$(docker inspect -f '{{{{range $k, $v := .ContainerConfig.ExposedPorts }}}}{{{{$k}}}}{{{{end}}}}' {image} | cut -d/ -f1) ; docker run  --rm --name {name} -P -e PORT=$port {image} {command}"
 TimeoutStartSec=20m
 """
 


### PR DESCRIPTION
Currently the Applications are launched using stateful containers, ie they
do not automatically die when they are killed. This PR makes them ephemereal
when they are launched so they are destroyed once done with.
