### PR TITLE
docs(*): explicitly specify --hosts parameter for clusters:create

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Use `deis keys:add` to add your SSH public key for `git push` access.
 Initialize a `dev` cluster with a list of CoreOS hosts and your CoreOS private key.
 
 ```console
-$ deis clusters:create dev local.deisapp.com --hosts=local.deisapp.com --auth=~/.vagrant.d/insecure_private_key
+$ deis clusters:create dev local.deisapp.com --hosts=172.17.8.100 --auth=~/.vagrant.d/insecure_private_key
 ```
 
 The parameters to `deis clusters:create` are:

--- a/docs/installing_deis/create-cluster.rst
+++ b/docs/installing_deis/create-cluster.rst
@@ -20,4 +20,4 @@ For example, to create a cluster on a local Deis installation:
 
 .. code-block:: console
 
-    $ deis clusters:create dev local.deisapp.com --hosts=local.deisapp.com --auth=~/.vagrant.d/insecure_private_key
+    $ deis clusters:create dev local.deisapp.com --hosts=172.17.8.100 --auth=~/.vagrant.d/insecure_private_key


### PR DESCRIPTION
It's convenient to use `local.deisapp.com`, but since we're also
using that as the cluster domain, it's quite confusing.
