### PR TITLE
ref(builder/registry): have builder push slugrunner in ExecStartPost

### DIFF
--- a/builder/conf.d/push-images.toml
+++ b/builder/conf.d/push-images.toml
@@ -1,0 +1,10 @@
+[template]
+src   = "push-images"
+dest  = "/usr/local/bin/push-images"
+uid = 0
+gid = 0
+mode  = "0755"
+keys = [
+  "/deis/registry",
+]
+check_cmd = "/app/bin/check {{ .src }}"

--- a/builder/templates/push-images
+++ b/builder/templates/push-images
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# wait until the docker image exists
+until docker history deis/slugrunner >/dev/null 2>&1; do
+  sleep 2
+done
+
+# tag and push
+docker tag deis/slugrunner:latest {{ .deis_registry_host }}:{{ .deis_registry_port }}/deis/slugrunner:latest
+docker push {{ .deis_registry_host }}:{{ .deis_registry_port }}/deis/slugrunner:latest

--- a/deisctl/units/deis-builder.service
+++ b/deisctl/units/deis-builder.service
@@ -8,6 +8,7 @@ ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder`; docker h
 ExecStartPre=/bin/sh -c "docker inspect deis-builder >/dev/null && docker rm -f deis-builder || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker run --name deis-builder --rm -p 2223:22 -e EXTERNAL_PORT=2223 -e HOST=$COREOS_PRIVATE_IPV4 --privileged $IMAGE"
 ExecStartPost=/bin/sh -c "echo 'Waiting for builder on 2223/tcp...' && until echo 'dummy-value' | ncat $COREOS_PRIVATE_IPV4 2223 >/dev/null 2>&1; do sleep 1; done"
+ExecStartPost=/bin/bash -c "nsenter --pid --uts --mount --ipc --net --target $(docker inspect --format='{{ .State.Pid }}' deis-builder) /usr/local/bin/push-images"
 ExecStopPost=/usr/bin/docker stop deis-builder
 
 [Install]

--- a/deisctl/units/deis-registry.service
+++ b/deisctl/units/deis-registry.service
@@ -7,8 +7,7 @@ TimeoutStartSec=30m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry`; docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-registry >/dev/null && docker rm -f deis-registry || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docker run --name deis-registry --rm -p 5000:5000 -e EXTERNAL_PORT=5000 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
-ExecStartPost=/bin/sh -c "echo 'Waiting for listener on 5000/tcp...' && until echo 'dummy-value' | ncat $COREOS_PRIVATE_IPV4 5000 >/dev/null 2>&1; do sleep 1; done && docker pull deis/slugrunner:latest && docker tag deis/slugrunner $COREOS_PRIVATE_IPV4:5000/deis/slugrunner && docker push $COREOS_PRIVATE_IPV4:5000/deis/slugrunner"
-ExecStopPost=/usr/bin/docker stop deis-registry
+ExecStopPost=-/usr/bin/docker stop deis-registry
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Because we have found no way to seed a Docker-in-Docker images at build time, we must seed the builder with a `deis/slug*` on boot.  In order to speed initial deploy times, we must also seed the exact layers we create in the builder for `deis/slugrunner` on the registry.

This PR adds a `push-images` script which is called in the builder's `ExecStartPost`.  This ensures the registry contains the correct layers each time we start the builder.  It also removes registry-seeding for users who do not deploy the builder (since they don't require the slugrunner).

Replaces #2048.
