### PR TITLE
feat(router): Support for WebSockets

### DIFF
--- a/router/templates/nginx.conf
+++ b/router/templates/nginx.conf
@@ -34,6 +34,11 @@ http {
     access_log /dev/stdout;
     error_log /dev/stdout;
 
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
     ## start deis-controller
     {{ if .deis_controller_host }}
     upstream deis-controller {
@@ -80,6 +85,9 @@ http {
             proxy_connect_timeout       10s;
             proxy_send_timeout          1200s;
             proxy_read_timeout          1200s;
+            proxy_http_version          1.1;
+            proxy_set_header            Upgrade $http_upgrade;
+            proxy_set_header            Connection $connection_upgrade;
 
             proxy_next_upstream         error timeout http_502 http_503 http_504;
 


### PR DESCRIPTION
WebSockets are now enabled for all new apps on Heroku. https://devcenter.heroku.com/articles/websockets#enabling-websockets

This PR does the same. Fixes #1061

To test:

``` bash
git clone https://github.com/heroku-examples/ruby-ws-test.git
cd ruby-ws-test
deis create
git push deis master
deis open
```
