### PR TITLE
ref(scheduler): remove calls to cut

### DIFF
--- a/controller/scheduler/coreos.py
+++ b/controller/scheduler/coreos.py
@@ -253,7 +253,7 @@ BindsTo={name}.service
 
 [Service]
 ExecStartPre=/bin/sh -c "until docker inspect {name} >/dev/null 2>&1; do sleep 1; done"
-ExecStart=/bin/sh -c "docker logs -f {name} 2>&1 | logger -p local0.info -t {app}[{c_type}.{c_num}] --udp --server $(etcdctl get /deis/logs/host | cut -d ':' -f1) --port $(etcdctl get /deis/logs/port | cut -d ':' -f2)"
+ExecStart=/bin/sh -c "docker logs -f {name} 2>&1 | logger -p local0.info -t {app}[{c_type}.{c_num}] --udp --server $(etcdctl get /deis/logs/host) --port $(etcdctl get /deis/logs/port)"
 TimeoutStartSec=20m
 
 [X-Fleet]


### PR DESCRIPTION
/deis/logs/host used to be represented as $HOST:$PORT. Now that it's
been moved out to /deis/logs/host and /deis/logs/port, this is no longer
required.
