### PR TITLE
fix(controller): deploy only when Build is present

### DIFF
--- a/controller/api/south_migrations/0018_drop_field_release_image__chg_field_release_build.py
+++ b/controller/api/south_migrations/0018_drop_field_release_image__chg_field_release_build.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Release.image'
+        db.delete_column(u'api_release', 'image')
+
+
+        # Changing field 'Release.build'
+        db.alter_column(u'api_release', 'build_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['api.Build'], null=True))
+
+    def backwards(self, orm):
+        # Adding field 'Release.image'
+        db.add_column(u'api_release', 'image',
+                      self.gf('django.db.models.fields.CharField')(default=u'deis/helloworld', max_length=256),
+                      keep_default=False)
+
+
+        # User chose to not deal with backwards NULL issues for 'Release.build'
+        raise RuntimeError("Cannot reverse this migration. 'Release.build' and its values cannot be restored.")
+        
+        # The following code is provided here to aid in writing a correct migration
+        # Changing field 'Release.build'
+        db.alter_column(u'api_release', 'build_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['api.Build']))
+
+    models = {
+        u'api.app': {
+            'Meta': {'object_name': 'App'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '64'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'structure': ('json_field.fields.JSONField', [], {'default': '{}', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('api.fields.UuidField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'})
+        },
+        u'api.build': {
+            'Meta': {'ordering': "[u'-created']", 'unique_together': "((u'app', u'uuid'),)", 'object_name': 'Build'},
+            'app': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.App']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'dockerfile': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'image': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'procfile': ('json_field.fields.JSONField', [], {'default': '{}', 'blank': 'True'}),
+            'sha': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('api.fields.UuidField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'})
+        },
+        u'api.config': {
+            'Meta': {'ordering': "[u'-created']", 'unique_together': "((u'app', u'uuid'),)", 'object_name': 'Config'},
+            'app': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.App']"}),
+            'cpu': ('json_field.fields.JSONField', [], {'default': '{}', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'memory': ('json_field.fields.JSONField', [], {'default': '{}', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'tags': ('json_field.fields.JSONField', [], {'default': '{}', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('api.fields.UuidField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'values': ('json_field.fields.JSONField', [], {'default': '{}', 'blank': 'True'})
+        },
+        u'api.container': {
+            'Meta': {'ordering': "[u'created']", 'object_name': 'Container'},
+            'app': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.App']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'num': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'release': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.Release']"}),
+            'state': ('django_fsm.FSMField', [], {'default': "u'initialized'", 'max_length': '50'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('api.fields.UuidField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'})
+        },
+        u'api.domain': {
+            'Meta': {'object_name': 'Domain'},
+            'app': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.App']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'domain': ('django.db.models.fields.TextField', [], {'unique': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'api.key': {
+            'Meta': {'unique_together': "((u'owner', u'id'),)", 'object_name': 'Key'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'public': ('django.db.models.fields.TextField', [], {'unique': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('api.fields.UuidField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'})
+        },
+        u'api.push': {
+            'Meta': {'ordering': "[u'-created']", 'unique_together': "((u'app', u'uuid'),)", 'object_name': 'Push'},
+            'app': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.App']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'fingerprint': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'receive_repo': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'receive_user': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sha': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'ssh_connection': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'ssh_original_command': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('api.fields.UuidField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'})
+        },
+        u'api.release': {
+            'Meta': {'ordering': "[u'-created']", 'unique_together': "((u'app', u'version'),)", 'object_name': 'Release'},
+            'app': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.App']"}),
+            'build': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.Build']", 'null': 'True'}),
+            'config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.Config']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'summary': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('api.fields.UuidField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'version': ('django.db.models.fields.PositiveIntegerField', [], {})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['api']

--- a/controller/api/tests/test_build.py
+++ b/controller/api/tests/test_build.py
@@ -43,12 +43,12 @@ class BuildTest(TransactionTestCase):
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
-        # check to see that an initial build was created
+        # check to see that no initial build was created
         url = "/api/apps/{app_id}/builds".format(**locals())
         response = self.client.get(url,
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['count'], 0)
         # post a new build
         body = {'image': 'autotest/example'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',

--- a/controller/api/tests/test_config.py
+++ b/controller/api/tests/test_config.py
@@ -58,7 +58,6 @@ class ConfigTest(TransactionTestCase):
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        self.assertIn('x-deis-release', response._headers)
         config2 = response.data
         self.assertNotEqual(config1['uuid'], config2['uuid'])
         self.assertIn('NEW_URL1', response.data['values'])
@@ -214,7 +213,6 @@ class ConfigTest(TransactionTestCase):
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        self.assertIn('x-deis-release', response._headers)
         limit1 = response.data
         # check memory limits
         response = self.client.get(url, content_type='application/json',
@@ -301,7 +299,6 @@ class ConfigTest(TransactionTestCase):
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        self.assertIn('x-deis-release', response._headers)
         limit1 = response.data
         # check memory limits
         response = self.client.get(url, content_type='application/json',
@@ -371,7 +368,6 @@ class ConfigTest(TransactionTestCase):
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        self.assertIn('x-deis-release', response._headers)
         tags1 = response.data
         # check tags again
         response = self.client.get(url, content_type='application/json',

--- a/controller/api/tests/test_release.py
+++ b/controller/api/tests/test_release.py
@@ -65,7 +65,6 @@ class ReleaseTest(TransactionTestCase):
         self.assertIn('config', response.data)
         self.assertIn('build', response.data)
         self.assertEquals(release1['version'], 1)
-        self.assertEquals(release1['image'], 'deis/helloworld')
         # check to see that a new release was created
         url = '/api/apps/{app_id}/releases/v2'.format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -118,11 +117,11 @@ class ReleaseTest(TransactionTestCase):
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
-        # try to rollback with only 1 release extant, expecting 404
+        # try to rollback with only 1 release extant, expecting 400
         url = "/api/apps/{app_id}/releases/rollback/".format(**locals())
         response = self.client.post(url, content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 400)
         # update config to roll a new release
         url = '/api/apps/{app_id}/config'.format(**locals())
         body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
@@ -132,7 +131,6 @@ class ReleaseTest(TransactionTestCase):
         self.assertEqual(response.status_code, 201)
         # update the build to roll a new release
         url = '/api/apps/{app_id}/builds'.format(**locals())
-        build_config = json.dumps({'PATH': 'bin:/usr/local/bin:/usr/bin:/bin'})
         body = {'image': 'autotest/example'}
         response = self.client.post(
             url, json.dumps(body), content_type='application/json',

--- a/controller/api/tests/test_scheduler.py
+++ b/controller/api/tests/test_scheduler.py
@@ -190,7 +190,7 @@ class SchedulerTest(TransactionTestCase):
         url = "/api/apps/{app_id}/builds".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data['results']), 2)
+        self.assertEqual(len(response.data['results']), 1)
         # inspect releases
         url = "/api/apps/{app_id}/releases".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -297,7 +297,7 @@ class SchedulerTest(TransactionTestCase):
         url = "/api/apps/{app_id}/builds".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data['results']), 2)
+        self.assertEqual(len(response.data['results']), 1)
         # inspect releases
         url = "/api/apps/{app_id}/releases".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))


### PR DESCRIPTION
In terms of 12 factor's best practices, a build and configuration is a
release. Currently, we create and deploy a new release with any change
to an application published a release. This is because we create an
initial build on app creation. With this change, no build is created on
app creation, and the first release is published to the scheduler once
the release has a build.

Other notable changes:
- the release's image field has been removed in favour of an app's ID +
  the release's version
- lots of the view logic has been refactored into the models
- build and config are mandatory in Release.new

Making Build and Config mandatory in Release.new had to happen as Builds
can be nil, which caused bugs when trying to roll back to a previous
release with a nil Build. Release.rollback would call Release.new with
an older build's release info, which sometimes had a nil Build. Because
of how Release.new worked, Release.new would use it's own current Build
in the new release if the supplied build was nil, causing unintentional
behaviour.
