### PR TITLE
fix(contrib/digitalocean) fix region check

### DIFF
--- a/contrib/digitalocean/provision-do-cluster.sh
+++ b/contrib/digitalocean/provision-do-cluster.sh
@@ -32,7 +32,7 @@ if [ -z "$DEIS_NUM_INSTANCES" ]; then
     DEIS_NUM_INSTANCES=3
 fi
 
-regions_with_private_networking=(4 5 6 7)
+regions_with_private_networking="4 5 6 7"
 if ! listcontains "$regions_with_private_networking" "$1";
 then
     echo_red "Invalid region. Please supply a region with private networking support."


### PR DESCRIPTION
Fix the allowed region checks.
This used to only allow 4 (New York 2), and not any of the others.
