### PR TITLE
docs(*): set required platform config before install/start

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ This instructs Vagrant to spin up 3 VMs. To be able to connect to the VMs, you m
 $ ssh-add ~/.vagrant.d/insecure_private_key
 ```
 
+## Configure Deis
+
+Before Deis will start successfully, there are a few administrative settings we need to provide.
+
+Set the default domain used to anchor your applications.  For a Vagrant environment, use `local3.deisapp.com` as it will resolve to your local routers:
+
+```console
+$ deisctl config platform set domain=local3.deisapp.com
+```
+
+If you want to allow `deis run` for one-off admin commands, you must provide an SSH private key that allows Deis to gather container logs on CoreOS hosts:
+
+```console
+$ deisctl config platform set sshPrivateKey=~/.vagrant.d/insecure_private_key
+```
+
 ## Provision Deis
 
 Install the [deisctl utility](deisctl#installation) used to provision and operate Deis.
@@ -74,22 +90,6 @@ $ deisctl start platform
 This can take some time - the **builder** must download and install the beefy Heroku cedar stack.  Grab some more coffee!
 
 Your Deis platform should be accessible at `deis.local3.deisapp.com`.  For clusters on other platforms see our guide to [Configuring DNS](http://docs.deis.io/en/latest/installing_deis/configure-dns/).
-
-## Configure Deis
-
-Now that Deis is running there are a few administrative settings we need to provide.
-
-Set the default domain used to anchor your applications.  For a Vagrant environment, use `local3.deisapp.com` as it will resolve to your local routers:
-
-```console
-$ deisctl config platform set domain=local3.deisapp.com
-```
-
-If you want to allow `deis run` for one-off admin commands, you must provide an SSH private key that allows Deis to gather container logs on CoreOS hosts:
-
-```console
-$ deisctl config platform set sshPrivateKey=~/.vagrant.d/insecure_private_key
-```
 
 ## Install the Deis Client
 

--- a/contrib/bare-metal/README.md
+++ b/contrib/bare-metal/README.md
@@ -53,15 +53,6 @@ and specify that version by appending the `-V` parameter to the install command,
 
 After the installation has finished reboot your server. Once your machine is back up you should be able to log in as the `core` user using the `deis` ssh key.
 
-## Initialize the cluster
-Once your server(s) are all provisioned you can proceed to install Deis. Use the hostname of one of your machines in the next step.
-
-```console
-$ ssh-add ~/.ssh/deis
-$ export DEISCTL_TUNNEL=your.server.name.here
-$ deisctl install platform && deisctl start platform
-```
-
 ## Configure Deis
 Set the default domain used to anchor your applications:
 
@@ -75,6 +66,15 @@ If you want to allow `deis run` for one-off admin commands, you must provide an 
 
 ```console
 $ deisctl config platform set sshPrivateKey=<path-to-private-key>
+```
+
+## Initialize the cluster
+Once your server(s) are all provisioned you can proceed to install Deis. Use the hostname of one of your machines in the next step.
+
+```console
+$ ssh-add ~/.ssh/deis
+$ export DEISCTL_TUNNEL=your.server.name.here
+$ deisctl install platform && deisctl start platform
 ```
 
 ## Use Deis!

--- a/contrib/digitalocean/README.md
+++ b/contrib/digitalocean/README.md
@@ -60,15 +60,6 @@ droplet size. The default is 8 GB. Specify the size with NGB, where N is 2, 4, 8
 
 This will print the IP addresses of the initialized machines.
 
-## Initialize the cluster
-set DEISCTL_TUNNEL to one of the IPs of the virtual machines (these are printed on the console in a previous step). You can also login to the web interface of DigitalOcean to see the Public IP addresses.
-
-```console
-$ export DEISCTL_TUNNEL=23.253.219.94
-$ deisctl install platform && deisctl start platform
-```
-Deisctl will deploy Deis and make sure the services are started properly. Grab a coffee.
-
 ## Configure Deis
 Set the default domain used to anchor your applications:
 
@@ -83,6 +74,15 @@ If you want to allow `deis run` for one-off admin commands, you must provide an 
 ```console
 $ deisctl config platform set sshPrivateKey=<path-to-private-key>
 ```
+
+## Initialize the cluster
+set DEISCTL_TUNNEL to one of the IPs of the virtual machines (these are printed on the console in a previous step). You can also login to the web interface of DigitalOcean to see the Public IP addresses.
+
+```console
+$ export DEISCTL_TUNNEL=23.253.219.94
+$ deisctl install platform && deisctl start platform
+```
+Deisctl will deploy Deis and make sure the services are started properly. Grab a coffee.
 
 ### Use Deis!
 After that, register with Deis!

--- a/contrib/ec2/README.md
+++ b/contrib/ec2/README.md
@@ -112,16 +112,6 @@ Please wait for all instances to come up as "running" before continuing.
 Check the AWS EC2 web control panel and wait until "Status Checks" for all instances have passed.
 This will take several minutes.
 
-## Initialize the cluster
-Once the cluster is up, get the hostname of any of the machines from EC2, set
-DEISCTL_TUNNEL, and issue a `deisctl install`:
-```console
-$ ssh-add ~/.ssh/deis
-$ export DEISCTL_TUNNEL=ec2-12-345-678-90.us-west-1.compute.amazonaws.com
-$ deisctl install platform && deisctl start platform
-```
-Deisctl will deploy Deis and make sure the services start properly.
-
 ## Configure Deis
 Set the default domain used to anchor your applications:
 
@@ -136,6 +126,16 @@ If you want to allow `deis run` for one-off admin commands, you must provide an 
 ```console
 $ deisctl config platform set sshPrivateKey=<path-to-private-key>
 ```
+
+## Initialize the cluster
+Once the cluster is up, get the hostname of any of the machines from EC2, set
+DEISCTL_TUNNEL, and issue a `deisctl install`:
+```console
+$ ssh-add ~/.ssh/deis
+$ export DEISCTL_TUNNEL=ec2-12-345-678-90.us-west-1.compute.amazonaws.com
+$ deisctl install platform && deisctl start platform
+```
+Deisctl will deploy Deis and make sure the services start properly.
 
 ## Configure load balancer
 The Deis provisioning scripts for EC2 automatically create an Elastic Load Balancer for your Deis

--- a/contrib/gce/README.md
+++ b/contrib/gce/README.md
@@ -305,15 +305,7 @@ $ deisctl list
 MACHINE		IP		METADATA
 ```
 
