### PR TITLE
fix(client): restore `--cluster=dev` as apps:create default

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -415,7 +415,7 @@ class DeisClient(object):
 
         Options:
           --cluster=<cluster>
-            target cluster to host application (default: dev).
+            target cluster to host application [default: dev].
           --no-remote
             do not create a `deis` git remote.
         """


### PR DESCRIPTION
In refactoring the Deis CLI docstrings, we broke the default cluster
for apps:create. This was pointed out by smoke_test.go.

Fixes #1440.
