### PR TITLE
fix(router): gzip content types syntax fixed

### DIFF
--- a/docs/managing_deis/router_settings.rst
+++ b/docs/managing_deis/router_settings.rst
@@ -30,31 +30,31 @@ Settings used by router
 ---------------------------
 The following etcd keys are used by the router component.
 
-====================================      =============================================================================================================================================================================================
-setting                                   description
-====================================      =============================================================================================================================================================================================
-/deis/domains/*                           domain configuration for applications (set by controller)
-/deis/services/*                          application configuration (set by application unit files)
-/deis/builder/host                        host of the builder component (set by builder)
-/deis/builder/port                        port of the builder component (set by builder)
-/deis/controller/host                     host of the controller component (set by controller)
-/deis/controller/port                     port of the controller component (set by controller)
-/deis/router/bodySize                     nginx body size setting (default: 1m)
-/deis/router/builder/timeout/connect      proxy_connect_timeout for deis-builder (default: 10000). Unit in miliseconds
-/deis/router/builder/timeout/read         proxy_read_timeout for deis-builder (default: 1200000). Unit in miliseconds
-/deis/router/builder/timeout/send         proxy_send_timeout for deis-builder (default: 1200000). Unit in miliseconds
-/deis/router/builder/timeout/tcp          timeout for deis-builder (default: 1200000). Unit in miliseconds
-/deis/router/controller/timeout/connect   proxy_connect_timeout for deis-controller (default: 10m)
-/deis/router/controller/timeout/read      proxy_read_timeout for deis-controller (default: 20m)
-/deis/router/controller/timeout/send      proxy_send_timeout for deis-controller (default: 20m)
-/deis/router/gzip                         nginx gzip setting (default: on)
-/deis/router/gzipHttpVersion              nginx gzipHttpVersion setting (default: 1.0)
-/deis/router/gzipCompLevel                nginx gzipCompLevel setting (default: 2)
-/deis/router/gzipProxied                  nginx gzipProxied setting (default: any)
-/deis/router/gzipVary                     nginx gzipVary setting (default: on)
-/deis/router/gzipDisable                  nginx gzipDisable setting (default: "msie6")
-/deis/router/gzipTypes                    nginx gzipTypes setting (default: "application/x-javascript, application/xhtml+xml, application/xml, application/xml+rss, application/json, text/css, text/javascript, text/plain, text/xml")
-====================================      =============================================================================================================================================================================================
+=======================================      =============================================================================================================================================================================================
+setting                                      description
+=======================================      =============================================================================================================================================================================================
+/deis/domains/*                              domain configuration for applications (set by controller)
+/deis/services/*                             application configuration (set by application unit files)
+/deis/builder/host                           host of the builder component (set by builder)
+/deis/builder/port                           port of the builder component (set by builder)
+/deis/controller/host                        host of the controller component (set by controller)
+/deis/controller/port                        port of the controller component (set by controller)
+/deis/router/bodySize                        nginx body size setting (default: 1m)
+/deis/router/builder/timeout/connect         proxy_connect_timeout for deis-builder (default: 10000). Unit in miliseconds
+/deis/router/builder/timeout/read            proxy_read_timeout for deis-builder (default: 1200000). Unit in miliseconds
+/deis/router/builder/timeout/send            proxy_send_timeout for deis-builder (default: 1200000). Unit in miliseconds
+/deis/router/builder/timeout/tcp             timeout for deis-builder (default: 1200000). Unit in miliseconds
+/deis/router/controller/timeout/connect      proxy_connect_timeout for deis-controller (default: 10m)
+/deis/router/controller/timeout/read         proxy_read_timeout for deis-controller (default: 20m)
+/deis/router/controller/timeout/send         proxy_send_timeout for deis-controller (default: 20m)
+/deis/router/gzip                            nginx gzip setting (default: on)
+/deis/router/gzipHttpVersion                 nginx gzipHttpVersion setting (default: 1.0)
+/deis/router/gzipCompLevel                   nginx gzipCompLevel setting (default: 2)
+/deis/router/gzipProxied                     nginx gzipProxied setting (default: any)
+/deis/router/gzipVary                        nginx gzipVary setting (default: on)
+/deis/router/gzipDisable                     nginx gzipDisable setting (default: "msie6")
+/deis/router/gzipTypes                       nginx gzipTypes setting (default: "application/x-javascript application/xhtml+xml application/xml application/xml+rss application/json text/css text/javascript text/plain text/xml")
+=======================================      =============================================================================================================================================================================================
 
 Using a custom router image
 ---------------------------

--- a/router/bin/boot
+++ b/router/bin/boot
@@ -43,7 +43,7 @@ etcd_set_default gzipCompLevel 2
 etcd_set_default gzipProxied any
 etcd_set_default gzipVary on
 etcd_set_default gzipDisable "\"msie6\""
-etcd_set_default gzipTypes "application/x-javascript, application/xhtml+xml, application/xml, application/xml+rss, application/json, text/css, text/javascript, text/plain, text/xml"
+etcd_set_default gzipTypes "application/x-javascript application/xhtml+xml application/xml application/xml+rss application/json text/css text/javascript text/plain text/xml"
 
 # wait for confd to run once and install initial templates
 until confd -onetime -node $ETCD -config-file /app/confd.toml >/dev/null 2>/dev/null; do


### PR DESCRIPTION
gzip content types are only whitespace separated and fixed missing table her http://docs.deis.io/en/latest/managing_deis/router_settings/
