### PR TITLE
ref(tests): move test scripts under tests/bin

### DIFF
--- a/tests/bin/build-deis-cli.sh
+++ b/tests/bin/build-deis-cli.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# Creates a python virtual environment and builds the `deis` client binary with it.
+
+virtualenv --system-site-packages venv
+. venv/bin/activate
+pip install docopt==0.6.2 python-dateutil==2.2 PyYAML==3.11 requests==2.3.0 pyinstaller==2.1
+make -C client/ client

--- a/tests/bin/destroy-all-vagrants.sh
+++ b/tests/bin/destroy-all-vagrants.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# WARNING: Don't run this script unless you understand that it will destroy all Deis vagrant VMs.
+#
+# Tells vagrant to destroy all VMs with "deis" in the name.
+
+VMS=$(vagrant global-status | grep deis | awk '{ print $5 }')
+for dir in $VMS; do
+    cd $dir && vagrant destroy --force
+done

--- a/tests/bin/git-ssh-nokeycheck.sh
+++ b/tests/bin/git-ssh-nokeycheck.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Allows git to exec SSH but bypass auth warnings.
+# To use, export the environment variable GIT_SSH as the location of this script,
+# then run git commands as usual:
+# $ export GIT_SSH=$HOME/bin/git-ssh-nokeycheck.sh
+
+SSH_ORIGINAL_COMMAND="ssh $@"
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"

--- a/tests/bin/halt-all-vagrants.sh
+++ b/tests/bin/halt-all-vagrants.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# Tells vagrant to halt all running VMs with "deis" in the name.
+
+RUNNING_VMS=$(vagrant global-status | grep deis | grep running | awk '{ print $5 }')
+for dir in $RUNNING_VMS; do
+    cd $dir && vagrant halt
+done

--- a/tests/bin/prime-docker-images.sh
+++ b/tests/bin/prime-docker-images.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# WARNING: Don't run this script unless you understand that it will remove all Docker items.
+#
+# Purges *all* Docker containers and images from the local graph, then pulls down a set of
+# images to help tests run faster.
+
+# Remove all Dockernalia
+docker kill `docker ps -q`
+docker rm `docker ps -a -q`
+docker rmi -f `docker images -q`
+
+# Pull Deis testing essentials
+docker pull deis/base:latest
+docker pull deis/slugbuilder:latest
+docker pull deis/slugrunner:latest
+docker pull deis/test-etcd:latest
+docker pull paintedfox/postgresql:latest

--- a/tests/bin/start-node.sh
+++ b/tests/bin/start-node.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Connects this machine as a Jenkins node to http://ci.deis.io/
+# Set NODE_NAME and NODE_SECRET to the values provided by Jenkins in the "Manage Nodes"
+# administrative interface.
+
+wget -N http://ci.deis.io/jnlpJars/slave.jar
+java -jar slave.jar -jnlpUrl http://ci.deis.io/computer/${NODE_NAME?}/slave-agent.jnlp -secret ${NODE_SECRET?} &

--- a/tests/bin/test-integration.sh
+++ b/tests/bin/test-integration.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Preps a test environment and runs `make test-integration` with single-node vagrant.
+
+echo Testing ${DEIS_TEST_APP?}...
+
+# Environment reset and configuration
+rm -rf ~/.deis ~/.fleetctl ~/.ssh/known_hosts
+ssh-add -D || eval $(ssh-agent) && ssh-add -D
+ssh-add ~/.vagrant.d/insecure_private_key
+ssh-add ~/.ssh/deis
+cd ${GOPATH?}/src/github.com/deis/deis
+rm -rf tests/example-*
+
+# Vagrant provisioning
+tests/bin/halt-all-vagrant.sh
+vagrant destroy --force
+vagrant up --provider virtualbox --provision
+
+# Trap exit signal to halt vagrant
+function cleanup {
+    set +e
+    make stop
+    vagrant halt
+}
+trap cleanup EXIT
+
+set -e
+
+# Build updated Deis CLI and use it for testing
+virtualenv --system-site-packages venv
+. venv/bin/activate
+pip install docopt==0.6.2 python-dateutil==2.2 PyYAML==3.11 requests==2.3.0 pyinstaller==2.1
+make -C client/ client
+chmod +x client/dist/deis
+export PATH=`pwd`/client/dist:$PATH
+
+# Install Deis and run tests
+make build
+make run
+make test-integration


### PR DESCRIPTION
There are several shell scripts in the $PATH on the CI nodes and
also defined in Jenkins jobs directly. This moves them to a central
location under version control for maintainability.
