### PR TITLE
feat(registry): image without development libraries to reduce the size.

### DIFF
--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -13,33 +13,6 @@ RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/opdem
 RUN curl -sSL -o /usr/local/bin/confd https://s3-us-west-2.amazonaws.com/opdemand/confd-v0.5.0-json \
     && chmod +x /usr/local/bin/confd
 
-# install required packages (copied from dotcloud/docker-registry Dockerfile)
-RUN sed -i 's/main$/main universe/' /etc/apt/sources.list
-RUN apt-get update && apt-get install -y git-core build-essential python-dev \
-    libevent-dev python-openssl liblzma-dev
-
-# install pip
-RUN curl -sSL https://raw.githubusercontent.com/pypa/pip/1.5.6/contrib/get-pip.py | python -
-
-# create a registry user
-RUN useradd -s /bin/bash registry
-
-# add the docker registry source from github
-RUN git clone https://github.com/deis/docker-registry /docker-registry && \
-    cd /docker-registry && \
-    git checkout 94e7707 && \
-    chown -R registry:registry /docker-registry
-
-# install boto configuration
-RUN cp /docker-registry/config/boto.cfg /etc/boto.cfg
-RUN cd /docker-registry && pip install -r requirements/main.txt
-
-# Install core
-RUN pip install /docker-registry/depends/docker-registry-core
-
-# Install registry
-RUN pip install file:///docker-registry#egg=docker-registry[bugsnag,newrelic,cors]
-
 ENV DOCKER_REGISTRY_CONFIG /docker-registry/config/config.yml
 ENV SETTINGS_FLAVOR deis
 
@@ -48,3 +21,5 @@ WORKDIR /app
 CMD ["/app/bin/boot"]
 EXPOSE 5000
 ADD . /app
+
+RUN /app/build.sh

--- a/registry/build.sh
+++ b/registry/build.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+DEBIAN_FRONTEND=noninteractive
+
+sed -i 's/main$/main universe/' /etc/apt/sources.list
+
+# install required packages (copied from dotcloud/docker-registry Dockerfile)
+apt-get install -y git-core build-essential python-dev \
+    libevent-dev python-openssl liblzma-dev
+
+# install pip
+curl -sSL https://raw.githubusercontent.com/pypa/pip/1.5.6/contrib/get-pip.py | python -
+
+# create a registry user
+useradd -s /bin/bash registry
+
+# add the docker registry source from github
+git clone https://github.com/deis/docker-registry /docker-registry && \
+    cd /docker-registry && \
+    git checkout 94e7707 && \
+    chown -R registry:registry /docker-registry
+
+# install boto configuration
+cp /docker-registry/config/boto.cfg /etc/boto.cfg
+cd /docker-registry && pip install -r requirements/main.txt
+
+# Install core
+pip install /docker-registry/depends/docker-registry-core
+
+# Install registry
+pip install file:///docker-registry#egg=docker-registry[bugsnag,newrelic,cors]
+
+# cleanup. indicate that python is a required package.
+apt-mark unmarkauto python python-openssl && \
+  apt-get remove -y --purge git-core build-essential python-dev && \
+  apt-get autoremove -y --purge && \
+  apt-get clean -y && \
+  rm -Rf /usr/share/man /usr/share/doc && \
+  rm -rf /tmp/* /var/tmp/* && \
+  rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
``` console
deis/registry                    reduce_size         2bb393d9b63b        1 hours ago         379.7 MB
deis/registry                    latest              a8031e3ad8e1        2 days ago          501.3 MB
```

The idea is to use a script to install all the requirements to run the registry and to remove all the development packages once the process finish. Running this script from the Dockerfile only one layer is created in which is possible to "release" disk space.
