### PR TITLE
docs(deisctl): add unit search paths behavior to README

### DIFF
--- a/deisctl/README.md
+++ b/deisctl/README.md
@@ -211,6 +211,13 @@ deis-router@2.service: launched
 deis-router@3.service: launched
 ```
 
+## Unit Search Paths
+
+deisctl looks for unit files in these directories, in this order:
+- the $DEISCTL_UNITS environment variable, if set
+- $HOME/.deis/units
+- /var/lib/deis/units
+
 ## License
 
 Copyright 2014, OpDemand LLC


### PR DESCRIPTION
Closes deis/deisctl#99, deis/deisctl#100.

[skip ci]