-Now we can bootstrap the Deis containers:
-
-```shell
-deisctl install platform && deisctl start platform
-```
-
-This operation will take a while as all the Deis systemd units are loaded into the CoreOS cluster and the Docker images are pulled down. Grab some iced tea!
-
-Once the command completes and `deisctl list` shows services as running, you can set the default domain used to anchor your applications:
+Now set the default domain used to anchor your applications:
 
 ```console
 $ deisctl config platform set domain=mycluster.local
@@ -326,6 +318,14 @@ If you want to allow `deis run` for one-off admin commands, you must provide an 
 ```console
 $ deisctl config platform set sshPrivateKey=<path-to-private-key>
 ```
+
+Now we can bootstrap the Deis containers:
+
+```shell
+deisctl install platform && deisctl start platform
+```
+
+This operation will take a while as all the Deis systemd units are loaded into the CoreOS cluster and the Docker images are pulled down. Grab some iced tea!
 
 Register the admin user. The first user added to the system becomes the admin:
 

--- a/contrib/openstack/README.md
+++ b/contrib/openstack/README.md
@@ -76,19 +76,6 @@ By default, the Makefile will provision 1 router. You can override this by setti
 $ export DEIS_NUM_ROUTERS=2
 ```
 
-### Initialize the cluster
-Once the cluster is up:
-* **If required, allocate and associate floating IPs to any or all of your hosts**
-* Get the IP address of any of the machines from Openstack
-* set DEISCTL_TUNNEL and install the platform:
-
-```console
-$ export DEISCTL_TUNNEL=23.253.219.94
-$ deisctl install platform && deisctl start platform
-```
-
-The installer will deploy Deis and make sure the services start properly.
-
 ## Configure Deis
 Set the default domain used to anchor your applications:
 
@@ -103,6 +90,19 @@ If you want to allow `deis run` for one-off admin commands, you must provide an 
 ```console
 $ deisctl config platform set sshPrivateKey=<path-to-private-key>
 ```
+
+### Initialize the cluster
+Once the cluster is up:
+* **If required, allocate and associate floating IPs to any or all of your hosts**
+* Get the IP address of any of the machines from Openstack
+* set DEISCTL_TUNNEL and install the platform:
+
+```console
+$ export DEISCTL_TUNNEL=23.253.219.94
+$ deisctl install platform && deisctl start platform
+```
+
+The installer will deploy Deis and make sure the services start properly.
 
 ### Use Deis!
 After that, register with Deis!

--- a/contrib/rackspace/README.md
+++ b/contrib/rackspace/README.md
@@ -54,16 +54,6 @@ Usage: provision-rackspace-cluster.sh <key pair name> [flavor]
 $ ./provision-rackspace-cluster.sh deis-key
 ```
 
-### Initialize the cluster
-Once the cluster is up, get the hostname of any of the machines from Rackspace, set
-DEISCTL_TUNNEL and install the platform:
-```console
-$ export DEISCTL_TUNNEL=23.253.219.94
-$ deisctl install platform && deisctl start platform
-```
-
-The installer will deploy Deis and make sure the services start properly.
-
 ## Configure Deis
 Set the default domain used to anchor your applications:
 
@@ -78,6 +68,16 @@ If you want to allow `deis run` for one-off admin commands, you must provide an 
 ```console
 $ deisctl config platform set sshPrivateKey=<path-to-private-key>
 ```
+
+### Initialize the cluster
+Once the cluster is up, get the hostname of any of the machines from Rackspace, set
+DEISCTL_TUNNEL and install the platform:
+```console
+$ export DEISCTL_TUNNEL=23.253.219.94
+$ deisctl install platform && deisctl start platform
+```
+
+The installer will deploy Deis and make sure the services start properly.
 
 ### Choose number of routers
 By default, `deisctl` will provision 1 router. You can override this by scaling up:


### PR DESCRIPTION
The docs around platform configuration were ordered incorrectly in #2172.  This PR fixes the order of command in the main README and in the contrib/ documentation for each provider.  

The diff looks a bit strange because I'm moving `Configure Deis` before `Initialize the Cluster` in contrib/.
