### PR TITLE
fix(controller): use build image for publishing releases

### DIFF
--- a/builder/templates/builder
+++ b/builder/templates/builder
@@ -61,9 +61,8 @@ GIT_SHA=$(get_git_sha $REPO_DIR $BRANCH)
 SHORT_SHA=${GIT_SHA:0:8}
 
 # define image names
-TMP_IMAGE="${APP_NAME}:git-${SHORT_SHA}"
-TARGET_IMAGE="{{ .deis_registry_host }}:{{ .deis_registry_port }}/${APP_NAME}"
-IMAGE_REFERENCE=$APP_NAME
+IMAGE_NAME="$APP_NAME:git-$SHORT_SHA"
+TMP_IMAGE="{{ .deis_registry_host }}:{{ .deis_registry_port }}/$IMAGE_NAME"
 
 # create app directories
 mkdir -p $BUILD_DIR $CACHE_DIR
@@ -142,10 +141,8 @@ fi
 echo
 puts-step "Building Docker image"
 docker build -t $TMP_IMAGE . 2>&1
-docker tag $TMP_IMAGE $TARGET_IMAGE
-
 puts-step "Pushing image to private registry"
-docker push $TARGET_IMAGE  &>/dev/null
+docker push $TMP_IMAGE  &>/dev/null
 echo
 
 if [ -f $TMP_DIR/slug.tgz ]; then
@@ -169,7 +166,7 @@ DOCKERFILE=$(echo $DOCKERFILE | sed -e 's/\"/\\\"/g')
 
 puts-step "Launching... "
 URL="{{ .deis_controller_protocol }}://{{ .deis_controller_host }}:{{ .deis_controller_port }}/api/hooks/build"
-DATA="{\"sha\":\"$GIT_SHA\",\"receive_user\":\"$USER\",\"receive_repo\":\"$APP_NAME\",\"image\":\"$IMAGE_REFERENCE\",\"procfile\":\"$RELEASE_INFO\",\"dockerfile\":\"$DOCKERFILE\"}"
+DATA="{\"sha\":\"$SHORT_SHA\",\"receive_user\":\"$USER\",\"receive_repo\":\"$APP_NAME\",\"image\":\"$APP_NAME\",\"procfile\":\"$RELEASE_INFO\",\"dockerfile\":\"$DOCKERFILE\"}"
 
 # notify the controller that the push was successful
 RESPONSE=$(curl -s -XPOST \
@@ -199,4 +196,4 @@ echo
 cd $REPO_DIR
 git gc &>/dev/null
 docker rm -f $JOB &>/dev/null
-docker rmi -f $TMP_IMAGE $TARGET_IMAGE &>/dev/null
+docker rmi -f $TMP_IMAGE &>/dev/null

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -493,7 +493,10 @@ class BuildHookViewSet(BaseHookViewSet):
     def post_save(self, build, created=False):
         if created:
             release = build.app.release_set.latest()
-            new_release = release.new(build.owner, build=build)
+            source_version = 'latest'
+            if build.sha:
+                source_version = 'git-{}'.format(build.sha)
+            new_release = release.new(build.owner, build=build, source_version=source_version)
             initial = True if build.app.structure == {} else False
             try:
                 build.app.deploy(build.owner, new_release, initial=initial)

--- a/controller/registry/private.py
+++ b/controller/registry/private.py
@@ -59,7 +59,7 @@ def publish_release(source, config, target):
     image['id'] = _new_id()
     config['DEIS_APP'] = target_image
     config['DEIS_RELEASE'] = target_tag
-    image['config']['Env'] = _construct_env(image['config']['Env'], config)
+    image['config']['Env'] = _construct_env(config)
     # update and tag the new image
     _commit(target_image, image, _empty_tar_archive(), target_tag)
 
@@ -162,17 +162,10 @@ def _put_tag(image_id, repository_path, tag):
 
 # utility functions
 
-def _construct_env(env, config):
+def _construct_env(config):
     "Update current environment with latest config"
     new_env = []
-    # see if we need to update existing ENV vars
-    for e in env:
-        k, v = e.split('=', 1)
-        if k in config:
-            # update values defined by config
-            v = config.pop(k)
-        new_env.append("{}={}".format(encode(k), encode(v)))
-    # add other config ENV items
+    # add config ENV items
     for k, v in config.items():
         new_env.append("{}={}".format(encode(k), encode(v)))
     return new_env


### PR DESCRIPTION
A release == build + config, not release + config. This change forces the builder to explicitly push a build tag, then tells the controller to use the last known build image, rather than tagging it as a release and bumping config on top of `latest`.

fixes https://github.com/deis/deis/issues/1818
