### PR TITLE
fix(tests): use aufs in builder functional tests

### DIFF
--- a/builder/tests/builder_test.go
+++ b/builder/tests/builder_test.go
@@ -22,7 +22,7 @@ func runDeisBuilderTest(
 			"--rm",
 			"-p", servicePort+":22",
 			"-e", "PUBLISH=22",
-			"-e", "STORAGE_DRIVER=devicemapper",
+			"-e", "STORAGE_DRIVER=aufs",
 			"-e", "HOST="+utils.GetHostIPAddress(),
 			"-e", "ETCD_PORT="+etcdPort,
 			"-e", "PORT="+servicePort,


### PR DESCRIPTION
We had previously switched to Ubuntu's default for Docker,
devicemapper. But aufs has proven to be faster and more reliable
for the CI system itself, and when we switched CI nodes to aufs we
did not do so with the builder functional test itself.

We have occasionally seen errors such as `statusCode=500 Driver devicemapper failed to create image rootfs` [here](http://ci.deis.io/job/test-builder/442/console). Hopefully using aufs in the builder tests as well will stop that from happening.
