### PR TITLE
fix(builder): fix race condition in /bin/boot

### DIFF
--- a/builder/bin/boot
+++ b/builder/bin/boot
@@ -60,14 +60,12 @@ docker load -i /progrium_cedarish.tar
 # pull required images
 
 # Custom slugbuilder?
-etcdctl --no-sync -C $ETCD mk /deis/slugbuilder/image deis/slugbuilder:latest >/dev/null 2>&1 || true
-SLUGBUILDER=`etcdctl --no-sync -C $ETCD get /deis/slugbuilder/image`
+SLUGBUILDER=`etcdctl --no-sync -C $ETCD get /deis/slugbuilder/image 2>/dev/null || etcdctl --no-sync -C $ETCD mk /deis/slugbuilder/image deis/slugbuilder:latest 2>/dev/null`
 docker pull ${SLUGBUILDER}
 docker tag  ${SLUGBUILDER} deis/slugbuilder:latest
 
 # Custom slugrunner?
-etcdctl --no-sync -C $ETCD mk /deis/slugrunner/image deis/slugrunner:latest >/dev/null 2>&1 || true
-SLUGRUNNER=`etcdctl --no-sync -C $ETCD get /deis/slugrunner/image`
+SLUGRUNNER=`etcdctl --no-sync -C $ETCD get /deis/slugrunner/image 2>/dev/null || etcdctl --no-sync -C $ETCD mk /deis/slugrunner/image deis/slugrunner:latest 2>/dev/null`
 docker pull ${SLUGRUNNER}
 docker tag  ${SLUGRUNNER} deis/slugrunner:latest
 


### PR DESCRIPTION
Commit b0572ef seemed to introduce a race condition. It seems that
etcdctl will return before the key that was set has fully persisted
to the key/value store, so a subsequent get will not always see the
new value of the key.

This resulted in builder often failing to start up, but restarting
it made it come up immediately. This is because the keys
`/deis/slugbuilder/image` and `/deis/slugrunner/image` were populated
by the second time the component was started.

This commit refactors this logic to remove the race condition.
