### PR TITLE
docs(contrib/ec2): document recommended instance size

### DIFF
--- a/contrib/ec2/README.md
+++ b/contrib/ec2/README.md
@@ -72,6 +72,9 @@ by setting the value in [cloudformation.json](cloudformation.json) like so:
 The only entry in cloudformation.json required to launch your cluster is `KeyPair`,
 which is already filled out. The defaults will be applied for the other settings.
 
+NOTE: The smallest recommended instance size is `large`. Having not enough CPU or RAM will result
+in numerous issues when using the cluster.
+
 ## Launch into an existing VPC
 By default, the provided CloudFormation script will create a new VPC for Deis. However, the script
 supports provisioning into an existing VPC instead. You'll need to have a VPC configured with an

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -35,7 +35,6 @@
         "m3.large",
         "m3.xlarge",
         "m3.2xlarge",
-        "m1.small",
         "m1.medium",
         "m1.large",
         "m1.xlarge",
@@ -63,9 +62,6 @@
         "r3.2xlarge",
         "r3.4xlarge",
         "r3.8xlarge",
-        "t1.micro",
-        "t2.micro",
-        "t2.small",
         "t2.medium"
       ],
       "ConstraintDescription" : "must be a valid EC2 instance type."


### PR DESCRIPTION
closes #1620

[skip ci]
