### PR TITLE
test(builds): optimize commit workflow

### DIFF
--- a/tests/builds_test.go
+++ b/tests/builds_test.go
@@ -41,11 +41,7 @@ func buildSetup(t *testing.T) *utils.DeisTestConfig {
 	}
 	utils.Execute(t, appsCreateCmd, cfg, false, "")
 	utils.Execute(t, gitPushCmd, cfg, false, "")
-	if err := utils.CreateFile(cfg.ExampleApp); err != nil {
-		t.Fatal(err)
-	}
-	utils.Execute(t, gitAddCmd, cfg, false, "")
-	utils.Execute(t, gitCommitCmd, cfg, false, "")
+	utils.Execute(t, "git commit --allow-empty -m bump", cfg, false, "")
 	utils.Execute(t, gitPushCmd, cfg, false, "")
 	if err := utils.Chdir(".."); err != nil {
 		t.Fatal(err)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -14,8 +14,6 @@ var (
 	gitCloneCmd  = "if [ ! -d {{.ExampleApp}} ] ; then git clone https://github.com/deis/{{.ExampleApp}}.git ; fi"
 	gitRemoveCmd = "git remote remove deis"
 	gitPushCmd   = "git push deis master"
-	gitAddCmd    = "git add ."
-	gitCommitCmd = "git commit -m fake"
 )
 
 func TestGlobal(t *testing.T) {


### PR DESCRIPTION
There's no need to create a new file, add and commit. You can simply supply the `--allow-empty` option to git and it will be happy.
