### PR TITLE
fix(controller): fix scale log event on git push

### DIFF
--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -468,7 +468,7 @@ class BuildHookViewSet(BaseHookViewSet):
             release = build.app.release_set.latest()
             new_release = release.new(build.owner, build=build)
             initial = True if build.app.structure == {} else False
-            build.app.deploy(self.request.user, new_release, initial=initial)
+            build.app.deploy(build.owner, new_release, initial=initial)
 
 
 class ConfigHookViewSet(BaseHookViewSet):


### PR DESCRIPTION
This fixes the scale log event displayed after the _first_ `git push` of a new application.

Before this PR:

```
Sep 21 20:26:48 deis-1 sh[17259]: INFO wiggly-teaspoon:  scaled containers web=1
```

After this PR:

```
Sep 21 20:26:48 deis-1 sh[17259]: INFO wiggly-teaspoon: gabrtv scaled containers web=1
```
