### PR TITLE
fix(router): update to confd 0.5.x branch to fix sort issue

### DIFF
--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/opdem
     && chmod +x /usr/local/bin/etcdctl
 
 # install confd
-RUN curl -sSL -o /usr/local/bin/confd https://s3-us-west-2.amazonaws.com/opdemand/confd-v0.5.0-json \
+RUN curl -sSL -o /usr/local/bin/confd https://s3-us-west-2.amazonaws.com/opdemand/confd-git-b8e693c \
     && chmod +x /usr/local/bin/confd
 
 WORKDIR /app


### PR DESCRIPTION
Switching back to upstream's 0.5.x branch resolves the sorting issue and prevents excess signals.  Post 0.13, we plan on moving to the mainline confd.  Closes #2030.
