### PR TITLE
fix(controller): add version tag to deis run

### DIFF
--- a/controller/api/tasks.py
+++ b/controller/api/tasks.py
@@ -79,9 +79,10 @@ def stop_containers(containers):
 def run_command(c, command):
     release = c.release
     version = release.version
-    image = '{}:{}/{}'.format(settings.REGISTRY_HOST,
-                              settings.REGISTRY_PORT,
-                              release.image)
+    image = '{}:{}/{}:v{}'.format(settings.REGISTRY_HOST,
+                                  settings.REGISTRY_PORT,
+                                  release.image,
+                                  release.version)
     try:
         # pull the image first
         rc, pull_output = c.run("docker pull {image}".format(**locals()))


### PR DESCRIPTION
This PR ensures `deis apps:run` targets the intended version tag.

Running a one-off admin command currently pulls _all_ images in the repository (which is horribly slow) and then runs against (:latest) as a default -- which is not always the intended release.
