### PR TITLE
fix(client): only allow numbers greater than 0 when scaling

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -1411,6 +1411,8 @@ class DeisClient(object):
         body = {}
         for type_num in args.get('<type>=<num>'):
             typ, count = type_num.split('=')
+            if int(count) < 0:
+                raise DocoptExit('number must be greater than 0')
             body.update({typ: int(count)})
         sys.stdout.write('Scaling processes... but first, coffee!\n')
         sys.stdout.flush()


### PR DESCRIPTION
I accidentally scaled a process to -1 and got a 500 from the server. Figured it was easier to make the check in the client. 
