### PR TITLE
chore(*): bump CoreOS to 386.1.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ else
   cpus = 1
 end
 
-COREOS_VERSION = "379.3.0"
+COREOS_VERSION = "386.1.0"
 
 Vagrant.configure("2") do |config|
   config.vm.box = "coreos-#{COREOS_VERSION}"

--- a/contrib/digitalocean/update-coreos
+++ b/contrib/digitalocean/update-coreos
@@ -2,7 +2,7 @@
 
 set -e
 
-COREOS_VERSION=379.3.0
+COREOS_VERSION=386.1.0
 BASE_URL="http://storage.core-os.net/coreos/amd64-usr/$COREOS_VERSION"
 
 KERNEL="/boot/coreos/vmlinuz"

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -4,28 +4,28 @@
   "Mappings" : {
       "RegionMap" : {
           "ap-northeast-1" : {
-              "AMI" : "ami-d7dc8cd6"
+              "AMI" : "ami-fbf3a1fa"
           },
           "sa-east-1" : {
-              "AMI" : "ami-0d329c10"
+              "AMI" : "ami-edab02f0"
           },
           "ap-southeast-2" : {
-              "AMI" : "ami-4d8fe877"
+              "AMI" : "ami-35d1b60f"
           },
           "ap-southeast-1" : {
-              "AMI" : "ami-5695cc04"
+              "AMI" : "ami-2a075f78"
           },
           "us-east-1" : {
-              "AMI" : "ami-3c66ab54"
+              "AMI" : "ami-88e52ce0"
           },
           "us-west-2" : {
-              "AMI" : "ami-bbb9c08b"
+              "AMI" : "ami-8b532bbb"
           },
           "us-west-1" : {
-              "AMI" : "ami-7d414238"
+              "AMI" : "ami-13eeed56"
           },
           "eu-west-1" : {
-              "AMI" : "ami-0573a472"
+              "AMI" : "ami-7de4350a"
           }
       }
   },

--- a/contrib/rackspace/provision-rackspace-cluster.sh
+++ b/contrib/rackspace/provision-rackspace-cluster.sh
@@ -42,7 +42,7 @@ $CONTRIB_DIR/util/check-user-data.sh
 
 i=1 ; while [[ $i -le $DEIS_NUM_INSTANCES ]] ; do \
     echo_yellow "Provisioning deis-$i..."
-    supernova production boot --image c3a4208a-3284-4e46-a99d-c29b56b457ba --flavor $FLAVOR --key-name $1 --user-data ../coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
+    supernova production boot --image 513f96f3-20e4-4865-b039-d2ca3944af4e --flavor $FLAVOR --key-name $1 --user-data ../coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
     ((i = i + 1)) ; \
 done
 


### PR DESCRIPTION
Includes internal fixes, notably some bigger ones for systemd 215.

https://coreos.com/releases/#386.1.0
