### PR TITLE
tests(integration): document regression test for `clusters:update --auth=`

### DIFF
--- a/tests/clusters_test.go
+++ b/tests/clusters_test.go
@@ -3,7 +3,6 @@
 package tests
 
 import (
-	_ "fmt"
 	"testing"
 
 	"github.com/deis/deis/tests/integration-utils"
@@ -33,11 +32,11 @@ func clustersInfoTest(t *testing.T, params *itutils.DeisTestConfig) {
 	itutils.Execute(t, cmd, params, false, "")
 }
 
-//Tets #1283
-
 func clustersUpdateTest(t *testing.T, params *itutils.DeisTestConfig) {
 	cmd := itutils.GetCommand("clusters", "update")
-	itutils.CheckList(t, params, cmd, "~/.ssh/"+params.AuthKey, true)
+	// Regression test for https://github.com/deis/deis/pull/1283
+	// Check that we didn't store the path of the key in the cluster.
+	itutils.CheckList(t, params, cmd, "~/.ssh/", true)
 }
 
 func clustersDestroyTest(t *testing.T, params *itutils.DeisTestConfig) {

--- a/tests/integration-utils/itutils.go
+++ b/tests/integration-utils/itutils.go
@@ -133,9 +133,10 @@ func AuthCancel(t *testing.T, params *DeisTestConfig) {
 
 }
 
-// CheckList executes a command and optionally tests whether its output contains
-// a given string.
-func CheckList(t *testing.T, params interface{}, cmd, contain string, notflag bool) {
+// CheckList executes a command and optionally tests whether its output does
+// or does not contain a given string.
+func CheckList(
+	t *testing.T, params interface{}, cmd, contain string, notflag bool) {
 	var cmdBuf bytes.Buffer
 	tmpl := template.Must(template.New("cmd").Parse(cmd))
 	if err := tmpl.Execute(&cmdBuf, params); err != nil {
@@ -149,12 +150,16 @@ func CheckList(t *testing.T, params interface{}, cmd, contain string, notflag bo
 	} else {
 		cmdl = exec.Command("sh", "-c", Deis+cmdString)
 	}
-	if stdout, _, err := utils.RunCommandWithStdoutStderr(cmdl); err == nil {
-		if strings.Contains(stdout.String(), contain) == notflag {
-			t.Fatal(err)
-		}
-	} else {
+	stdout, _, err := utils.RunCommandWithStdoutStderr(cmdl)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if strings.Contains(stdout.String(), contain) == notflag {
+		if notflag {
+			t.Fatalf(
+				"Didn't expect '%s' in command output:\n%s", contain, stdout)
+		}
+		t.Fatalf("Expected '%s' in command output:\n%s", contain, stdout)
 	}
 }
 


### PR DESCRIPTION
We already had a regression test to ensure the deis CLI wasn't just
sending the key path when updating the cluster. This change makes that
clearer and clarifies the output of the `CheckList()` test function.

Fixes #1372, refs #1283.
