### PR TITLE
fix(controller): tack on host/port to image id

### DIFF
--- a/controller/api/tasks.py
+++ b/controller/api/tasks.py
@@ -79,12 +79,14 @@ def stop_containers(containers):
 def run_command(c, command):
     release = c.release
     version = release.version
-    image = release.image
+    image = '{}:{}/{}'.format(settings.REGISTRY_HOST,
+                              settings.REGISTRY_PORT,
+                              release.image)
     try:
         # pull the image first
         rc, pull_output = c.run("docker pull {image}".format(**locals()))
         if rc != 0:
-            raise EnvironmentError('Could not pull image: {pull_image}'.format(**locals()))
+            raise EnvironmentError('Could not pull image: {image}'.format(**locals()))
         # run the command
         docker_args = ' '.join(['--entrypoint=/bin/sh',
                                 '-a', 'stdout', '-a', 'stderr', '--rm', image])


### PR DESCRIPTION
With the changes to how we store images in the controller, we stripped
the host/port from the image. We must add it back if we want to pull
it from the registry.

closes #1516
