### PR TITLE
fix(deisctl): control plane components should restart on failure

### DIFF
--- a/deisctl/units/deis-builder.service
+++ b/deisctl/units/deis-builder.service
@@ -10,6 +10,8 @@ ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker ru
 ExecStartPost=/bin/sh -c "echo 'Waiting for builder on 2223/tcp...' && until echo 'dummy-value' | ncat $COREOS_PRIVATE_IPV4 2223 >/dev/null 2>&1; do sleep 1; done"
 ExecStartPost=/bin/bash -c "nsenter --pid --uts --mount --ipc --net --target $(docker inspect --format='{{ .State.Pid }}' deis-builder) /usr/local/bin/push-images"
 ExecStopPost=-/usr/bin/docker stop deis-builder
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-cache.service
+++ b/deisctl/units/deis-cache.service
@@ -8,6 +8,8 @@ ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache` && docker h
 ExecStartPre=/bin/sh -c "docker inspect deis-cache >/dev/null && docker rm -f deis-cache || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache` && docker run --name deis-cache --rm -p 6379:6379 -e EXTERNAL_PORT=6379 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStopPost=-/usr/bin/docker stop deis-cache
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-controller.service
+++ b/deisctl/units/deis-controller.service
@@ -11,6 +11,8 @@ ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && doc
 ExecStartPre=/bin/sh -c "docker inspect deis-controller >/dev/null && docker rm -f deis-controller || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker run --name deis-controller -v /var/run/fleet.sock:/var/run/fleet.sock --rm -p 8000:8000 -e EXTERNAL_PORT=8000 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from=deis-logger $IMAGE"
 ExecStopPost=-/usr/bin/docker stop deis-controller
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-database.service
+++ b/deisctl/units/deis-database.service
@@ -8,6 +8,8 @@ ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docke
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker start -a deis-database >/dev/null || docker run --name deis-database -p 5432:5432 -e EXTERNAL_PORT=5432 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStopPost=-/bin/bash -c "nsenter --pid --uts --mount --ipc --net --target $(docker inspect --format='{{ .State.Pid }}' deis-database) sudo service postgresql stop"
 ExecStopPost=-/usr/bin/docker stop deis-database
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-logger.service
+++ b/deisctl/units/deis-logger.service
@@ -10,6 +10,8 @@ ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker 
 ExecStartPre=/bin/sh -c "docker inspect deis-logger >/dev/null && docker rm -f deis-logger || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker run --name deis-logger --rm -p 514:514/udp -e EXTERNAL_PORT=514 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from deis-logger-data $IMAGE"
 ExecStopPost=-/usr/bin/docker stop deis-logger
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-logspout.service
+++ b/deisctl/units/deis-logspout.service
@@ -9,6 +9,8 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logspout` && docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-logspout >/dev/null && docker rm -f deis-logspout || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logspout` && docker run --name deis-logspout --rm -v /var/run/docker.sock:/tmp/docker.sock -e ETCD_HOST=$COREOS_PRIVATE_IPV4 -e HOST=$COREOS_PRIVATE_IPV4 -e DEBUG=1 $IMAGE"
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-publisher.service
+++ b/deisctl/units/deis-publisher.service
@@ -9,6 +9,8 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-publisher >/dev/null && docker rm -f deis-publisher || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker run --name deis-publisher --rm -e HOST=$COREOS_PRIVATE_IPV4 -e ETCD_HOST=$COREOS_PRIVATE_IPV4 -v /var/run/docker.sock:/var/run/docker.sock $IMAGE"
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-registry.service
+++ b/deisctl/units/deis-registry.service
@@ -8,6 +8,8 @@ ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docke
 ExecStartPre=/bin/sh -c "docker inspect deis-registry >/dev/null && docker rm -f deis-registry || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docker run --name deis-registry --rm -p 5000:5000 -e EXTERNAL_PORT=5000 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStopPost=-/usr/bin/docker stop deis-registry
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-router.service
+++ b/deisctl/units/deis-router.service
@@ -8,6 +8,8 @@ ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router` && docker 
 ExecStartPre=/bin/sh -c "docker inspect deis-router >/dev/null && docker rm -f deis-router || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router` && docker run --name deis-router --rm -p 80:80 -p 2222:2222 -e EXTERNAL_PORT=80 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStopPost=-/usr/bin/docker stop deis-router
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-store-daemon.service
+++ b/deisctl/units/deis-store-daemon.service
@@ -7,6 +7,8 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-daemon` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-daemon` && docker start -a deis-store-daemon >/dev/null || docker run --name deis-store-daemon -e HOST=$COREOS_PRIVATE_IPV4 -p 6800 --net host $IMAGE"
 ExecStopPost=-/usr/bin/docker stop deis-store-daemon
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-store-gateway.service
+++ b/deisctl/units/deis-store-gateway.service
@@ -7,6 +7,8 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-gateway` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-gateway >/dev/null 2>&1 && docker rm -f deis-store-gateway || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-gateway` && docker run --name deis-store-gateway -h deis-store-gateway --rm -e HOST=$COREOS_PRIVATE_IPV4 -e EXTERNAL_PORT=8888 -p 8888:8888 $IMAGE"
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-store-monitor.service
+++ b/deisctl/units/deis-store-monitor.service
@@ -8,6 +8,8 @@ ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-monitor` && 
 ExecStartPre=/bin/sh -c "etcdctl set /deis/store/hosts/$COREOS_PRIVATE_IPV4 `hostname` >/dev/null"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-monitor` && docker start -a deis-store-monitor >/dev/null || docker run --name deis-store-monitor -e HOST=$COREOS_PRIVATE_IPV4 -p 6789 --net host $IMAGE"
 ExecStopPost=-/usr/bin/docker stop deis-store-monitor
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds a Systemd restart policy to all Deis control plane components.  This will help workaround:
- Docker Hub connection failures
- Service unavailability during rolling upgrades
- Intermittent crashing of components (e.g. #2046)
