### PR TITLE
fix(contrib): give /var/lib/docker 30GB on DO

### DIFF
--- a/contrib/digitalocean/create-coreos-docker-store
+++ b/contrib/digitalocean/create-coreos-docker-store
@@ -5,7 +5,7 @@ if [ ! -f "/media/doroot/var/lib/coreos/docker.img" ]; then
   DOFORMAT=1
 fi
 
-truncate -s 10G /media/doroot/var/lib/coreos/docker.img
+truncate -s 30G /media/doroot/var/lib/coreos/docker.img
 LODEV=`losetup -f --show /media/doroot/var/lib/coreos/docker.img`
 
 if [ -n "$DOFORMAT" ]; then


### PR DESCRIPTION
This bumps our partitions on DigitalOcean to 30GB, which is more suitable for CoreOS. An external block storage would be more suitable, but alas...

This also has a side effect of restricting the size of the VM to 2GB+ as per the spec on DigitalOcean droplets.

fixes #1409
