### PR TITLE
fix(userdata template): put motd directly in the OS

### DIFF
--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -56,17 +56,6 @@ coreos:
       Type=oneshot
       ExecStart=/usr/bin/systemctl stop update-engine.service
       ExecStartPost=/usr/bin/systemctl mask update-engine.service
-  - name: write-deis-motd.service
-    command: start
-    content: |
-      [Unit]
-      Description=write the Deis motd
-      ConditionFileNotEmpty=/run/deis/motd
-
-      [Service]
-      Type=oneshot
-      ExecStartPre=/usr/bin/rm /etc/motd
-      ExecStart=/usr/bin/ln -s /run/deis/motd /etc/motd
   - name: link-deis-bashrc.service
     command: start
     content: |
@@ -82,7 +71,7 @@ write_files:
   - path: /etc/deis-release
     content: |
       DEIS_RELEASE=latest
-  - path: /run/deis/motd
+  - path: /etc/motd
     content: " \e[31m* *    \e[34m*   \e[32m*****    \e[39mddddd   eeeeeee iiiiiii   ssss\n\e[31m*   *  \e[34m* *  \e[32m*   *     \e[39md   d   e    e    i     s    s\n \e[31m* *  \e[34m***** \e[32m*****     \e[39md    d  e         i    s\n\e[32m*****  \e[31m* *    \e[34m*       \e[39md     d e         i     s\n\e[32m*   * \e[31m*   *  \e[34m* *      \e[39md     d eee       i      sss\n\e[32m*****  \e[31m* *  \e[34m*****     \e[39md     d e         i         s\n  \e[34m*   \e[32m*****  \e[31m* *      \e[39md    d  e         i          s\n \e[34m* *  \e[32m*   * \e[31m*   *     \e[39md   d   e    e    i    s    s\n\e[34m***** \e[32m*****  \e[31m* *     \e[39mddddd   eeeeeee iiiiiii  ssss\n\n\e[39mWelcome to Deis\t\t\tPowered by Core\e[38;5;45mO\e[38;5;206mS\e[39m\n"
   - path: /run/deis/.bashrc
     owner: core


### PR DESCRIPTION
Same kind of fix as PR #1444. Trivial fix that saves a systemd unit from being run needlessly.
