### PR TITLE
feat(Vagrantfile): use "virtio" network devices in virtualbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,9 +54,9 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provider :virtualbox do |vb, override|
-    # Use AMD Lance nic which seems less problematic than Intel
-    vb.customize ["modifyvm", :id, "--nictype1", "Am79C973"]
-    vb.customize ["modifyvm", :id, "--nictype2", "Am79C973"]
+    # Use paravirtualized network adapters
+    vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+    vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
   end
 
   config.vm.provider :virtualbox do |v|


### PR DESCRIPTION
When having problems with the default Intel NICs in vagrant, we previously tried to use the [**virtio**](https://www.virtualbox.org/manual/ch06.html) paravirtualized adapter but ended up with an AMD card. The issue then was that we couldn't get a DHCP address reliably; this seems fixed now as of https://github.com/coreos/manifest/releases/tag/v459.0.0.

We didn't track a specific issue for this in deis. The CoreOS changes appear to be these:
- https://github.com/coreos/coreos-overlay/pull/900
- https://github.com/coreos/coreos-overlay/pull/904
