### PR TITLE
fix(contrib/coreos): configure public IP for fleet

### DIFF
--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -7,6 +7,10 @@ coreos:
     # discovery: https://discovery.etcd.io/12345693838asdfasfadf13939923
     addr: $private_ipv4:4001
     peer-addr: $private_ipv4:7001
+  fleet:
+    # We have to set the public_ip here so this works on Vagrant -- otherwise, Vagrant VMs
+    # will all publish the same private IP. This is harmless for cloud providers.
+    public_ip: $private_ipv4
   units:
   - name: etcd.service
     command: start


### PR DESCRIPTION
We previously defined this, but we did so by overwriting the
stock CoreOS unit file for fleet. That's bad. This enables us
to tweak this setting and still use the stock CoreOS unit file,
which is good.

This is necessary only for Vagrant, but it is safe for cloud
providers as well.

TESTING: provision multi-node, and make sure `fleetctl list-machines`
shows different IPs:

``` console
$ fleetctl list-machines
MACHINE     IP      METADATA
4cbcb7c5... 172.17.8.101    -
e00803ec... 172.17.8.100    -
```

Works on EC2 as well...

```
fleetctl list-machines
MACHINE     IP      METADATA
2c985b00... 172.31.12.86    -
43cca2ad... 172.31.35.1 -
ecf3fc08... 172.31.31.144   -
```
