### PR TITLE
ref(scheduler): replace announcer with deis/publisher

### DIFF
--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -26,6 +26,20 @@ coreos:
       Type=oneshot
       ExecStart=/usr/bin/systemctl stop update-engine.service
       ExecStartPost=/usr/bin/systemctl mask update-engine.service
+  - name: deis-publisher.service
+    command: start
+    content: |
+      [Unit]
+      Description=deis-publisher
+      Requires=docker.socket
+      After=docker.socket
+
+      [Service]
+      EnvironmentFile=/etc/environment
+      ExecStart=/usr/bin/docker run -v /var/run/docker.sock:/tmp/docker.sock -e ETCD_HOST=${COREOS_PRIVATE_IPV4} -e HOST=${COREOS_PRIVATE_IPV4} bacongobbler/publisher
+
+      [Install]
+      WantedBy=multi-user.target
 write_files:
   - path: /etc/deis-release
     content: |

--- a/controller/scheduler/mock.py
+++ b/controller/scheduler/mock.py
@@ -26,25 +26,25 @@ class MockSchedulerClient(object):
 
     # job api
 
-    def create(self, name, image, command, use_announcer, **kwargs):
+    def create(self, name, image, command, **kwargs):
         """
         Create a new job
         """
         return {'state': 'inactive'}
 
-    def start(self, name, use_announcer):
+    def start(self, name):
         """
         Start an idle job
         """
         return {'state': 'active'}
 
-    def stop(self, name, use_announcer):
+    def stop(self, name):
         """
         Stop a running job
         """
         return {'state': 'inactive'}
 
-    def destroy(self, name, use_announcer):
+    def destroy(self, name):
         """
         Destroy an existing job
         """


### PR DESCRIPTION
This has been refactored into a micro-service image called publisher,
which listens on a socket and publishes metadata to etcd.

Note that I pushed my own build of this image as `bacongobbler/publisher`, so before we merge this I'd need to amend the commit and to publish the release as `deis/publisher`. Let me know what you guys think!

Source can be found at https://github.com/deis/publisher
