### PR TITLE
Retry Fleet container scheduling operations

### DIFF
--- a/controller/scheduler/coreos.py
+++ b/controller/scheduler/coreos.py
@@ -189,7 +189,13 @@ class FleetHTTPClient(object):
         self._wait_for_destroy(name)
 
     def _destroy_container(self, name):
-        return self._delete_unit(name)
+        for attempt in range(RETRIES):
+            try:
+                self._delete_unit(name)
+                break
+            except:
+                if attempt == (RETRIES - 1):  # account for 0 indexing
+                    raise
 
     def run(self, name, image, entrypoint, command):  # noqa
         """Run a one-off command"""


### PR DESCRIPTION
This PR introduces some retry logic to work around common Fleet failures.  The two failures we see are:
- Failed to create container (see #1997)
- Failed to destroy container (see #1997)
- Failed to start container -- where Fleet reports units as "failed" for a time even though they go "active" shortly

Fixes #1997
