### PR TITLE
fix(deisctl): "deisctl scale router=N" uses async interface

### DIFF
--- a/deisctl/backend/backend.go
+++ b/deisctl/backend/backend.go
@@ -8,7 +8,7 @@ type Backend interface {
 	Destroy([]string, *sync.WaitGroup, chan string, chan error)
 	Start([]string, *sync.WaitGroup, chan string, chan error)
 	Stop([]string, *sync.WaitGroup, chan string, chan error)
-	Scale(string, int) error
+	Scale(string, int, *sync.WaitGroup, chan string, chan error)
 	ListUnits() error
 	ListUnitFiles() error
 	Status(string) error

--- a/deisctl/backend/fleet/scale.go
+++ b/deisctl/backend/fleet/scale.go
@@ -9,48 +9,45 @@ import (
 )
 
 // Scale creates or destroys units to match the desired number
-func (c *FleetClient) Scale(component string, requested int) error {
-
-	outchan := make(chan string)
-	errchan := make(chan error)
-	var wg sync.WaitGroup
+func (c *FleetClient) Scale(
+	component string, requested int, wg *sync.WaitGroup, outchan chan string, errchan chan error) {
 
 	if requested < 0 {
-		return errors.New("cannot scale below 0")
+		errchan <- errors.New("cannot scale below 0")
 	}
 	// check how many currently exist
 	components, err := c.Units(component)
 	if err != nil {
 		// skip checking the first time; we just want a tally
 		if !strings.Contains(err.Error(), "could not find unit") {
-			return err
+			errchan <- err
+			return
 		}
 	}
 
 	timesToScale := int(math.Abs(float64(requested - len(components))))
 	if timesToScale == 0 {
-		return nil
+		return
 	}
 	if requested-len(components) > 0 {
-		return scaleUp(c, component, len(components), timesToScale, &wg, outchan, errchan)
+		scaleUp(c, component, len(components), timesToScale, wg, outchan, errchan)
+	} else {
+		scaleDown(c, component, len(components), timesToScale, wg, outchan, errchan)
 	}
-	return scaleDown(c, component, len(components), timesToScale, &wg, outchan, errchan)
 }
 
 func scaleUp(c *FleetClient, component string, numExistingContainers, numTimesToScale int,
-	wg *sync.WaitGroup, outchan chan string, errchan chan error) error {
+	wg *sync.WaitGroup, outchan chan string, errchan chan error) {
 	for i := 0; i < numTimesToScale; i++ {
 		target := component + "@" + strconv.Itoa(numExistingContainers+i+1)
 		c.Create([]string{target}, wg, outchan, errchan)
 	}
-	return nil
 }
 
 func scaleDown(c *FleetClient, component string, numExistingContainers, numTimesToScale int,
-	wg *sync.WaitGroup, outchan chan string, errchan chan error) error {
+	wg *sync.WaitGroup, outchan chan string, errchan chan error) {
 	for i := 0; i < numTimesToScale; i++ {
 		target := component + "@" + strconv.Itoa(numExistingContainers-i)
 		c.Destroy([]string{target}, wg, outchan, errchan)
 	}
-	return nil
 }


### PR DESCRIPTION
The scale command uses a similar async `WaitGroup` interface to other commands now, which fixes the `deisctl scale` command. Also disallows scale operations on anything but router, since other unit types do not expect the "unit@1" naming scheme.

Closes #2193.

Fixing #2075 ("scale should also start units") will involve polling for a target state in `Create` in order to know that we can `Start` the units reliably. I will fix that in a follow-on PR.
