### PR TITLE
chore(logger): update go to 1.3.1

### DIFF
--- a/logger/Dockerfile
+++ b/logger/Dockerfile
@@ -2,7 +2,7 @@ FROM deis/base:latest
 MAINTAINER OpDemand <info@opdemand.com>
 
 # install go runtime
-RUN wget -qO- https://storage.googleapis.com/golang/go1.2.2.linux-amd64.tar.gz | tar -C /usr/local -xz
+RUN wget -qO- https://storage.googleapis.com/golang/go1.3.1.linux-amd64.tar.gz | tar -C /usr/local -xz
 
 # prepare go environment
 RUN mkdir -p /go

--- a/tests/etcdutils/Dockerfile
+++ b/tests/etcdutils/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Matt Boersma <matt@opdemand.com>
 
 # Install prerequisites: wget, git, and go.
 RUN apt-get update -q && DEBIAN_FRONTEND=noninteractive apt-get install -qy wget git-core
-RUN wget -qO- https://storage.googleapis.com/golang/go1.3.linux-amd64.tar.gz | tar -C /usr/local -xz
+RUN wget -qO- https://storage.googleapis.com/golang/go1.3.1.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:$PATH
 
 # Build etcd v0.4.5. Keep this in sync with Deis' version.


### PR DESCRIPTION
Also updated to go 1.3.1 in our etcd test container.
