### PR TITLE
docs(README): add build status badge for CI test-master job

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Deis (pronounced DAY-iss) is an open source PaaS that makes it easy to deploy and manage applications on your own servers. Deis builds upon [Docker](http://docker.io/) and [CoreOS](http://coreos.com) to provide a lightweight PaaS with a [Heroku-inspired](http://heroku.com) workflow.
 
+[![Build Status](http://ci.deis.io/buildStatus/icon?job=test-master)](http://ci.deis.io/job/test-master/)
 [![Current Release](http://img.shields.io/badge/release-v0.13.0-blue.svg)](https://github.com/deis/deis/releases/tag/v0.13.0)
 
 ![Deis Graphic](https://s3-us-west-2.amazonaws.com/deis-images/deis-graphic.png)


### PR DESCRIPTION
Restores a build status badge to the main README file, pointing to our Jenkins instance. We can always change the target of the badge to another job in the future. Uses the [Embeddable Build Status Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Embeddable+Build+Status+Plugin) for Jenkins.

Live examples:
Test-integration [![Build Status](http://ci.deis.io/buildStatus/icon?job=test-integration)](http://ci.deis.io/job/test-integration/)
Test-master [![Build Status](http://ci.deis.io/buildStatus/icon?job=test-master)](http://ci.deis.io/job/test-master/)
Test-nightly-dart [![Build Status](http://ci.deis.io/buildStatus/icon?job=test-nightly-dart)](http://ci.deis.io/job/test-nightly-dart/)

[skip ci]

Closes #1911.
