### PR TITLE
fix(Makefile): fix multiple make discovery-url runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ dev-registry: check-docker
 	@echo "    export DEV_REGISTRY=`boot2docker ip 2>/dev/null`:5000"
 
 discovery-url:
-	sed -e "s,# discovery: https://discovery.etcd.io/12345693838asdfasfadf13939923,discovery: $$(curl -s -w '\n' https://discovery.etcd.io/new)," contrib/coreos/user-data > contrib/coreos/user-data.new
+	sed -e "s,# discovery:,discovery:," -e "s,discovery: https://discovery.etcd.io/.*,discovery: $$(curl -s -w '\n' https://discovery.etcd.io/new)," contrib/coreos/user-data > contrib/coreos/user-data.new
 	mv contrib/coreos/user-data.new contrib/coreos/user-data
 
 build: check-docker


### PR DESCRIPTION
closes #1915

Running `make discovery-url` multiple times now refreshes the url.
