### PR TITLE
feat(deisctl): check for required configuration on platform install

### DIFF
--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -79,6 +79,21 @@ func Start(b backend.Backend, targets []string) error {
 	return nil
 }
 
+// checkRequiredKeys exist in etcd
+func checkRequiredKeys() error {
+	if err := config.CheckConfig("/deis/platform/", "domain"); err != nil {
+		return fmt.Errorf(`Missing platform domain, use:
+deisctl config platform set domain=<your-domain>`)
+	}
+
+	if err := config.CheckConfig("/deis/platform/", "sshPrivateKey"); err != nil {
+		fmt.Printf(`Warning: Missing sshPrivateKey, "deis run" will be unavailable. Use:
+deisctl config platform set sshPrivateKey=<path-to-key>
+`)
+	}
+	return nil
+}
+
 func StartPlatform(b backend.Backend) error {
 
 	outchan := make(chan string)
@@ -255,6 +270,10 @@ func Install(b backend.Backend, targets []string) error {
 }
 
 func InstallPlatform(b backend.Backend) error {
+
+	if err := checkRequiredKeys(); err != nil {
+		return err
+	}
 
 	outchan := make(chan string)
 	errchan := make(chan error)

--- a/deisctl/config/config.go
+++ b/deisctl/config/config.go
@@ -32,6 +32,23 @@ func Config() error {
 	return doConfig(args)
 }
 
+// CheckConfig looks for a value at a keyspace path
+// and returns an error if a value is not found
+func CheckConfig(root string, k string) error {
+
+	client, err := getEtcdClient()
+	if err != nil {
+		return err
+	}
+
+	_, err = doConfigGet(client, root, []string{k})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Flags for config package
 var Flags struct {
 }


### PR DESCRIPTION
This PR adds checks for required configuration on `deisctl install platform`.
- If `/deis/platform/domain` is missing, we print an error message and exit since the controller won't start
- If `/deis/platform/sshPrivateKey` is missing, we print a warning and continue, since only `deis run` will be affected

Output on missing `/deis/platform/domain`:

``` console
$ deisctl install platform
Error: Missing platform domain, use:
deisctl config platform set domain=<your-domain>
$
```

Output on missing `/deis/platform/sshPrivateKey`:

``` console
$ deisctl install platform
Warning: Missing sshPrivateKey, "deis run" will be unavailable. Use:
deisctl config platform set sshPrivateKey=<path-to-key>
● ▴ ■
■ ● ▴ Installing Deis...
▴ ■ ●
```
