### PR TITLE
fix(registry): make deis-cache mandatory

### DIFF
--- a/registry/templates/config.yml
+++ b/registry/templates/config.yml
@@ -26,8 +26,8 @@ common: &common
         tags_cache_ttl: _env:MIRROR_TAGS_CACHE_TTL:172800 # seconds
 
     cache:
-        host: {{ .deis_cache_host }}
-        port: {{ .deis_cache_port }}
+        host: {{ or (.deis_cache_host) "~" }}
+        port: {{ or (.deis_cache_port) "~" }}
         password: _env:CACHE_REDIS_PASSWORD
         db: 1
 


### PR DESCRIPTION
Sometimes the redis cache would take longer than the registry to come
up. In that case, confd would then set the host and port to be "",
in which case the registry would parse the YAML value as `None`. This
change makes the cache mandatory in order for the registry to come up.

fixes https://github.com/deis/deis/issues/1885
