### PR TITLE
fix(tests): Increased test timeout for smoke tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ test: test-smoke
 
 test-smoke: test-style
 	GOPATH=$(CURDIR)/_vendor:$(GOPATH) \
-		go test -tags integration -short -v -run TestSmoke
+		go test -tags integration -short -timeout 20m -v -run TestSmoke
 
 test-full: test-style
 	GOPATH=$(CURDIR)/_vendor:$(GOPATH) \


### PR DESCRIPTION
For some heroku buildpacks the initial setup is really slow. This should fix the php smoke tests and provide more room for flaky tests: http://ci.deis.io/job/test-nightly-play/6/console (Passing, but runtime: 543.13 seconds)
