### PR TITLE
fix(Makefile): fix check-fleet Makefile target

### DIFF
--- a/includes.mk
+++ b/includes.mk
@@ -44,8 +44,8 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 ROUTER_UNITS = $(shell seq -f "deis-router@%g.service" -s " " $(DEIS_FIRST_ROUTER) 1 $(DEIS_LAST_ROUTER))
 
 check-fleet:
-  @LOCAL_VERSION=`$(FLEETCTL) -version`; \
-  REMOTE_VERSION=`ssh -o StrictHostKeyChecking=no core@$(subst :, -p ,$(FLEETCTL_TUNNEL)) fleetctl -version`; \
-  if [ "$$LOCAL_VERSION" != "$$REMOTE_VERSION" ]; then \
-      echo "Your fleetctl client version should match the server. Local version: $$LOCAL_VERSION, server version: $$REMOTE_VERSION. Uninstall your local version and install the latest build from https://github.com/coreos/fleet/releases"; exit 1; \
-  fi
+	@LOCAL_VERSION=`$(FLEETCTL) -version`; \
+	REMOTE_VERSION=`ssh -o StrictHostKeyChecking=no core@$(subst :, -p ,$(FLEETCTL_TUNNEL)) fleetctl -version`; \
+	if [ "$$LOCAL_VERSION" != "$$REMOTE_VERSION" ]; then \
+		echo "Your fleetctl client version should match the server. Local version: $$LOCAL_VERSION, server version: $$REMOTE_VERSION. Install the appropriate version from https://github.com/coreos/fleet/releases"; exit 1; \
+	fi


### PR DESCRIPTION
Just a little indentation issue.

``` console
$ make status
Your fleetctl client version should match the server. Local version: fleetctl version 0.5.0, server version: fleetctl version 0.6.2. Uninstall your local version and install the latest build from https://github.com/coreos/fleet/releases
make: *** [check-fleet] Error 1
```

For easy testing, check out #1541 without updating your local `fleetctl`.

fixes #1505
