### PR TITLE
fix(controller): increment run containers and keep db models

### DIFF
--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -392,6 +392,8 @@ class AppContainerViewSet(BaseAppViewSet):
         container_type = self.kwargs.get('type')
         if container_type:
             qs = qs.filter(type=container_type)
+        else:
+            qs = qs.exclude(type='run')
         return qs
 
     def get_object(self, *args, **kwargs):


### PR DESCRIPTION
This PR keeps the database models for containers created by `deis run`.  This ensures `run` processes are incremented following Heroku behavior and fixing problems related to reusing container names in Fleet.
