### PR TITLE
fix(client): use only stdout handler

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -2169,14 +2169,11 @@ correct and the server is running.")
 
 def _init_logger():
     logger = logging.getLogger(__name__)
-    stdoutHandler = logging.StreamHandler(sys.stdout)
-    stderrHandler = logging.StreamHandler(sys.stderr)
+    handler = logging.StreamHandler(sys.stdout)
     # TODO: add a --debug flag
     logger.setLevel(logging.INFO)
-    stdoutHandler.setLevel(logging.INFO)
-    stderrHandler.setLevel(logging.WARNING)
-    logger.addHandler(stdoutHandler)
-    logger.addHandler(stderrHandler)
+    handler.setLevel(logging.INFO)
+    logger.addHandler(handler)
 
 
 def main():


### PR DESCRIPTION
If a warning message was logged, it would be logged to both stdout
and stderr. Using only the stdout handler will only log messages to
stdout.
