### PR TITLE
docs(client readme): remove travis build status icon

### DIFF
--- a/client/README.rst
+++ b/client/README.rst
@@ -6,9 +6,6 @@ Deis controller, providing a Heroku-inspired PaaS workflow.
 .. image:: https://badge.fury.io/py/deis.png
     :target: http://badge.fury.io/py/deis
 
-.. image:: https://travis-ci.org/deis/deis.png?branch=master
-    :target: https://travis-ci.org/deis/deis
-
 .. image:: https://pypip.in/d/deis/badge.png
     :target: https://pypi.python.org/pypi/deis/
     :alt: Downloads


### PR DESCRIPTION
As travis is no longer being used
