### PR TITLE
fix(deisctl): create unit download URL properly after move to subdir

### DIFF
--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -296,7 +296,7 @@ Options:
 		return err
 	}
 	// download and save the unit files to the specified path
-	rootURL := "https://raw.githubusercontent.com/deis/deis/deisctl/"
+	rootURL := "https://raw.githubusercontent.com/deis/deis/"
 	tag := args["--tag"].(string)
 	units := []string{
 		"deis-builder.service",
@@ -311,7 +311,7 @@ Options:
 		"deis-router.service",
 	}
 	for _, unit := range units {
-		src := rootURL + tag + "/units/" + unit
+		src := rootURL + tag + "/deisctl/units/" + unit
 		dest := filepath.Join(dir, unit)
 		res, err := http.Get(src)
 		if err != nil {


### PR DESCRIPTION
When moving `deisctl` to the `deis` repo, I botched the URL construction for downloading the unit files; this fixes it. Not that `deis refresh-units -t` isn't going to work for anything but recent SHAs since there are no tags (yet) with the _deisctl/_ directory in it.

Refs #1958.
