### PR TITLE
fix(contrib/coreos): bump timeouts for etcd and fleet

### DIFF
--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -7,10 +7,16 @@ coreos:
     # discovery: https://discovery.etcd.io/12345693838asdfasfadf13939923
     addr: $private_ipv4:4001
     peer-addr: $private_ipv4:7001
+    # give etcd more time if it's under heavy load - prevent leader election thrashing
+    peer-election-timeout: 2000
+    # heartbeat interval should ideally be 1/4 or 1/5 of peer election timeout, but that's a long time...
+    peer-heartbeat-interval: 200
   fleet:
     # We have to set the public_ip here so this works on Vagrant -- otherwise, Vagrant VMs
     # will all publish the same private IP. This is harmless for cloud providers.
     public_ip: $private_ipv4
+    # allow etcd to slow down at times
+    etcd_request_timeout: 3
   units:
   - name: etcd.service
     command: start


### PR DESCRIPTION
See discussion in https://github.com/deis/deis/issues/1688
