### PR TITLE
fix(logger): kill temporary build container in "make build"

### DIFF
--- a/logger/Makefile
+++ b/logger/Makefile
@@ -6,9 +6,11 @@ BUILD_IMAGE := $(COMPONENT)-build
 DEV_IMAGE = $(DEV_REGISTRY)/$(IMAGE)
 
 build: check-docker
-	docker build -t $(BUILD_IMAGE) .	
-	docker cp `docker run -d $(BUILD_IMAGE)`:/go/bin/logger image/bin/
+	docker build -t $(BUILD_IMAGE) .
+	@$(eval CID := $(shell docker run -d $(BUILD_IMAGE)))
+	docker cp $(CID):/go/bin/logger image/bin/
 	docker build -t $(IMAGE) image
+	-docker kill $(CID)
 	rm -rf image/bin/logger
 
 clean: check-docker check-registry


### PR DESCRIPTION
The two-stage Dockerfile build process leaves a temporary container running after logger builds. This changes the Makefile to catch and kill the temporary logger-build container.

I tested this interactively before-and-after, and it definitely fixes the zombie container issue on my box.

Closes #2137.
