### PR TITLE
feat(controller): pipe release notes to app logs

### DIFF
--- a/tests/apps_test.go
+++ b/tests/apps_test.go
@@ -74,7 +74,8 @@ func appsListTest(t *testing.T, params *utils.DeisTestConfig, notflag bool) {
 
 func appsLogsTest(t *testing.T, params *utils.DeisTestConfig) {
 	cmd := appsLogsCmd
-	utils.Execute(t, cmd, params, true, "204 NO CONTENT")
+	// test for application lifecycle logs
+	utils.Execute(t, cmd, params, false, "204 NO CONTENT")
 	if err := utils.Chdir(params.ExampleApp); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Whenever a release is created for an application, its logs will now
also be seen in `deis logs`. The log pattern follows the same syntax
as Heroku's logs:

```
2014-08-25T20:23:53.275002+00:00 heroku[api]: Enable Logplex by me@bacongobbler.com
2014-08-25T20:23:53.275063+00:00 heroku[api]: Release v2 created by me@bacongobbler.com
```

The log syntax coming from the controller looks like so in the app logs:

```
2014-08-25 14:25:50 deis[api]: bacongobbler created initial release
```

Which follows the same syntax as our app logs:

```
2014-08-25 14:25:50 island-larkspur[web.1]: listening on port 5000...
```

~~ISSUES: Currently the test suite runner silences all logs when the
test suite is running. Because this feature relies on python's
logging module, the application lifecycle logs are silenced as well.~~

EDIT: This now relies on writing to the file itself, so no need to worry about it being silenced in the logs. I've added tests for this.
# Commands Supported

The following application lifecycle logs are supported by this PR:
- `apps:create`
- `ps:scale`
- `git push` (creates a new release)
- `config:set/unset`
- `builds:create` (AKA `deis pull`)
- `limits:set/unset`
- `tags:set/unset`
- `releases:rollback`
- `domains:add/remove`

~~TODO: add `domains:add/remove` support~~

closes #1145 
