### PR TITLE
fix(docs): add client reference for `deis tags`

### DIFF
--- a/docs/reference/client.rst
+++ b/docs/reference/client.rst
@@ -117,3 +117,12 @@ deis releases
 .. automethod:: client.deis.DeisClient.releases_list
 .. automethod:: client.deis.DeisClient.releases_info
 .. automethod:: client.deis.DeisClient.releases_rollback
+
+.. _deis_tags:
+
+deis tags
+---------
+
+.. automethod:: client.deis.DeisClient.tags_list
+.. automethod:: client.deis.DeisClient.tags_set
+.. automethod:: client.deis.DeisClient.tags_unset


### PR DESCRIPTION
http://docs.deis.io/en/latest/reference/client/#deis-tags is not there, but should be.

I tested the Sphinx docs locally.
