### PR TITLE
ref(tests): fix confusing Go style issue

### DIFF
--- a/builder/tests/builder_test.go
+++ b/builder/tests/builder_test.go
@@ -10,8 +10,7 @@ import (
 	"github.com/deis/deis/tests/utils"
 )
 
-func runDeisBuilderTest(
-	t *testing.T, testID string, etcdPort string, servicePort string) {
+func runDeisBuilderTest(t *testing.T, testID string, etcdPort string, servicePort string) {
 	var err error
 	dockercli.RunDeisDataTest(t, "--name", "deis-builder-data",
 		"-v", "/var/lib/docker", "deis/base", "true")
@@ -27,7 +26,8 @@ func runDeisBuilderTest(
 			"-e", "ETCD_PORT="+etcdPort,
 			"-e", "PORT="+servicePort,
 			"--volumes-from", "deis-builder-data",
-			"--privileged", "deis/builder:"+testID)
+			"--privileged", "deis/builder:"+testID,
+		)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "deis-builder running")
 	if err != nil {
@@ -69,7 +69,6 @@ func TestBuilder(t *testing.T) {
 	runDeisBuilderTest(t, testID, etcdPort, servicePort)
 	// TODO: builder needs a few seconds to wake up here--fixme!
 	time.Sleep(5000 * time.Millisecond)
-	dockercli.DeisServiceTest(
-		t, "deis-builder-"+testID, servicePort, "tcp")
+	dockercli.DeisServiceTest(t, "deis-builder-"+testID, servicePort, "tcp")
 	dockercli.ClearTestSession(t, testID)
 }

--- a/cache/tests/cache_test.go
+++ b/cache/tests/cache_test.go
@@ -8,8 +8,7 @@ import (
 	"github.com/deis/deis/tests/utils"
 )
 
-func runDeisCacheTest(
-	t *testing.T, testID string, etcdPort string, servicePort string) {
+func runDeisCacheTest(t *testing.T, testID string, etcdPort string, servicePort string) {
 	var err error
 	cli, stdout, stdoutPipe := dockercli.GetNewClient()
 	go func() {
@@ -20,7 +19,8 @@ func runDeisCacheTest(
 			"-e", "PUBLISH="+servicePort,
 			"-e", "HOST="+utils.GetHostIPAddress(),
 			"-e", "ETCD_PORT="+etcdPort,
-			"deis/cache:"+testID)
+			"deis/cache:"+testID,
+		)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "started")
 	if err != nil {
@@ -39,7 +39,6 @@ func TestCache(t *testing.T) {
 	servicePort := utils.GetRandomPort()
 	fmt.Printf("--- Test deis-cache-%s at port %s\n", testID, servicePort)
 	runDeisCacheTest(t, testID, etcdPort, servicePort)
-	dockercli.DeisServiceTest(
-		t, "deis-cache-"+testID, servicePort, "tcp")
+	dockercli.DeisServiceTest(t, "deis-cache-"+testID, servicePort, "tcp")
 	dockercli.ClearTestSession(t, testID)
 }

--- a/controller/tests/controller_test.go
+++ b/controller/tests/controller_test.go
@@ -10,8 +10,7 @@ import (
 	"github.com/deis/deis/tests/utils"
 )
 
-func runDeisControllerTest(
-	t *testing.T, testID string, etcdPort string, servicePort string) {
+func runDeisControllerTest(t *testing.T, testID string, etcdPort string, servicePort string) {
 	var err error
 	cli, stdout, stdoutPipe := dockercli.GetNewClient()
 	go func() {
@@ -22,7 +21,8 @@ func runDeisControllerTest(
 			"-e", "PUBLISH="+servicePort,
 			"-e", "HOST="+utils.GetHostIPAddress(),
 			"-e", "ETCD_PORT="+etcdPort,
-			"deis/controller:"+testID)
+			"deis/controller:"+testID,
+		)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "Booting")
 	if err != nil {
@@ -59,7 +59,6 @@ func TestController(t *testing.T) {
 	servicePort := utils.GetRandomPort()
 	fmt.Printf("--- Test deis-controller-%s at port %s\n", testID, servicePort)
 	runDeisControllerTest(t, testID, etcdPort, servicePort)
-	dockercli.DeisServiceTest(
-		t, "deis-controller-"+testID, servicePort, "http")
+	dockercli.DeisServiceTest(t, "deis-controller-"+testID, servicePort, "http")
 	dockercli.ClearTestSession(t, testID)
 }

--- a/database/tests/database_test.go
+++ b/database/tests/database_test.go
@@ -8,8 +8,7 @@ import (
 	"github.com/deis/deis/tests/utils"
 )
 
-func runDeisDatabaseTest(
-	t *testing.T, testID string, etcdPort string, servicePort string) {
+func runDeisDatabaseTest(t *testing.T, testID string, etcdPort string, servicePort string) {
 	var err error
 	dockercli.RunDeisDataTest(t, "--name", "deis-database-data",
 		"-v", "/var/lib/postgresql", "deis/base", "true")
@@ -23,7 +22,8 @@ func runDeisDatabaseTest(
 			"-e", "HOST="+utils.GetHostIPAddress(),
 			"-e", "ETCD_PORT="+etcdPort,
 			"--volumes-from", "deis-database-data",
-			"deis/database:"+testID)
+			"deis/database:"+testID,
+		)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "deis-database running")
 	if err != nil {
@@ -42,7 +42,6 @@ func TestDatabase(t *testing.T) {
 	servicePort := utils.GetRandomPort()
 	fmt.Printf("--- Test deis-database-%s at port %s\n", testID, servicePort)
 	runDeisDatabaseTest(t, testID, etcdPort, servicePort)
-	dockercli.DeisServiceTest(
-		t, "deis-database-"+testID, servicePort, "tcp")
+	dockercli.DeisServiceTest(t, "deis-database-"+testID, servicePort, "tcp")
 	dockercli.ClearTestSession(t, testID)
 }

--- a/logger/tests/logger_test.go
+++ b/logger/tests/logger_test.go
@@ -8,8 +8,7 @@ import (
 	"github.com/deis/deis/tests/utils"
 )
 
-func runDeisLoggerTest(
-	t *testing.T, testID string, etcdPort string, servicePort string) {
+func runDeisLoggerTest(t *testing.T, testID string, etcdPort string, servicePort string) {
 	var err error
 	dockercli.RunDeisDataTest(t, "--name", "deis-logger-data",
 		"-v", "/var/log/deis", "deis/base", "/bin/true")
@@ -23,7 +22,8 @@ func runDeisLoggerTest(
 			"-e", "HOST="+utils.GetHostIPAddress(),
 			"-e", "ETCD_PORT="+etcdPort,
 			"--volumes-from", "deis-logger-data",
-			"deis/logger:"+testID)
+			"deis/logger:"+testID,
+		)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "deis-logger running")
 	if err != nil {
@@ -42,7 +42,6 @@ func TestLogger(t *testing.T) {
 	servicePort := utils.GetRandomPort()
 	fmt.Printf("--- Test deis-logger-%s at port %s\n", testID, servicePort)
 	runDeisLoggerTest(t, testID, etcdPort, servicePort)
-	dockercli.DeisServiceTest(
-		t, "deis-logger-"+testID, servicePort, "udp")
+	dockercli.DeisServiceTest(t, "deis-logger-"+testID, servicePort, "udp")
 	dockercli.ClearTestSession(t, testID)
 }

--- a/registry/tests/registry_test.go
+++ b/registry/tests/registry_test.go
@@ -24,7 +24,8 @@ func runDeisRegistryTest(
 			"-e", "HOST="+utils.GetHostIPAddress(),
 			"-e", "ETCD_PORT="+etcdPort,
 			"--volumes-from", "deis-registry-data",
-			"deis/registry:"+testID)
+			"deis/registry:"+testID,
+		)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "Booting")
 	if err != nil {
@@ -52,7 +53,6 @@ func TestRegistry(t *testing.T) {
 	servicePort := utils.GetRandomPort()
 	fmt.Printf("--- Test deis-registry-%s at port %s\n", testID, servicePort)
 	runDeisRegistryTest(t, testID, etcdPort, servicePort)
-	dockercli.DeisServiceTest(
-		t, "deis-registry-"+testID, servicePort, "http")
+	dockercli.DeisServiceTest(t, "deis-registry-"+testID, servicePort, "http")
 	dockercli.ClearTestSession(t, testID)
 }

--- a/router/tests/router_test.go
+++ b/router/tests/router_test.go
@@ -23,7 +23,8 @@ func runDeisRouterTest(
 			"-e", "PUBLISH="+servicePort,
 			"-e", "HOST="+utils.GetHostIPAddress(),
 			"-e", "ETCD_PORT="+etcdPort,
-			"deis/router:"+testID)
+			"deis/router:"+testID,
+		)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "deis-router running")
 	if err != nil {
@@ -60,7 +61,6 @@ func TestRouter(t *testing.T) {
 	runDeisRouterTest(t, testID, etcdPort, servicePort)
 	// TODO: nginx needs a few seconds to wake up here--fixme!
 	time.Sleep(5000 * time.Millisecond)
-	dockercli.DeisServiceTest(
-		t, "deis-router-"+testID, servicePort, "http")
+	dockercli.DeisServiceTest(t, "deis-router-"+testID, servicePort, "http")
 	dockercli.ClearTestSession(t, testID)
 }

--- a/tests/dockercli/dockercli.go
+++ b/tests/dockercli/dockercli.go
@@ -61,8 +61,7 @@ func CloseWrap(args ...io.Closer) error {
 
 // DeisServiceTest tries to connect to a container and port using the
 // specified protocol.
-func DeisServiceTest(
-	t *testing.T, container string, port string, protocol string) {
+func DeisServiceTest(t *testing.T, container string, port string, protocol string) {
 	ipaddr := os.Getenv("HOST_IPADDR")
 	if ipaddr == "" {
 		ipaddr = GetInspectData(
@@ -93,8 +92,7 @@ func DeisServiceTest(
 }
 
 // GetNewClient returns a new docker test client.
-func GetNewClient() (
-	cli *client.DockerCli, stdout *io.PipeReader, stdoutPipe *io.PipeWriter) {
+func GetNewClient() (cli *client.DockerCli, stdout *io.PipeReader, stdoutPipe *io.PipeWriter) {
 	testDaemonAddr := DaemonAddr()
 	testDaemonProto := DaemonProto()
 	stdout, stdoutPipe = io.Pipe()
@@ -104,8 +102,7 @@ func GetNewClient() (
 }
 
 // PrintToStdout prints a string to stdout.
-func PrintToStdout(t *testing.T, stdout *io.PipeReader,
-	stdoutPipe *io.PipeWriter, stoptag string) string {
+func PrintToStdout(t *testing.T, stdout *io.PipeReader, stdoutPipe *io.PipeWriter, stoptag string) string {
 	var result string
 	r := bufio.NewReader(stdout)
 	for {

--- a/tests/mock/mock.go
+++ b/tests/mock/mock.go
@@ -44,7 +44,8 @@ func RunMockDatabase(t *testing.T, uid string, etcdPort string, dbPort string) {
 	etcdutils.Publishvalues(t, dbhandler)
 	etcdutils.SetEtcdValues(t,
 		[]string{"/deis/database/host", "/deis/database/port", "/deis/database/engine"},
-		[]string{ipaddr, dbPort, "postgresql_psycopg2"}, dbhandler.C)
+		[]string{ipaddr, dbPort, "postgresql_psycopg2"}, dbhandler.C,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/ps_test.go
+++ b/tests/ps_test.go
@@ -60,7 +60,8 @@ func psScaleTest(t *testing.T, params *utils.DeisTestConfig) {
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "PasswordAuthentication=no",
-		"core@deis."+params.Domain, "ls")
+		"core@deis."+params.Domain, "ls",
+	)
 	out, err := sshCmd.Output()
 	if err != nil {
 		t.Fatal(err)

--- a/tests/utils/itutils.go
+++ b/tests/utils/itutils.go
@@ -130,8 +130,7 @@ func AuthCancel(t *testing.T, params *DeisTestConfig) {
 
 // CheckList executes a command and optionally tests whether its output does
 // or does not contain a given string.
-func CheckList(
-	t *testing.T, cmd string, params interface{}, contain string, notflag bool) {
+func CheckList(t *testing.T, cmd string, params interface{}, contain string, notflag bool) {
 	var cmdBuf bytes.Buffer
 	tmpl := template.Must(template.New("cmd").Parse(cmd))
 	if err := tmpl.Execute(&cmdBuf, params); err != nil {

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -176,8 +176,7 @@ func runCommand(cmd *exec.Cmd) (exitCode int, err error) {
 	return
 }
 
-func runCommandWithOutput(
-	cmd *exec.Cmd) (output string, exitCode int, err error) {
+func runCommandWithOutput(cmd *exec.Cmd) (output string, exitCode int, err error) {
 	exitCode = 0
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Corrected calls like:

```
Foo(
    bar, baz)
```

to

```
Foo(bar, baz)
```

Taken from the [formatting](http://golang.org/doc/effective_go.html#formatting) section on Effective Go.
