### PR TITLE
fix(userdata template): put `nse` function in FHS

### DIFF
--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -56,27 +56,16 @@ coreos:
       Type=oneshot
       ExecStart=/usr/bin/systemctl stop update-engine.service
       ExecStartPost=/usr/bin/systemctl mask update-engine.service
-  - name: link-deis-bashrc.service
-    command: start
-    content: |
-      [Unit]
-      Description=remove .bashrc file for CoreOS user
-      ConditionFileNotEmpty=/run/deis/.bashrc
 
-      [Service]
-      Type=oneshot
-      ExecStartPre=/usr/bin/rm /home/core/.bashrc
-      ExecStart=/usr/bin/ln -s /run/deis/.bashrc /home/core/.bashrc
 write_files:
   - path: /etc/deis-release
     content: |
       DEIS_RELEASE=latest
   - path: /etc/motd
     content: " \e[31m* *    \e[34m*   \e[32m*****    \e[39mddddd   eeeeeee iiiiiii   ssss\n\e[31m*   *  \e[34m* *  \e[32m*   *     \e[39md   d   e    e    i     s    s\n \e[31m* *  \e[34m***** \e[32m*****     \e[39md    d  e         i    s\n\e[32m*****  \e[31m* *    \e[34m*       \e[39md     d e         i     s\n\e[32m*   * \e[31m*   *  \e[34m* *      \e[39md     d eee       i      sss\n\e[32m*****  \e[31m* *  \e[34m*****     \e[39md     d e         i         s\n  \e[34m*   \e[32m*****  \e[31m* *      \e[39md    d  e         i          s\n \e[34m* *  \e[32m*   * \e[31m*   *     \e[39md   d   e    e    i    s    s\n\e[34m***** \e[32m*****  \e[31m* *     \e[39mddddd   eeeeeee iiiiiii  ssss\n\n\e[39mWelcome to Deis\t\t\tPowered by Core\e[38;5;45mO\e[38;5;206mS\e[39m\n"
-  - path: /run/deis/.bashrc
-    owner: core
+  - path: /etc/profile.d/nse-function.sh
+    permissions: 0755
     content: |
-      source /usr/share/skel/.bashrc
       function nse() {
         sudo nsenter --pid --uts --mount --ipc --net --target $(docker inspect --format="{{ .State.Pid }}" $1)
       }


### PR DESCRIPTION
Gentoo's `/etc/profile` automatically sources all `.sh` files in `/etc/profile.d` when bash is run. This reduces boot time at the expense of an extra file read per shell opened. However this is a minimal cost for the FHS convenience. Trivial fix.
