### PR TITLE
fix(publisher): skip when failed to retrieve container

### DIFF
--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -60,7 +60,8 @@ func listenContainers(client *docker.Client, etcdClient *etcd.Client, ttl time.D
 			if event.Status == "start" {
 				container, err := getContainer(client, event.ID)
 				if err != nil {
-					log.Fatal(err)
+					log.Println(err)
+					continue
 				}
 				publishContainer(etcdClient, container, ttl)
 			}


### PR DESCRIPTION
There is a race condition where a container starts via `docker run`,
but then immediately fails because an incorrect command was specified
or some other error occurred that caused the container to fail over. In
this case, we should just log and fail over, rather than killing
publisher.
