### PR TITLE
ref(data-units): use ubuntu:14.04 instead of deprecated deis/base

### DIFF
--- a/database/tests/database_test.go
+++ b/database/tests/database_test.go
@@ -19,7 +19,7 @@ func TestDatabase(t *testing.T) {
 	defer cli.CmdRm("-f", etcdName)
 	dataName := "deis-database-data-" + tag
 	dockercli.RunDeisDataTest(t, "--name", dataName,
-		"-v", "/var/lib/postgresql", "ubuntu:14.04", "true")
+		"-v", "/var/lib/postgresql", "ubuntu:14.04", "/bin/true")
 	host, port := utils.HostAddress(), utils.RandomPort()
 	fmt.Printf("--- Run deis/database:%s at %s:%s\n", tag, host, port)
 	name := "deis-database-" + tag

--- a/deisctl/units/deis-database-data.service
+++ b/deisctl/units/deis-database-data.service
@@ -4,8 +4,8 @@ Description=deis-database-data
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStartPre=/bin/sh -c "docker history deis/base:latest >/dev/null 2>&1 || docker pull deis/base:latest"
-ExecStart=/bin/sh -c "docker inspect deis-database-data >/dev/null 2>&1 || docker run --name deis-database-data -v /var/lib/postgresql deis/base:latest true"
+ExecStartPre=/bin/sh -c "docker history ubuntu:14.04 >/dev/null 2>&1 || docker pull ubuntu:14.04"
+ExecStart=/bin/sh -c "docker inspect deis-database-data >/dev/null 2>&1 || docker run --name deis-database-data -v /var/lib/postgresql ubuntu:14.04 /bin/true"
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-logger-data.service
+++ b/deisctl/units/deis-logger-data.service
@@ -4,8 +4,8 @@ Description=deis-logger-data
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStartPre=/bin/sh -c "docker history deis/base:latest >/dev/null 2>&1 || docker pull deis/base:latest"
-ExecStart=/bin/sh -c "docker inspect deis-logger-data >/dev/null 2>&1 || docker run --name deis-logger-data -v /var/log/deis deis/base:latest true"
+ExecStartPre=/bin/sh -c "docker history ubuntu:14.04 >/dev/null 2>&1 || docker pull ubuntu:14.04"
+ExecStart=/bin/sh -c "docker inspect deis-logger-data >/dev/null 2>&1 || docker run --name deis-logger-data -v /var/log/deis ubuntu:14.04 /bin/true"
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-registry-data.service
+++ b/deisctl/units/deis-registry-data.service
@@ -4,8 +4,8 @@ Description=deis-registry-data
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStartPre=/bin/sh -c "docker history deis/base:latest >/dev/null 2>&1 || docker pull deis/base:latest"
-ExecStart=/bin/sh -c "docker inspect deis-registry-data >/dev/null 2>&1 || docker run --name deis-registry-data -v /data deis/base:latest /bin/true"
+ExecStartPre=/bin/sh -c "docker history ubuntu:14.04 >/dev/null 2>&1 || docker pull ubuntu:14.04"
+ExecStart=/bin/sh -c "docker inspect deis-registry-data >/dev/null 2>&1 || docker run --name deis-registry-data -v /data ubuntu:14.04 /bin/true"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Although these data containers may be on their way out soon, for now it is wasteful to have them continue to use deis/base. The functional tests were already using ubuntu:14.04 for data containers. Doing so allows sharing of docker layers, whereas deis/base uses ubuntu:12.04.
