### PR TITLE
fix(tests): mock postgresql should wait until initialization complete

### DIFF
--- a/tests/mock/mock.go
+++ b/tests/mock/mock.go
@@ -33,7 +33,7 @@ func RunMockDatabase(t *testing.T, tag string, etcdPort string, dbPort string) {
 			dbImage)
 	}()
 	time.Sleep(1000 * time.Millisecond)
-	dockercli.PrintToStdout(t, stdout, stdoutPipe, "Starting")
+	dockercli.PrintToStdout(t, stdout, stdoutPipe, "Initialization complete.")
 	setkeys := []string{
 		"/deis/database/user",
 		"/deis/database/password",


### PR DESCRIPTION
Note this required a corresponding change in deis/test-postgresql@3eba8075cffabf7deb7b32a574dbb33b956187a3.

Closes #1919.
