### PR TITLE
chore(*): bump CoreOS to 472.0.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,7 @@ else
   $vb_cpus = 1
 end
 
-COREOS_VERSION = "471.1.0"
+COREOS_VERSION = "472.0.0"
 
 if File.exist?(CONFIG)
   require CONFIG

--- a/contrib/bare-metal/README.md
+++ b/contrib/bare-metal/README.md
@@ -49,7 +49,7 @@ coreos-install -C alpha -c /tmp/config -d /dev/sda
 ```
 
 This will install the current [CoreOS](https://coreos.com/) release to disk. If you want to install the recommended [CoreOS](https://coreos.com/) version check the [Deis changelog](../../CHANGELOG.md)
-and specify that version by appending the `-V` parameter to the install command, e.g. `-V 471.1.0`.
+and specify that version by appending the `-V` parameter to the install command, e.g. `-V 472.0.0`.
 
 After the installation has finished reboot your server. Once your machine is back up you should be able to log in as the `core` user using the `deis` ssh key.
 

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -84,14 +84,14 @@
 
   "Mappings" : {
     "CoreOSAMIs" : {
-      "us-east-1"      : { "PV" : "ami-2017af48", "HVM" : "ami-2217af4a" },
-      "us-west-2"      : { "PV" : "ami-5df7bb6d", "HVM" : "ami-5bf7bb6b" },
-      "us-west-1"      : { "PV" : "ami-73435636", "HVM" : "ami-7d435638" },
-      "eu-west-1"      : { "PV" : "ami-72228e05", "HVM" : "ami-74228e03" },
-      "ap-southeast-1" : { "PV" : "ami-2863427a", "HVM" : "ami-2a634278" },
-      "ap-southeast-2" : { "PV" : "ami-bd5c3187", "HVM" : "ami-bf5c3185" },
-      "ap-northeast-1" : { "PV" : "ami-4bd0e64a", "HVM" : "ami-4dd0e64c" },
-      "sa-east-1"      : { "PV" : "ami-5ba11546", "HVM" : "ami-55a11548" }
+      "us-east-1"      : { "PV" : "ami-52db613a", "HVM" : "ami-50db6138" },
+      "us-west-2"      : { "PV" : "ami-77410e47", "HVM" : "ami-75410e45" },
+      "us-west-1"      : { "PV" : "ami-810411c4", "HVM" : "ami-830411c6" },
+      "eu-west-1"      : { "PV" : "ami-7eb91609", "HVM" : "ami-7cb9160b" },
+      "ap-southeast-1" : { "PV" : "ami-ec5071be", "HVM" : "ami-925071c0" },
+      "ap-southeast-2" : { "PV" : "ami-07b0dd3d", "HVM" : "ami-05b0dd3f" },
+      "ap-northeast-1" : { "PV" : "ami-c73504c6", "HVM" : "ami-c93504c8" },
+      "sa-east-1"      : { "PV" : "ami-6b8d3976", "HVM" : "ami-698d3974" }
     },
     "RootDevices" : {
       "HVM" : { "Name": "/dev/xvda" },

--- a/contrib/gce/README.md
+++ b/contrib/gce/README.md
@@ -112,10 +112,10 @@ Table of resources:
 +--------+---------------+--------+---------+
 ```
 
-Launch 3 instances using `coreos-alpha-471-1-0-v20141016` image. You can choose another starting CoreOS image from the listing output of `gcloud compute images list`:
+Launch 3 instances using `coreos-alpha-472-0-0-v20141017` image. You can choose another starting CoreOS image from the listing output of `gcloud compute images list`:
 
 ```console
-$ for num in 1 2 3; do gcutil addinstance --image projects/coreos-cloud/global/images/coreos-alpha-471-1-0-v20141016 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
+$ for num in 1 2 3; do gcutil addinstance --image projects/coreos-cloud/global/images/coreos-alpha-472-0-0-v20141017 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
 
 Table of resources:
 


### PR DESCRIPTION
See https://coreos.com/releases/#472.0.0. CoreOS now includes Docker 1.3.0.

Please double-check alpha IDs at https://coreos.com/docs/running-coreos/cloud-providers/ec2/ and https://coreos.com/docs/running-coreos/cloud-providers/google-compute-engine/
