### PR TITLE
fix(controller/registry): strip hostname from repo

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -13,6 +13,7 @@ django-guardian==1.1.1
 django-json-field==0.5.5
 django-yamlfield==0.5
 djangorestframework==2.3.13
+docker-py==0.4.0
 gunicorn==18.0
 psycopg2==2.5.2
 python-etcd==0.3.0

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -16,6 +16,7 @@ git+https://github.com/bacongobbler/django-fsm@add-exception-handling
 django-guardian==1.1.1
 django-json-field==0.5.5
 djangorestframework==2.3.13
+docker-py==0.4.0
 gunicorn==18.0
 psycopg2==2.5.2
 python-etcd==0.3.0


### PR DESCRIPTION
The changes to the registry module did not strip the hostname from the
app image. This fixes that by properly parsing the source for the
repository name in the registry and the tag.
