### PR TITLE
fix(docs): improper config:pull docstring syntax

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -1194,9 +1194,12 @@ class DeisClient(object):
         Usage: deis config:pull [options]
 
         Options:
-          -a APP --app=APP  The application that you wish to pull from
-          -i --interactive  Prompts for each value to be overwritten
-          -o --overwrite    Allows you to have the pull overwrite keys in .env
+          -a APP --app=<app>
+            The application that you wish to pull from
+          -i --interactive
+            Prompts for each value to be overwritten
+          -o --overwrite
+            Allows you to have the pull overwrite keys in .env
         """
         app = args.get('--app')
         overwrite = args.get('--overwrite')

--- a/docs/reference/client.rst
+++ b/docs/reference/client.rst
@@ -56,7 +56,7 @@ deis config
 .. automethod:: client.deis.DeisClient.config_list
 .. automethod:: client.deis.DeisClient.config_set
 .. automethod:: client.deis.DeisClient.config_unset
-.. automethod:: client.deis.DeisClient.config:pull
+.. automethod:: client.deis.DeisClient.config_pull
 
 .. _deis_domains:
 


### PR DESCRIPTION
The documentation is not being built at the moment because config:pull
syntax is incorrect. This fixes it to reflect the changes made in "the
big docstring refactor" AKA #1329 
