### PR TITLE
docs(*): add load balancer info to EC2 and Rackspace

### DIFF
--- a/contrib/ec2/README.md
+++ b/contrib/ec2/README.md
@@ -101,6 +101,12 @@ $ cd ../.. && make run
 ```
 The script will deploy Deis and make sure the services start properly.
 
+## Configure load balancer
+The Deis provisioning scripts for EC2 automatically create an Elastic Load Balancer for your Deis
+cluster. However, ELBs on EC2 have a default timeout of 60 seconds, which will disrupt a ``git push``
+when using Deis. You should manually [increase this timeout](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/config-idle-timeout.html)
+to 1200 seconds to match the timeout on the router and application unit files.
+
 ## Configure DNS
 While you can reference the controller and hosted applications with public hostnames provided by EC2, it is recommended for ease-of-use that
 you configure your own DNS records using a domain you own. See [Configuring DNS](http://docs.deis.io/en/latest/installing_deis/configure-dns/) for details.

--- a/contrib/rackspace/README.md
+++ b/contrib/rackspace/README.md
@@ -81,11 +81,11 @@ You'll need to create two load balancers on Rackspace to handle your cluster.
     Health Monitoring -
       Monitor Type HTTP
       HTTP Path /health-check
-      
+
     Load Balancer 2
     Virtual IP Shared VIP on Another Load Balancer (select Load Balancer 1)
     Port 2222
-    Protocol TCP (this can probably be anything, but TCP worked for me)
+    Protocol TCP
 
 ### Use Deis!
 After that, register with Deis!

--- a/docs/installing_deis/configure-load-balancers.rst
+++ b/docs/installing_deis/configure-load-balancers.rst
@@ -28,9 +28,31 @@ port 80 on all nodes in the Deis cluster. The health check endpoint returns an H
 the load balancer to serve trafic to whichever hosts happen to be running the deis-router component
 at any moment.
 
-.. note::
+EC2
+===
 
-  Elastic load balancers on EC2 have a default timeout of 60 seconds, which will disrupt
-  a ``git push`` when using Deis. You should manually `increase this timeout`_ to 1200 seconds.
+The Deis provisioning scripts for EC2 automatically create an Elastic Load Balancer for your Deis
+cluster. However, ELBs on EC2 have a default timeout of 60 seconds, which will disrupt a ``git push``
+when using Deis. You should manually `increase this timeout`_ to 1200 seconds to match the timeout
+on the router and application unit files.
+
+Rackspace
+=========
+
+You'll need to create two load balancers on Rackspace, as follows:
+
+.. code-block:: text
+
+    Load Balancer 1
+      Port 80
+      Protocol HTTP
+    Health Monitoring -
+      Monitor Type HTTP
+      HTTP Path /health-check
+
+    Load Balancer 2
+      Virtual IP Shared VIP on Another Load Balancer (select Load Balancer 1)
+      Port 2222
+      Protocol TCP
 
 .. _`increase this timeout`: http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/config-idle-timeout.html


### PR DESCRIPTION
More explicitly call out load balancer creation/configuration for EC2 and Rackspace wherever it's necessary.

Thanks to @dubcanada for the Rackspace setup instructions.

replaces #1431
