### PR TITLE
feat(client/deis): add python3 support

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -1,6 +1,6 @@
 
 build: setup-venv
-	venv/bin/pip install docopt==0.6.2 python-dateutil==2.2 requests==2.3.0 pyinstaller==2.1 termcolor==1.1.0
+	venv/bin/pip install docopt==0.6.2 future==0.14.1 python-dateutil==2.2 requests==2.3.0 pyinstaller==2.1 termcolor==1.1.0
 	venv/bin/pyinstaller deis.spec
 	chmod +x dist/deis
 

--- a/client/README.rst
+++ b/client/README.rst
@@ -75,7 +75,7 @@ you used to provision the server. You can make a symlink or shell alias for
 
 .. code-block:: console
 
-    $ pip install docopt==0.6.2 python-dateutil==2.2 requests==2.3.0 termcolor==1.1.0
+    $ pip install docopt==0.6.2 future==0.14.1 python-dateutil==2.2 requests==2.3.0 termcolor==1.1.0
     $ sudo ln -fs $(pwd)/client/deis.py /usr/local/bin/deis
     $ deis
     Usage: deis <command> [<args>...]

--- a/client/deis.py
+++ b/client/deis.py
@@ -39,6 +39,9 @@ Use ``git push deis master`` to deploy to an application.
 """
 
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
+
 from collections import namedtuple
 from collections import OrderedDict
 from datetime import datetime
@@ -56,7 +59,7 @@ import re
 import subprocess
 import sys
 import time
-import urlparse
+import urllib.parse as urlparse
 import webbrowser
 
 from dateutil import parser
@@ -88,7 +91,7 @@ class Session(requests.Session):
         }
         # Create the $HOME/.deis dir if it doesn't exist
         if not os.path.isdir(config_dir):
-            os.mkdir(config_dir, 0700)
+            os.mkdir(config_dir, 0o700)
 
     @property
     def app(self):
@@ -166,7 +169,7 @@ class Settings(dict):
         path = os.path.expanduser('~/.deis')
         # Create the $HOME/.deis dir if it doesn't exist
         if not os.path.isdir(path):
-            os.mkdir(path, 0700)
+            os.mkdir(path, 0o700)
         self._path = os.path.join(path, 'client.json')
         if not os.path.exists(self._path):
             settings = {}

--- a/client/setup.py
+++ b/client/setup.py
@@ -57,7 +57,7 @@ setup(name='deis',
       ],
       long_description=LONG_DESCRIPTION,
       install_requires=[
-          'docopt==0.6.2', 'python-dateutil==2.2', 'requests==2.3.0', 'termcolor==1.1.0'
+          'docopt==0.6.2', 'future==0.14.1', 'python-dateutil==2.2', 'requests==2.3.0', 'termcolor==1.1.0'
       ],
       zip_safe=True,
       **KWARGS)

--- a/contrib/bumpver/bump_test.go
+++ b/contrib/bumpver/bump_test.go
@@ -193,7 +193,7 @@ setup(name='deis',
           'Programming Language :: Python :: 2.7',
       ],
       install_requires=[
-          'docopt==0.6.2', 'python-dateutil==2.2', 'requests==2.3.0', 'termcolor==1.1.0'
+          'docopt==0.6.2', 'future==0.14.1', 'python-dateutil==2.2', 'requests==2.3.0', 'termcolor==1.1.0'
       ],
       **KWARGS)
 `
@@ -219,7 +219,7 @@ setup(name='deis',
           'Programming Language :: Python :: 2.7',
       ],
       install_requires=[
-          'docopt==0.6.2', 'python-dateutil==2.2', 'requests==2.3.0', 'termcolor==1.1.0'
+          'docopt==0.6.2', 'future==0.14.1', 'python-dateutil==2.2', 'requests==2.3.0', 'termcolor==1.1.0'
       ],
       **KWARGS)
 `
@@ -279,7 +279,7 @@ write_files:
 var rst = `
 .. code-block:: console
 
-    $ pip install docopt==0.6.2 python-dateutil==2.2 requests==2.3.0 termcolor==1.1.0
+    $ pip install docopt==0.6.2 future==0.14.1 python-dateutil==2.2 requests==2.3.0 termcolor==1.1.0
     $ sudo ln -fs $(pwd)/client/deis.py /usr/local/bin/deis
     $ deis
     Usage: deis <command> [<args>...]
@@ -294,7 +294,7 @@ version of the Deis client for Mac OS X, Linux amd64, or Windows:
 var rstAfter = `
 .. code-block:: console
 
-    $ pip install docopt==0.6.2 python-dateutil==2.2 requests==2.3.0 termcolor==1.1.0
+    $ pip install docopt==0.6.2 future==0.14.1 python-dateutil==2.2 requests==2.3.0 termcolor==1.1.0
     $ sudo ln -fs $(pwd)/client/deis.py /usr/local/bin/deis
     $ deis
     Usage: deis <command> [<args>...]

--- a/controller/dev_requirements.txt
+++ b/controller/dev_requirements.txt
@@ -1,5 +1,6 @@
 # Deis client requirements
 docopt==0.6.2
+future==0.14.1
 python-dateutil==2.2
 requests==2.3.0
 

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -22,6 +22,7 @@ South==1.0
 
 # Deis client requirements
 docopt==0.6.2
+future==0.14.1
 python-dateutil==2.2
 requests==2.3.0
 termcolor==1.1.0

--- a/docs/installing_deis/register-admin-user.rst
+++ b/docs/installing_deis/register-admin-user.rst
@@ -19,7 +19,7 @@ you used to provision the server. You can make a symlink or shell alias for
 
 .. code-block:: console
 
-    $ pip install docopt==0.6.2 python-dateutil==2.2 requests==2.3.0 termcolor==1.1.0
+    $ pip install docopt==0.6.2 future==0.14.1 python-dateutil==2.2 requests==2.3.0 termcolor==1.1.0
     $ sudo ln -fs $(pwd)/client/deis.py /usr/local/bin/deis
     $ deis
     Usage: deis <command> [<args>...]

--- a/docs/using_deis/install-client.rst
+++ b/docs/using_deis/install-client.rst
@@ -17,7 +17,7 @@ you used to provision the server. You can make a symlink or shell alias for
 
 .. code-block:: console
 
-    $ pip install docopt==0.6.2 python-dateutil==2.2 requests==2.3.0 termcolor==1.1.0
+    $ pip install docopt==0.6.2 future==0.14.1 python-dateutil==2.2 requests==2.3.0 termcolor==1.1.0
     $ sudo ln -fs $(pwd)/client/deis.py /usr/local/bin/deis
     $ deis
     Usage: deis <command> [<args>...]

--- a/tests/bin/build-deis-cli.sh
+++ b/tests/bin/build-deis-cli.sh
@@ -4,5 +4,5 @@
 
 virtualenv --system-site-packages venv
 . venv/bin/activate
-pip install docopt==0.6.2 python-dateutil==2.2 requests==2.3.0 pyinstaller==2.1 termcolor==1.1.0
+pip install docopt==0.6.2 future==0.14.1 python-dateutil==2.2 requests==2.3.0 pyinstaller==2.1 termcolor==1.1.0
 make -C client/ client


### PR DESCRIPTION
Changes:
- use python `future` for single source
- change octals to new style of `0oXXX`
- add `future==0.14.1` as dependency

Breaking Changes:
- `future==0.14.1` requires python >= 2.6
