### PR TITLE
Add CORS headers to api

### DIFF
--- a/controller/deis/settings.py
+++ b/controller/deis/settings.py
@@ -102,6 +102,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -141,6 +142,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'rest_framework.authtoken',
     'south',
+    'corsheaders',
     # Deis apps
     'api',
     'web',
@@ -160,6 +162,20 @@ LOGIN_URL = '/v1/auth/login/'
 LOGIN_REDIRECT_URL = '/'
 
 SOUTH_TESTS_MIGRATE = False
+
+CORS_ORIGIN_ALLOW_ALL = True
+
+CORS_ALLOW_HEADERS = (
+    'content-type',
+    'accept',
+    'origin',
+    'Authentication',
+)
+
+CORS_EXPOSE_HEADERS = (
+    'X_DEIS_VERSION',
+    'X_DEIS_RELEASE',
+)
 
 REST_FRAMEWORK = {
     'DEFAULT_MODEL_SERIALIZER_CLASS':

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -18,3 +18,4 @@ PyYAML==3.11
 redis==2.9.1
 static==1.0.2
 South==1.0
+django-cors-headers==0.13

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -19,6 +19,7 @@ paramiko==1.14.1
 psycopg2==2.5.4
 python-etcd==0.3.0
 South==1.0
+django-cors-headers==0.13
 
 # Deis client requirements
 docopt==0.6.2


### PR DESCRIPTION
This needs to be tested, but it allows url's other than the controller to make api calls on the controller by setting CORS headers. I was having issues testing this locally but this should work :pray:. 
