### PR TITLE
fix(controller): expose app URL

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -572,15 +572,10 @@ class DeisClient(object):
         # TODO: replace with a single API call to apps endpoint
         response = self._dispatch('get', "/api/apps/{}".format(app))
         if response.status_code == requests.codes.ok:  # @UndefinedVariable
-            cluster = response.json()['cluster']
-        else:
-            raise ResponseError(response)
-        response = self._dispatch('get', "/api/clusters/{}".format(cluster))
-        if response.status_code == requests.codes.ok:  # @UndefinedVariable
-            domain = response.json()['domain']
+            url = response.json()['url']
             # use the OS's default handler to open this URL
-            webbrowser.open('http://{}.{}/'.format(app, domain))
-            return domain
+            webbrowser.open('http://{}.{}/'.format(app, url))
+            return url
         else:
             raise ResponseError(response)
 

--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -131,6 +131,10 @@ class App(UuidAuditedModel):
     def __str__(self):
         return self.id
 
+    @property
+    def url(self):
+        return self.id + '.' + self.cluster.domain
+
     def create(self, *args, **kwargs):
         config = Config.objects.create(owner=self.owner, app=self, values={})
         build = Build.objects.create(owner=self.owner, app=self, image=settings.DEFAULT_BUILD)

--- a/controller/api/serializers.py
+++ b/controller/api/serializers.py
@@ -172,6 +172,7 @@ class AppSerializer(serializers.ModelSerializer):
     owner = serializers.Field(source='owner.username')
     id = serializers.SlugField(default=utils.generate_app_name)
     cluster = serializers.SlugRelatedField(slug_field='id')
+    url = serializers.Field(source='url')
 
     class Meta:
         """Metadata options for a :class:`AppSerializer`."""

--- a/controller/api/tests/test_app.py
+++ b/controller/api/tests/test_app.py
@@ -42,6 +42,8 @@ class AppTest(TestCase):
         app_id = response.data['id']  # noqa
         self.assertIn('cluster', response.data)
         self.assertIn('id', response.data)
+        self.assertIn('url', response.data)
+        self.assertEqual(response.data['url'], '{app_id}.autotest.local'.format(**locals()))
         response = self.client.get('/api/apps')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)


### PR DESCRIPTION
While users should not have access to the clusters endpoint, they
should still be able to see what root domain their app is currently
being served at.

closes #903
