### PR TITLE
fix(deisctl): install only deisctl

### DIFF
--- a/deisctl/.gitignore
+++ b/deisctl/.gitignore
@@ -1,5 +1,5 @@
 package/
-deisctl/deisctl
+deisctl
 makeself/
 
 # ctags index

--- a/deisctl/Makefile
+++ b/deisctl/Makefile
@@ -1,7 +1,7 @@
 COMPONENTS=builder cache controller database logger registry router
 
 build:
-	CGO_ENABLED=0 godep go build -a -ldflags '-s' ./...
+	CGO_ENABLED=0 godep go build -a -ldflags '-s' .
 
 installer:
 	rm -rf dist && mkdir -p dist
@@ -12,7 +12,7 @@ installer:
 		"deisctl refresh-units && chmod 755 /var/lib/deis /var/lib/deis/units && chmod -R 644 /var/lib/deis/units/*"
 
 install:
-	godep go install -v ./...
+	godep go install -v .
 
 setup-root-gotools:
 	sudo GOPATH=/tmp/tmpGOPATH go get -u -v code.google.com/p/go.tools/cmd/cover


### PR DESCRIPTION
./... means "this and all subpackages", but we only want to build
`deisctl`. The other problem seems to be that ./... doesn't actually
drop the main binary in the root.
