### PR TITLE
chore(tests): update etcd to match CoreOS 402.2.0

### DIFF
--- a/tests/etcdutils/Dockerfile
+++ b/tests/etcdutils/Dockerfile
@@ -6,12 +6,12 @@ RUN apt-get update -q && DEBIAN_FRONTEND=noninteractive apt-get install -qy wget
 RUN wget -qO- https://storage.googleapis.com/golang/go1.3.1.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:$PATH
 
-# Build etcd v0.4.5. Keep this in sync with Deis' version.
+# Build etcd v0.4.6. Keep this in sync with Deis' version.
 RUN git clone -q https://github.com/coreos/etcd.git /opt/etcd
-RUN cd /opt/etcd && git checkout -q v0.4.5 && ./build
+RUN cd /opt/etcd && git checkout -q v0.4.6 && ./build
 
 # Download latest stable etcdctl. Keep this in sync with Deis' version.
-ADD https://s3-us-west-2.amazonaws.com/opdemand/etcdctl-v0.4.5 /usr/local/bin/etcdctl
+ADD https://s3-us-west-2.amazonaws.com/opdemand/etcdctl-v0.4.6 /usr/local/bin/etcdctl
 RUN chmod +x /usr/local/bin/etcdctl
 
 EXPOSE 4001 7001


### PR DESCRIPTION
This only affects the deis/test-etcd component we use in integration tests. Details:
https://github.com/coreos/etcd/releases/tag/v0.4.6
