### PR TITLE
ref(cache): build Redis from source

### DIFF
--- a/cache/Dockerfile
+++ b/cache/Dockerfile
@@ -1,10 +1,22 @@
 FROM deis/base:latest
 MAINTAINER OpDemand <info@opdemand.com>
 
-# install redis from OS package
-RUN apt-get update && apt-get install -yq python-software-properties
-RUN add-apt-repository ppa:chris-lea/redis-server -y
-RUN apt-get update && apt-get install -yq redis-server
+# build Redis from source
+RUN buildDeps='gcc libc6-dev make curl'; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    set -x; \
+    apt-get update && apt-get install -y $buildDeps net-tools --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /usr/src/redis \
+    && curl -sSL http://download.redis.io/releases/redis-2.8.15.tar.gz -o redis.tar.gz \
+    && echo "afc0d753cea68a26038775df2dea75a76e3d0e1d *redis.tar.gz" | sha1sum -c - \
+    && tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1 \
+    && make -C /usr/src/redis \
+    && make -C /usr/src/redis install \
+    && rm -r redis.tar.gz /usr/src/redis \
+    && apt-get purge -y $buildDeps \
+    && apt-get autoremove -y \
+    && apt-get clean
 
 WORKDIR /app
 CMD ["/app/bin/boot"]

--- a/cache/bin/boot
+++ b/cache/bin/boot
@@ -30,8 +30,9 @@ if ! etcdctl --no-sync -C $ETCD ls $ETCD_PATH >/dev/null 2>&1 ; then
 fi
 
 # spawn the service in the background
+mkdir -p /var/lib/redis
 cd /var/lib/redis
-sudo -u redis /usr/bin/redis-server /etc/redis/redis.conf &
+/usr/local/bin/redis-server /etc/redis/redis.conf &
 SERVICE_PID=$!
 
 # smart shutdown on SIGINT and SIGTERM


### PR DESCRIPTION
Pins our version of Redis to 2.8.15 and builds it from source, discarding the build tools afterward. Based on [docker-library's Redis](https://github.com/docker-library/redis/blob/master/2.8.13/Dockerfile).
