### PR TITLE
fix(tests): use our own fork of postgresql container for testing

### DIFF
--- a/tests/bin/prime-docker-images.sh
+++ b/tests/bin/prime-docker-images.sh
@@ -15,4 +15,4 @@ docker pull deis/base:latest
 docker pull deis/slugbuilder:latest
 docker pull deis/slugrunner:latest
 docker pull deis/test-etcd:latest
-docker pull paintedfox/postgresql:latest
+docker pull deis/test-postgresql:latest

--- a/tests/mock/mock.go
+++ b/tests/mock/mock.go
@@ -16,7 +16,7 @@ func RunMockDatabase(t *testing.T, uid string, etcdPort string, dbPort string) {
 	var err error
 	cli, stdout, stdoutPipe := dockercli.GetNewClient()
 	done := make(chan bool, 1)
-	dbImage := "paintedfox/postgresql:latest"
+	dbImage := "deis/test-postgresql:latest"
 	ipaddr := utils.GetHostIPAddress()
 	done <- true
 	go func() {


### PR DESCRIPTION
We had been using paintedfox/postgresql directly from the Docker Hub,
the reasoning being that using a container other than deis/database
keeps the functional tests more honest. Instead, use a container
from a forked repo, so we can control changes to it.
