### PR TITLE
fix(contrib/digitalocean): Use correct CoreOS image ID on DO.

### DIFF
--- a/contrib/digitalocean/provision-do-cluster.sh
+++ b/contrib/digitalocean/provision-do-cluster.sh
@@ -49,7 +49,7 @@ fi
 $CONTRIB_DIR/util/check-user-data.sh
 
 # TODO: Make it follow a specific ID once circumstances allow us to do so.
-BASE_IMAGE_ID='coreos-alpha'
+BASE_IMAGE_ID=$(docl images -p | grep CoreOS | grep alpha | cut -d":" -f2)
 
 if [ -z "$BASE_IMAGE_ID" ]; then
 	echo_red "DigitalOcean Image not found..."


### PR DESCRIPTION
DigitalOcean removed the coreos-alpha shortcut. Changed the
provision script to refresh the list of images and grep the latest
CoreOS alpha ID. Note that this might be unsupported at some point.

Moving on to CoreOS Stable/Beta soonish would be beneficial.
