### PR TITLE
feat(slugbuilder): build without using a pipe for git archive

### DIFF
--- a/builder/templates/builder
+++ b/builder/templates/builder
@@ -74,11 +74,11 @@ if __name__ == '__main__':
         # some applications do not have a Procfile, so only check for a Dockerfile
         if not os.path.exists(dockerfile):
             if os.path.exists('/buildpacks'):
-                build_cmd = "docker run -i -a stdin {config_env} -v {cache_dir}:/tmp/cache:rw -v /buildpacks:/tmp/buildpacks deis/slugbuilder".format(**locals())
+                build_cmd = "docker run -i -a stdin {config_env} -v {temp_dir}:/tmp/app -v {cache_dir}:/tmp/cache:rw -v /buildpacks:/tmp/buildpacks deis/slugbuilder".format(**locals())
             else:
-                build_cmd = "docker run -i -a stdin {config_env} -v {cache_dir}:/tmp/cache:rw deis/slugbuilder".format(**locals())
+                build_cmd = "docker run -i -a stdin {config_env} -v {temp_dir}:/tmp/app -v {cache_dir}:/tmp/cache:rw deis/slugbuilder".format(**locals())
             # run slugbuilder in the background
-            p = subprocess.Popen("git archive {branch} | ".format(**locals()) + build_cmd, shell=True, cwd=repo_dir, stdout=subprocess.PIPE)
+            p = subprocess.Popen(build_cmd, shell=True, cwd=repo_dir, stdout=subprocess.PIPE)
             container = p.stdout.read().strip('\n')
             # attach to slugbuilder output
             p = subprocess.Popen('docker attach {container}'.format(**locals()), shell=True, cwd=temp_dir)


### PR DESCRIPTION
Ref #785

This will break builds if the corresponding slugbuilder patch is not merged first.

Blocked by deis/slugbuilder#9. After that is merged tests for this branch will pass.
