### PR TITLE
ref(Dockerfiles): use ubuntu-debootstrap:14.04 as base image

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:14.04
+FROM ubuntu-debootstrap:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
 # install common packages
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl net-tools sudo
 
 # install etcdctl
 RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/opdemand/etcdctl-v0.4.6 \

--- a/builder/README.md
+++ b/builder/README.md
@@ -3,7 +3,7 @@
 A Docker image that builds Docker images, for use in the [Deis](http://deis.io/) open source PaaS.
 
 This Docker image is based on the official
-[ubuntu:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
+[ubuntu-debootstrap:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
 
 Please add any [issues](https://github.com/deis/deis/issues) you find with this software to
 the [Deis Project](https://github.com/deis/deis).

--- a/cache/Dockerfile
+++ b/cache/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:14.04
+FROM ubuntu-debootstrap:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
 # install common packages
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl net-tools sudo
 
 # install etcdctl
 RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/opdemand/etcdctl-v0.4.6 \

--- a/cache/README.md
+++ b/cache/README.md
@@ -3,7 +3,7 @@
 A Redis cache server for use in the [Deis](http://deis.io/) open source PaaS.
 
 This Docker image is based on the official
-[ubuntu:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
+[ubuntu-debootstrap:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
 
 Please add any [issues](https://github.com/deis/deis/issues) you find with this software to
 the [Deis Project](https://github.com/deis/deis).

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:14.04
+FROM ubuntu-debootstrap:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
 # install common packages
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl net-tools sudo
 
 # install etcdctl
 RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/opdemand/etcdctl-v0.4.6 \

--- a/controller/README.md
+++ b/controller/README.md
@@ -4,7 +4,7 @@ A RESTful API server for use in the [Deis](http://deis.io) open source PaaS.
 
 
 This Docker image is based on the official
-[ubuntu:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
+[ubuntu-debootstrap:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
 
 Please add any [issues](https://github.com/deis/deis/issues) you find with this software to
 the [Deis Project](https://github.com/deis/deis).

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:14.04
+FROM ubuntu-debootstrap:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
 # install common packages
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl net-tools sudo
 
 # install etcdctl
 RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/opdemand/etcdctl-v0.4.6 \

--- a/database/README.md
+++ b/database/README.md
@@ -3,7 +3,7 @@
 A PostgreSQL database for use in the [Deis](http://deis.io) open source PaaS.
 
 This Docker image is based on the official
-[ubuntu:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
+[ubuntu-debootstrap:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
 
 Please add any [issues](https://github.com/deis/deis/issues) you find with this software to
 the [Deis Project](https://github.com/deis/deis).

--- a/deisctl/units/deis-logger-data.service
+++ b/deisctl/units/deis-logger-data.service
@@ -4,8 +4,8 @@ Description=deis-logger-data
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStartPre=/bin/sh -c "docker history ubuntu:14.04 >/dev/null 2>&1 || docker pull ubuntu:14.04"
-ExecStart=/bin/sh -c "docker inspect deis-logger-data >/dev/null 2>&1 || docker run --name deis-logger-data -v /var/log/deis ubuntu:14.04 /bin/true"
+ExecStartPre=/bin/sh -c "docker history ubuntu-debootstrap:14.04 >/dev/null 2>&1 || docker pull ubuntu-debootstrap:14.04"
+ExecStart=/bin/sh -c "docker inspect deis-logger-data >/dev/null 2>&1 || docker run --name deis-logger-data -v /var/log/deis ubuntu-debootstrap:14.04 /bin/true"
 
 [Install]
 WantedBy=multi-user.target

--- a/logger/README.md
+++ b/logger/README.md
@@ -3,7 +3,7 @@
 A system logger for use in the [Deis](http://deis.io) open source PaaS.
 
 This Docker image is based on the official
-[ubuntu:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
+[ubuntu-debootstrap:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
 
 Please add any [issues](https://github.com/deis/deis/issues) you find with this software to
 the [Deis Project](https://github.com/deis/deis).

--- a/logger/tests/logger_test.go
+++ b/logger/tests/logger_test.go
@@ -19,7 +19,7 @@ func TestLogger(t *testing.T) {
 	defer cli.CmdRm("-f", etcdName)
 	dataName := "deis-logger-data-" + tag
 	dockercli.RunDeisDataTest(t, "--name", dataName,
-		"-v", "/var/log/deis", "ubuntu:14.04", "/bin/true")
+		"-v", "/var/log/deis", "ubuntu-debootstrap:14.04", "/bin/true")
 	host, port := utils.HostAddress(), utils.RandomPort()
 	fmt.Printf("--- Run deis/logger:%s at %s:%s\n", tag, host, port)
 	name := "deis-logger-" + tag

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:14.04
+FROM ubuntu-debootstrap:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
 # install common packages
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl net-tools sudo
 
 # install etcdctl
 RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/opdemand/etcdctl-v0.4.6 \

--- a/registry/README.md
+++ b/registry/README.md
@@ -3,7 +3,7 @@
 A Docker image registry for use in the [Deis](http://deis.io) open source PaaS.
 
 This Docker image is based on the official
-[ubuntu:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
+[ubuntu-debootstrap:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
 
 Please add any [issues](https://github.com/deis/deis/issues) you find with this software to
 the [Deis Project](https://github.com/deis/deis).

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:14.04
+FROM ubuntu-debootstrap:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
 # install common packages
-RUN apt-get update && apt-get install -y libgeoip1 curl && apt-get clean
+RUN apt-get update && apt-get install -y curl net-tools sudo
 
 # install etcdctl
 RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/opdemand/etcdctl-v0.4.6 \
@@ -12,6 +12,9 @@ RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/opdem
 # install confd
 RUN curl -sSL -o /usr/local/bin/confd https://s3-us-west-2.amazonaws.com/opdemand/confd-git-b8e693c \
     && chmod +x /usr/local/bin/confd
+
+# install common packages
+RUN apt-get update && apt-get install -y libgeoip1
 
 WORKDIR /app
 

--- a/router/README.md
+++ b/router/README.md
@@ -3,7 +3,7 @@
 An nginx proxy for use in the [Deis](http://deis.io) open source PaaS.
 
 This Docker image is based on the official
-[ubuntu:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
+[ubuntu-debootstrap:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
 
 Please add any [issues](https://github.com/deis/deis/issues) you find with this software to
 the [Deis Project](https://github.com/deis/deis).

--- a/router/parent/Dockerfile
+++ b/router/parent/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu-debootstrap:14.04
 
 ADD . /tmp
 

--- a/store/README.md
+++ b/store/README.md
@@ -7,7 +7,7 @@ The bin/boot scripts and Dockerfiles were inspired by
 Seán C. McCord's [docker-ceph](https://github.com/Ulexus/docker-ceph) repository.
 
 This Docker image is based on the official
-[ubuntu:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
+[ubuntu-debootstrap:14.04](https://registry.hub.docker.com/_/ubuntu/) image.
 
 Please add any issues you find with this software to the
 [Deis project](https://github.com/deis/deis/issues).

--- a/store/base/Dockerfile
+++ b/store/base/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:14.04
+FROM ubuntu-debootstrap:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
 # install common packages
-RUN apt-get update && apt-get install -yq curl
+RUN apt-get update && apt-get install -y curl net-tools sudo
 
 # install etcdctl
 RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/opdemand/etcdctl-v0.4.6 \

--- a/tests/bin/prime-docker-images.sh
+++ b/tests/bin/prime-docker-images.sh
@@ -11,7 +11,7 @@ docker rm `docker ps -a -q`
 docker rmi -f `docker images -q`
 
 # Pull Deis testing essentials
-docker pull ubuntu:14.04
+docker pull ubuntu-debootstrap:14.04
 docker pull deis/slugbuilder:latest
 docker pull deis/slugrunner:latest
 docker pull deis/test-etcd:latest

--- a/tests/etcdutils/Dockerfile
+++ b/tests/etcdutils/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:14.04
+FROM ubuntu-debootstrap:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
 # install common packages
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl net-tools sudo
 
 # install etcdctl
 RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/opdemand/etcdctl-v0.4.6 \


### PR DESCRIPTION
The difference in virtual sizes on my boot2docker builds, YMMV:

``` console
$ docker images
REPOSITORY           TAG              IMAGE ID         CREATED              VIRTUAL SIZE
deis/store-gateway   ubuntu           255a52a16581     34 seconds ago       485.7 MB
deis/store-gateway   debootstrap      8be7773d3684     3 minutes ago        389.9 MB
deis/store-monitor   ubuntu           92889ab5899b     About a minute ago   440.3 MB
deis/store-monitor   debootstrap      089b398bc018     3 minutes ago        322.9 MB
deis/store-daemon    ubuntu           93634a31d925     About a minute ago   440.3 MB
deis/store-daemon    debootstrap      eeab0dbf720b     3 minutes ago        322.9 MB
deis/store-base      ubuntu           aff69a86d13e     About a minute ago   440.3 MB
deis/store-base      debootstrap      2c9e6b01b297     3 minutes ago        322.9 MB
deis/router          ubuntu           14557e2086bf     About a minute ago   254.8 MB
deis/router          debootstrap      c4a1a996f92b     4 minutes ago        155.6 MB
deis/publisher       ubuntu           545c3e85793f     2 minutes ago        5.032 MB
deis/publisher       debootstrap      339f13ab5bee     4 minutes ago        5.032 MB
deis/logspout        ubuntu           f26b540224cd     2 minutes ago        12.29 MB
deis/logspout        debootstrap      e3abf90eb770     4 minutes ago        12.29 MB
deis/logger          ubuntu           5f6718986d35     3 minutes ago        4.782 MB
deis/logger          debootstrap      a202ec92bb8e     4 minutes ago        4.782 MB
deis/registry        ubuntu           db8f747c93ba     2 minutes ago        499.9 MB
deis/registry        debootstrap      85982cd2b12a     19 minutes ago       416.1 MB
deis/database        ubuntu           110665976fab     3 minutes ago        535.5 MB
deis/database        debootstrap      6a4eeff98b7a     22 minutes ago       480.1 MB
deis/controller      ubuntu           9c7ce6599741     3 minutes ago        342 MB
deis/controller      debootstrap      926abfd02d6c     25 minutes ago       259.3 MB
deis/cache           ubuntu           8565f218ce4f     5 minutes ago        256 MB
deis/cache           debootstrap      56b33815fee4     27 minutes ago       133.7 MB
deis/builder         ubuntu           8e487a1e09f3     5 minutes ago        1.487 GB
deis/builder         debootstrap      7e04cf6a4516     28 minutes ago       1.428 GB
ubuntu               14.04            9cbaf023786c     3 days ago           192.8 MB
ubuntu-debootstrap   14.04            f4bf82423f0c     3 days ago           87.16 MB
```

ping @aledbf!
