### PR TITLE
fix(deisctl): escape $HOME in post-install script

### DIFF
--- a/deisctl/Makefile
+++ b/deisctl/Makefile
@@ -16,7 +16,7 @@ installer:
 		"./deisctl refresh-units \
 		&& echo \
 		&& echo '\033[0;36mdeisctl\033[0m is in the current directory and unit files are' \
-		&& echo 'in $$HOME/.deis/units. Please move \033[0;36mdeisctl\033[0m to a' \
+		&& echo 'in \$$HOME/.deis/units. Please move \033[0;36mdeisctl\033[0m to a' \
 		&& echo 'directory in your search PATH.' \
 		&& echo \
 		&& echo 'See http://docs.deis.io/ for documentation.' \


### PR DESCRIPTION
Otherwise $HOME was evaluated at the time the installer script was created, meaning everyone would see their unit files had been installed to "/home/jenkins/.deis/units" instead of to their actual $HOME dir.
