### PR TITLE
fix(builder): set /app as working directory for apps

### DIFF
--- a/builder/templates/builder
+++ b/builder/templates/builder
@@ -27,8 +27,9 @@ def parse_args():
 
 DOCKERFILE_SHIM = """FROM deis/slugrunner
 RUN mkdir -p /app
-ADD slug.tgz /app
+WORKDIR /app
 ENTRYPOINT ["/runner/init"]
+ADD slug.tgz /app
 """
 
 


### PR DESCRIPTION
When you run commands with Heroku, you are running under
/app as the intial directory.
