### PR TITLE
ref(builder): switch to pre-receive hook

### DIFF
--- a/builder/templates/builder
+++ b/builder/templates/builder
@@ -11,13 +11,6 @@ get_app_name() {
     echo $1 | awk -F"." '{print $1}'
 }
 
-get_git_sha() {
-    repo=$1
-    branch=$2
-    branch_file="${repo}/${branch}"
-    cat $branch_file
-}
-
 indent() {
     echo "       $@"
 }
@@ -35,7 +28,7 @@ puts-warn() {
 }
 
 usage() {
-    echo "Usage: $0 <user> <repo> <branch>"
+    echo "Usage: $0 <user> <repo> <sha>"
 }
 
 if [ $# -ne $ARGS ]; then
@@ -45,7 +38,8 @@ fi
 
 USER=$1
 REPO=$2
-BRANCH=$3
+GIT_SHA=$3
+SHORT_SHA=${GIT_SHA:0:8}
 APP_NAME=$(get_app_name $REPO)
 
 cd $(dirname $0) # ensure we are in the root dir
@@ -55,10 +49,6 @@ DOCKERFILE_SHIM="$ROOT_DIR/shim.dockerfile"
 REPO_DIR="${ROOT_DIR}/${REPO}"
 BUILD_DIR="${REPO_DIR}/build"
 CACHE_DIR="${REPO_DIR}/cache"
-
-# get git sha of branch
-GIT_SHA=$(get_git_sha $REPO_DIR $BRANCH)
-SHORT_SHA=${GIT_SHA:0:8}
 
 # define image names
 IMAGE_NAME="$APP_NAME:git-$SHORT_SHA"
@@ -70,8 +60,7 @@ mkdir -p $BUILD_DIR $CACHE_DIR
 TMP_DIR=$(mktemp -d --tmpdir=$BUILD_DIR)
 
 cd $REPO_DIR
-# extract git branch
-git archive $BRANCH | tar -xmC $TMP_DIR
+git archive $GIT_SHA | tar -xmC $TMP_DIR
 
 # switch to app context
 cd $TMP_DIR

--- a/builder/templates/gitreceive
+++ b/builder/templates/gitreceive
@@ -35,37 +35,26 @@ case "$1" in
 cat | $SELF pre-receive
 EOF
     chmod +x $PRERECEIVE_HOOK
-    POSTRECEIVE_HOOK="$REPO_PATH/hooks/post-receive"
-    # inject a post-receive hook
-    cat > $POSTRECEIVE_HOOK <<EOF
-#!/bin/bash
-cat | $SELF post-receive
-EOF
-    chmod +x $POSTRECEIVE_HOOK
+    # call the original git-shell
     git-shell -c "$SSH_ORIGINAL_COMMAND"
     ;;
 
   pre-receive)
     while read oldrev newrev refname
     do
+      # check for authorization on this repo
       $GITHOME/receiver "$RECEIVE_REPO" "$newrev" "$RECEIVE_USER" "$RECEIVE_FINGERPRINT"
       rc=$?
       if [[ $rc != 0 ]] ; then
         echo "      ERROR: failed on rev $newrev - push denied"
         exit $rc
       fi
-    done
-    ;;
-
-  post-receive)
-    while read oldrev newrev refname
-    do
       # builder assumes that we are running this script from $GITHOME
       cd $GITHOME
       # if we're processing a receive-pack on an existing repo, run a build
       if [[ $SSH_ORIGINAL_COMMAND == git-receive-pack* ]]; then
         # SECURITY: git user runs the builder as root (for docker access)
-        sudo $GITHOME/builder $RECEIVE_USER $RECEIVE_REPO $refname 2>&1 | strip_remote_prefix
+        sudo $GITHOME/builder $RECEIVE_USER $RECEIVE_REPO $newrev 2>&1 | strip_remote_prefix
       fi
     done
     ;;


### PR DESCRIPTION
This PR switches the builder from a `post-receive` hook to a `pre-receive` hook, so that a failure in the build stage will not update refs.  This allows the user to re-push the app without having to bump a commit.

Fixes #1798
Fixes #1874
