### PR TITLE
docs(*): remove references to `DOCKER_HOST`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Upgrading from a previous Deis release? See [Upgrading Deis](http://docs.deis.io
 On your workstation:
 * Install [Vagrant v1.6+](http://www.vagrantup.com/downloads.html) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 * Install the fleetctl client: Install v0.6.2 from the [fleet GitHub page](https://github.com/coreos/fleet/releases/tag/v0.6.2).
-* Install the Docker client if you want to run Docker commands locally (optional)
 
 A single-node cluster launched with Vagrant will consume about 5 GB of RAM on
 the host machine. Please be sure you have sufficient free memory before
@@ -57,10 +56,9 @@ This instructs Vagrant to spin up each VM. To be able to connect to the VMs, you
 $ ssh-add ~/.vagrant.d/insecure_private_key
 ```
 
-Export some environment variables so you can connect to the VM using the `docker` and `fleetctl` clients on your workstation.
+Export `FLEETCTL_TUNNEL` so you can connect to the VM using the `fleetctl` client on your workstation.
 
 ```console
-$ export DOCKER_HOST=tcp://172.17.8.100:4243
 $ export FLEETCTL_TUNNEL=172.17.8.100
 ```
 

--- a/docs/contributing/localdev.rst
+++ b/docs/contributing/localdev.rst
@@ -18,7 +18,7 @@ Prerequisites
 We strongly recommend using `Vagrant`_ with `VirtualBox`_ so you can
 develop inside a set of isolated virtual machines. You will need:
 
- * Vagrant 1.5.1+
+ * Vagrant 1.6+
  * VirtualBox 4.2+
 
 Fork the Repository
@@ -53,12 +53,10 @@ prompted for an administrative password.
     deis: Running: inline script
     $
 
-Set environment variables to have the `docker` and `fleetctl` clients on
-your workstation connect to the VM:
+Set ``FLEETCTL_TUNNEL`` so the ``fleetctl`` client on your workstation can connect to the VM:
 
 .. code-block:: console
 
-    export DOCKER_HOST=tcp://172.17.8.100:4243
     export FLEETCTL_TUNNEL=172.17.8.100
 
 Next, run ``make pull && make build`` to SSH into the VM, pull Deis'


### PR DESCRIPTION
This is no longer exposed via a TCP socket.
