### PR TITLE
ref(user-data): switch get_image to use /deis/platform/version

### DIFF
--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -72,7 +72,7 @@ write_files:
 
       # if no image was set in etcd, we use the default plus the release string
       if [ $? -ne 0 ]; then
-        RELEASE=`etcdctl get /deis/release 2>/dev/null`
+        RELEASE=`etcdctl get /deis/platform/version 2>/dev/null`
 
         # if no release was set in etcd, use the default provisioned with the server
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
The `/deis/release` keyspace doesn't work with our `deisctl` configuration convention.  This PR allows users to change platform release with:

``` console
$ deisctl config platform set version=v0.13.1
```

Note `/run/deis/bin/get_image` will need to be updated manually on systems provisioned with old user-data.
