### PR TITLE
feat(router): Changed store hostname to deis-store

### DIFF
--- a/router/templates/nginx.conf
+++ b/router/templates/nginx.conf
@@ -74,7 +74,7 @@ http {
     }
 
     server {
-        server_name ~^store\.deis\.(?<domain>.+)$;
+        server_name ~^deis-store\.(?<domain>.+)$;
         server_name_in_redirect off;
         port_in_redirect off;
 


### PR DESCRIPTION
SSL and multilevel subdomains are not easy to setup. http://blog.endpoint.com/2013/10/ssl-certificate-sans-and-multi-level.html
This makes deis-store accessible via https when using a standard wildcard certificate.
