### PR TITLE
fix(tests): don't make assumptions about the user's system

### DIFF
--- a/tests/builds_test.go
+++ b/tests/builds_test.go
@@ -45,7 +45,7 @@ func buildSetup(t *testing.T) *itutils.DeisTestConfig {
 }
 
 func buildsListTest(t *testing.T, params *itutils.DeisTestConfig) {
-	Deis := "/usr/local/bin/deis "
+	Deis := "deis "
 	cmd := itutils.GetCommand("builds", "list")
 	var cmdBuf bytes.Buffer
 	tmpl := template.Must(template.New("cmd").Parse(cmd))

--- a/tests/integration-utils/itutils.go
+++ b/tests/integration-utils/itutils.go
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-var Deis = "/usr/local/bin/deis "
+var Deis = "deis "
 
 type DeisTestConfig struct {
 	AuthKey      string
@@ -80,7 +80,7 @@ func Curl(t *testing.T, params *DeisTestConfig) {
 
 func AuthCancel(t *testing.T, params *DeisTestConfig) {
 	fmt.Println("deis auth:cancel")
-	child, err := gexpect.Spawn("/usr/local/bin/deis auth:cancel")
+	child, err := gexpect.Spawn(Deis + " auth:cancel")
 	if err != nil {
 		t.Fatalf("command not started\n%v", err)
 	}


### PR DESCRIPTION
A simple misconception I saw when trying to run the tests locally. Trivial fix.
