### PR TITLE
fix(controller): remove /run/deis/determine_registry

### DIFF
--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -60,21 +60,3 @@ write_files:
 
       # remove leading slash
       echo ${IMAGE#/}
-  - path: /run/deis/bin/determine_registry
-    permissions: 0755
-    content: |
-      #!/bin/bash
-      # usage: determine_registry <build_image>
-      REGISTRY_HOST=`etcdctl get /deis/registry/host 2>/dev/null`
-      if [ $? -ne 0 ]; then
-        echo "Can't find registry host in /deis/registry/host."
-        exit 1
-      fi
-
-      REGISTRY_PORT=`etcdctl get /deis/registry/port 2>/dev/null`
-      if [ $? -ne 0 ]; then
-        echo "Can't find registry port in /deis/registry/port."
-        exit 1
-      fi
-
-      echo $REGISTRY_HOST:$REGISTRY_PORT/$1

--- a/controller/scheduler/coreos.py
+++ b/controller/scheduler/coreos.py
@@ -222,9 +222,9 @@ CONTAINER_TEMPLATE = """
 Description={name}
 
 [Service]
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/determine_registry {image}`; docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "IMAGE=$(etcdctl get /deis/registry/host 2>&1):$(etcdctl get /deis/registry/port 2>&1)/{image}; docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect {name} >/dev/null 2>&1 && docker rm -f {name} || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/determine_registry {image}`; port=$(docker inspect -f '{{{{range $k, $v := .ContainerConfig.ExposedPorts }}}}{{{{$k}}}}{{{{end}}}}' $IMAGE | cut -d/ -f1) ; docker run --name {name} -P -e PORT=$port $IMAGE {command}"
+ExecStart=/bin/sh -c "IMAGE=$(etcdctl get /deis/registry/host 2>&1):$(etcdctl get /deis/registry/port 2>&1)/{image}; port=$(docker inspect -f '{{{{range $k, $v := .ContainerConfig.ExposedPorts }}}}{{{{$k}}}}{{{{end}}}}' $IMAGE | cut -d/ -f1) ; docker run --name {name} -P -e PORT=$port $IMAGE {command}"
 ExecStop=/usr/bin/docker rm -f {name}
 TimeoutStartSec=20m
 """


### PR DESCRIPTION
This script is backwards-incompatible with existing clusters. Moving the
calls to etcd directly into the unit file removes the dependency and
ultimately makes master backwards-compatible again.

We don't necessarily need to check if the values are present or not. If they're not there, the pull will fail due to the image name being `:/<appname>` and the unit will exit.
