### PR TITLE
ref(contributing): changes to the commit style guideline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ The allowed {types} are as follows:
     fix -> bug fix
     docs -> documentation
     style -> formatting
-    refactor
+    ref -> refactoring code
     test -> adding missing tests
     chore -> maintenance
 

--- a/docs/contributing/standards.rst
+++ b/docs/contributing/standards.rst
@@ -209,7 +209,7 @@ The allowed {types} are as follows:
 - fix -> bug fix
 - docs -> documentation
 - style -> formatting
-- refactor
+- ref -> refactoring code
 - test -> adding missing tests
 - chore -> maintenance
 


### PR DESCRIPTION
Commits with messages over 72 characters is wrapped in github's web interface. This is just a guideline, so it does not need to be enforced but I thought it was a good-to-know. Everything else is just format changes. See also https://github.com/blog/926-shiny-new-commit-styles
