### PR TITLE
chore(*): bump CoreOS to 471.1.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,7 @@ else
   $vb_cpus = 1
 end
 
-COREOS_VERSION = "459.0.0"
+COREOS_VERSION = "471.1.0"
 
 if File.exist?(CONFIG)
   require CONFIG

--- a/contrib/bare-metal/README.md
+++ b/contrib/bare-metal/README.md
@@ -49,7 +49,7 @@ coreos-install -C alpha -c /tmp/config -d /dev/sda
 ```
 
 This will install the current [CoreOS](https://coreos.com/) release to disk. If you want to install the recommended [CoreOS](https://coreos.com/) version check the [Deis changelog](../../CHANGELOG.md)
-and specify that version by appending the `-V` parameter to the install command, e.g. `-V 459.0.0`.
+and specify that version by appending the `-V` parameter to the install command, e.g. `-V 471.1.0`.
 
 After the installation has finished reboot your server. Once your machine is back up you should be able to log in as the `core` user using the `deis` ssh key.
 

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -84,14 +84,14 @@
 
   "Mappings" : {
     "CoreOSAMIs" : {
-      "us-east-1"      : { "PV" : "ami-aed360c6", "HVM" : "ami-acd360c4" },
-      "us-west-2"      : { "PV" : "ami-91014ca1", "HVM" : "ami-af014c9f" },
-      "us-west-1"      : { "PV" : "ami-8be5eece", "HVM" : "ami-89e5eecc" },
-      "eu-west-1"      : { "PV" : "ami-62903315", "HVM" : "ami-64903313" },
-      "ap-southeast-1" : { "PV" : "ami-34b89f66", "HVM" : "ami-3ab89f68" },
-      "ap-southeast-2" : { "PV" : "ami-01a9cb3b", "HVM" : "ami-07a9cb3d" },
-      "ap-northeast-1" : { "PV" : "ami-73e4ce72", "HVM" : "ami-75e4ce74" },
-      "sa-east-1"      : { "PV" : "ami-f98237e4", "HVM" : "ami-fb8237e6" }
+      "us-east-1"      : { "PV" : "ami-2017af48", "HVM" : "ami-2217af4a" },
+      "us-west-2"      : { "PV" : "ami-5df7bb6d", "HVM" : "ami-5bf7bb6b" },
+      "us-west-1"      : { "PV" : "ami-73435636", "HVM" : "ami-7d435638" },
+      "eu-west-1"      : { "PV" : "ami-72228e05", "HVM" : "ami-74228e03" },
+      "ap-southeast-1" : { "PV" : "ami-2863427a", "HVM" : "ami-2a634278" },
+      "ap-southeast-2" : { "PV" : "ami-bd5c3187", "HVM" : "ami-bf5c3185" },
+      "ap-northeast-1" : { "PV" : "ami-4bd0e64a", "HVM" : "ami-4dd0e64c" },
+      "sa-east-1"      : { "PV" : "ami-5ba11546", "HVM" : "ami-55a11548" }
     },
     "RootDevices" : {
       "HVM" : { "Name": "/dev/xvda" },

--- a/contrib/gce/README.md
+++ b/contrib/gce/README.md
@@ -112,10 +112,10 @@ Table of resources:
 +--------+---------------+--------+---------+
 ```
 
-Launch 3 instances using `coreos-alpha-459-0-0-v20141003` image. You can choose another starting CoreOS image from the listing output of `gcloud compute images list`:
+Launch 3 instances using `coreos-alpha-471-1-0-v20141016` image. You can choose another starting CoreOS image from the listing output of `gcloud compute images list`:
 
 ```console
-$ for num in 1 2 3; do gcutil addinstance --image projects/coreos-cloud/global/images/coreos-alpha-459-0-0-v20141003 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
+$ for num in 1 2 3; do gcutil addinstance --image projects/coreos-cloud/global/images/coreos-alpha-471-1-0-v20141016 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
 
 Table of resources:
 


### PR DESCRIPTION
See https://coreos.com/releases/#471.1.0. In particular, Ceph FS support in the kernel may be important for Deis in the future.

Please double-check alpha IDs at https://coreos.com/docs/running-coreos/cloud-providers/ec2/ and https://coreos.com/docs/running-coreos/cloud-providers/google-compute-engine/
