### PR TITLE
fix(controller): Use correct entrypoint for run

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -496,8 +496,14 @@ class Container(UuidAuditedModel):
         """Run a one-off command"""
         image = self.release.image + ':v' + str(self.release.version)
         job_id = self._job_id
+        entrypoint = '/bin/bash'
+        if self.release.build.procfile:
+            entrypoint = '/runner/init'
+            command = "'{}'".format(command)
+        else:
+            command = "-c '{}'".format(command)
         try:
-            rc, output = self._scheduler.run(job_id, image, command)
+            rc, output = self._scheduler.run(job_id, image, entrypoint, command)
             return rc, output
         except Exception as e:
             err = '{} (run): {}'.format(job_id, e)

--- a/controller/scheduler/chaos.py
+++ b/controller/scheduler/chaos.py
@@ -54,7 +54,7 @@ class ChaosSchedulerClient(object):
             raise RuntimeError
         return True
 
-    def run(self, name, image, command):
+    def run(self, name, image, entrypoint, command):
         """
         Run a one-off command
         """

--- a/controller/scheduler/mock.py
+++ b/controller/scheduler/mock.py
@@ -44,7 +44,7 @@ class MockSchedulerClient(object):
         """
         return
 
-    def run(self, name, image, command):
+    def run(self, name, image, entrypoint, command):
         """
         Run a one-off command
         """


### PR DESCRIPTION
Running commands in an image build using git push requires to use ‘/runner/init’ as entrypoint, otherwise environment variables inject by buildpacks are missing.

Fixes #1801, fixes #1568
