### PR TITLE
Retry downloading deisctl

### DIFF
--- a/contrib/coreos/user-data
+++ b/contrib/coreos/user-data
@@ -50,7 +50,7 @@ coreos:
 
       [Service]
       Type=oneshot
-      ExecStart=/usr/bin/sh -c 'curl -sSL http://deis.io/deisctl/install.sh | sh -s 0.13.1'
+      ExecStart=/usr/bin/sh -c 'curl -sSL --retry 5 --retry-delay 2 http://deis.io/deisctl/install.sh | sh -s 0.13.1'
 write_files:
   - path: /etc/deis-release
     content: |


### PR DESCRIPTION
I've run into an issue where the automated download of deisctl did not work. 

My setup runs CoreOS inside a VM with bridged networking and DHCP.

Adding a retry solved the issue.
