### PR TITLE
fix(builder): disallow password authentication

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -48,4 +48,5 @@ CMD ["/app/bin/boot"]
 EXPOSE 22
 
 ADD . /app
+ADD sshd_config /etc/ssh/sshd_config
 RUN chown -R root:root /app

--- a/builder/sshd_config
+++ b/builder/sshd_config
@@ -1,0 +1,29 @@
+Port 22
+Protocol 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+UsePrivilegeSeparation yes
+KeyRegenerationInterval 3600
+ServerKeyBits 768
+SyslogFacility AUTH
+LogLevel INFO
+LoginGraceTime 120
+PermitRootLogin yes
+StrictModes yes
+RSAAuthentication yes
+PubkeyAuthentication yes
+IgnoreRhosts yes
+RhostsRSAAuthentication no
+HostbasedAuthentication no
+PermitEmptyPasswords no
+ChallengeResponseAuthentication no
+PasswordAuthentication no
+X11Forwarding no
+X11DisplayOffset 10
+PrintMotd no
+PrintLastLog yes
+TCPKeepAlive yes
+AcceptEnv LANG LC_*
+Subsystem sftp /usr/lib/openssh/sftp-server
+UsePAM yes


### PR DESCRIPTION
Closes #1340

Replaces the previous password prompt with an error message similar to:

``` console
kamina ~/tmp/deis/example-go (git:master) ✔
$ git push deis master
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Ideally we would brand this with a Deis-centric message, but for now
this should be good enough until we overhaul the builder completely.
