### PR TITLE
Update gunicorn to support dynamic configuration reload

### DIFF
--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -55,7 +55,9 @@ chown -R deis:deis /var/log/deis
 sudo -E -u deis ./manage.py syncdb --migrate --noinput
 
 # spawn a gunicorn server in the background
-sudo -E -u deis ./manage.py run_gunicorn -b 0.0.0.0 -w 8 -t 600 -n deis --log-level debug --pid=/tmp/gunicorn.pid --timeout=1200 &
+sudo -E -u deis gunicorn deis.wsgi -b 0.0.0.0 -w 8 -n deis --timeout=1200 --pid=/tmp/gunicorn.pid \
+                         --log-level info --error-logfile - --access-logfile - \
+                         --access-logformat '%(h)s "%(r)s" %(s)s %(b)s "%(a)s"' &
 
 # smart shutdown on SIGINT and SIGTERM
 function on_exit() {

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -12,7 +12,7 @@ django-json-field==0.5.5
 django-yamlfield==0.5
 djangorestframework==2.3.14
 docker-py==0.4.0
-gunicorn==18.0
+gunicorn==19.1.1
 paramiko==1.14.1
 psycopg2==2.5.2
 python-etcd==0.3.0


### PR DESCRIPTION
This PR bumps gunicorn from 18.0.0 to 19.1.1.  With the new version, the controller now properly reloads settings when a `SIGHUP` signal is received.  This is important for upcoming work on controller HA in case the database or registry move hosts.

Closes #1928.
Refs #984.
