### PR TITLE
fix(tests): remove orphaned test containers in cleanup

### DIFF
--- a/tests/bin/test-setup.sh
+++ b/tests/bin/test-setup.sh
@@ -89,6 +89,7 @@ function cleanup {
     ${GOPATH}/src/github.com/deis/deis/tests/bin/destroy-all-vagrants.sh
     VBoxManage list vms | grep deis | sed -n -e 's/^.* {\(.*\)}/\1/p' | xargs -L1 -I {} VBoxManage unregistervm {} --delete
     vagrant global-status --prune
+    docker rm -f -v `docker ps | grep deis- | awk '{print $1}'` 2>/dev/null
     log_phase "Test run complete"
 }
 


### PR DESCRIPTION
The functional tests usually clean up the containers they create, but there are certain failure paths that can end the tests abruptly and leave containers running. In the case of deis-store containers, this often prevents a subsequent test from running.

This change removes "deis-*" containers in the test cleanup trap routine.

Closes #2135.
