### PR TITLE
ref(builder): compress archive into tarball

### DIFF
--- a/builder/slugbuilder/builder/build.sh
+++ b/builder/slugbuilder/builder/build.sh
@@ -106,9 +106,9 @@ fi
 ## Produce slug
 
 if [[ -f "$build_root/.slugignore" ]]; then
-	tar --exclude='.git' -X "$build_root/.slugignore" -C $build_root -cf $slug_file . | cat
+	tar -z --exclude='.git' -X "$build_root/.slugignore" -C $build_root -cf $slug_file . | cat
 else
-	tar --exclude='.git' -C $build_root -cf $slug_file . | cat
+	tar -z --exclude='.git' -C $build_root -cf $slug_file . | cat
 fi
 
 if [[ "$slug_file" != "-" ]]; then


### PR DESCRIPTION
When we removed pigz from slugbuilder, it changed the format to a
tar file. Compressing it with gzip by supplying tar the -z option
reverts this behaviour.
