### PR TITLE
fix(builder): add config environment variables to Dockerfile when custom dockerfile is being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ $ cd example-ruby-sinatra
 $ deis create
 ```
 
-Use `deis create --cluster=prod` to place the app on a different cluster.  Don't like our name-generator?  Use `deis create myappname`.
+Don't like our name-generator?  Use `deis create myappname`.
 
 ## Deploy
 When you created the application, a git remote for Deis was added automatically.  Deploy with `git push`.


### PR DESCRIPTION
I noticed that when pushing a repository with a custom Dockerfile to the builder, config environment variables that were set using `deis config:set key=value` were not being exported to the final docker image.
This PR appends the config variables to the Dockerfile, much like the GIT_SHA environment variable is appended currently.
