### PR TITLE
ref(Makefile): refactor `make dev-release`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,12 @@ run: install start
 dev-release:
 	@$(foreach C, $(COMPONENTS), $(MAKE) -C $(C) dev-release &&) echo done
 
+push:
+	@$(foreach C, $(COMPONENTS), $(MAKE) -C $(C) push &&) echo done
+
+set-image:
+	@$(foreach C, $(COMPONENTS), $(MAKE) -C $(C) set-image &&) echo done
+
 release: check-registry
 	@$(foreach C, $(COMPONENTS), $(MAKE) -C $(C) release &&) echo done
 	@$(foreach C, $(CLIENTS), $(MAKE) -C $(C) release &&) echo done

--- a/builder/Makefile
+++ b/builder/Makefile
@@ -30,9 +30,13 @@ restart: stop start
 
 run: install start
 
-dev-release: check-registry check-deisctl
+dev-release: push set-image
+
+push: check-registry
 	docker tag $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
+
+set-image: check-deisctl
 	deisctl config $(COMPONENT) set image=$(DEV_IMAGE)
 
 release:

--- a/cache/Makefile
+++ b/cache/Makefile
@@ -29,9 +29,13 @@ restart: stop start
 
 run: install start
 
-dev-release: check-registry check-deisctl
+dev-release: push set-image
+
+push: check-registry
 	docker tag $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
+
+set-image: check-deisctl
 	deisctl config $(COMPONENT) set image=$(DEV_IMAGE)
 
 release:

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -33,9 +33,13 @@ restart: stop start
 
 run: install start
 
-dev-release: check-registry check-deisctl
+dev-release: push set-image
+
+push: check-registry
 	docker tag $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
+
+set-image: check-deisctl
 	deisctl config $(COMPONENT) set image=$(DEV_IMAGE)
 
 release:

--- a/database/Makefile
+++ b/database/Makefile
@@ -29,9 +29,13 @@ restart: stop start
 
 run: install start
 
-dev-release: check-registry check-deisctl
+dev-release: push set-image
+
+push: check-registry
 	docker tag $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
+
+set-image: check-deisctl
 	deisctl config $(COMPONENT) set image=$(DEV_IMAGE)
 
 release:

--- a/logger/Makefile
+++ b/logger/Makefile
@@ -29,9 +29,13 @@ restart: stop start
 
 run: install start
 
-dev-release: check-registry check-deisctl
+dev-release: push set-image
+
+push: check-registry
 	docker tag $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
+
+set-image: check-deisctl
 	deisctl config $(COMPONENT) set image=$(DEV_IMAGE)
 
 release:

--- a/logspout/Makefile
+++ b/logspout/Makefile
@@ -36,9 +36,13 @@ restart: stop start
 
 run: install start
 
-dev-release: check-registry check-deisctl
+dev-release: push set-image
+
+push: check-registry
 	docker tag $(RELEASE_IMAGE) $(DEV_DOCKER_IMAGE)
 	docker push $(DEV_DOCKER_IMAGE)
+
+set-image: check-deisctl
 	deisctl config $(COMPONENT) set image=$(DEV_DOCKER_IMAGE)
 
 release:

--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -21,9 +21,13 @@ full-clean: check-docker check-registry
 install: check-deisctl
 	deisctl install publisher
 
-dev-release: check-docker check-registry check-deisctl
+dev-release: push set-image
+
+push: check-registry
 	docker tag $(RELEASE_IMAGE) $(REMOTE_IMAGE)
 	docker push $(REMOTE_IMAGE)
+
+set-image: check-deisctl
 	deisctl config publisher set image=$(REMOTE_IMAGE)
 
 release: check-docker

--- a/registry/Makefile
+++ b/registry/Makefile
@@ -29,9 +29,13 @@ restart: stop start
 
 run: install start
 
-dev-release: check-registry check-deisctl
+dev-release: push set-image
+
+push: check-registry
 	docker tag $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
+
+set-image: check-deisctl
 	deisctl config $(COMPONENT) set image=$(DEV_IMAGE)
 
 release:

--- a/router/Makefile
+++ b/router/Makefile
@@ -7,7 +7,7 @@ DEV_IMAGE = $(DEV_REGISTRY)/$(IMAGE)
 build: check-docker
 	cd parent && docker build -t deis/binary-router .
 	docker cp `docker run -d deis/binary-router`:/nginx.tgz .
-	docker build -t $(IMAGE) .	
+	docker build -t $(IMAGE) .
 	rm nginx.tgz
 
 clean: check-docker check-registry
@@ -32,9 +32,13 @@ restart: stop start
 
 run: install start
 
-dev-release: check-registry check-deisctl
+dev-release: push set-image
+
+push: check-registry
 	docker tag $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
+
+set-image: check-deisctl
 	deisctl config $(COMPONENT) set image=$(DEV_IMAGE)
 
 release:

--- a/store/Makefile
+++ b/store/Makefile
@@ -65,15 +65,19 @@ restart: stop start
 
 run: install start
 
-dev-release: check-registry check-deisctl
+dev-release: push set-image
+
+push: check-registry
 	docker tag $(DAEMON_IMAGE) $(DAEMON_DEV_IMAGE)
 	docker push $(DAEMON_DEV_IMAGE)
-	deisctl config store-daemon set image=$(DAEMON_DEV_IMAGE)
 	docker tag $(MONITOR_IMAGE) $(MONITOR_DEV_IMAGE)
 	docker push $(MONITOR_DEV_IMAGE)
-	deisctl config store-monitor set image=$(MONITOR_DEV_IMAGE)
 	docker tag $(GATEWAY_IMAGE) $(GATEWAY_DEV_IMAGE)
 	docker push $(GATEWAY_DEV_IMAGE)
+
+set-image: check-deisctl
+	deisctl config store-daemon set image=$(DAEMON_DEV_IMAGE)
+	deisctl config store-monitor set image=$(MONITOR_DEV_IMAGE)
 	deisctl config store-gateway set image=$(GATEWAY_DEV_IMAGE)
 
 release:


### PR DESCRIPTION
This allows us to run `make -C controller config` when we know that
the image is pushed onto the registry and we just need to tell the
cluster to use this image. This is useful for when we kill the cluster
but we're still on the same commit as before, or we know that the
tag is up on the shared dev registry but we've purged our local
docker graph.
