### PR TITLE
fix(client): skip logout if connection fails

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -773,7 +773,10 @@ class DeisClient(object):
         """
         controller = self._settings.get('controller')
         if controller:
-            self._dispatch('get', '/api/auth/logout/')
+            try:
+                self._dispatch('get', '/api/auth/logout/')
+            except requests.exceptions.ConnectionError:
+                pass
         self._session.cookies.clear()
         self._session.cookies.save()
         self._settings['controller'] = None


### PR DESCRIPTION
Logout should never really fail - if the controller is inaccessible, we
should make sure we're deleting the cookies and then return.

closes #1053
