### PR TITLE
ref(tests): test docs/ before building any images to fail faster

### DIFF
--- a/tests/bin/test-acceptance.sh
+++ b/tests/bin/test-acceptance.sh
@@ -17,6 +17,11 @@ source $THIS_DIR/test-setup.sh
 trap cleanup EXIT
 trap dump_logs ERR
 
+log_phase "Running documentation tests"
+
+# test building documentation
+make -C docs/ test
+
 log_phase "Building from current source tree"
 
 # build all docker images and client binaries
@@ -24,10 +29,6 @@ make build
 
 # use the built client binaries
 export PATH=$DEIS_ROOT/deisctl:$DEIS_ROOT/client/dist:$PATH
-
-log_phase "Running documentation tests"
-
-make -C docs/ test
 
 log_phase "Running unit and functional tests"
 

--- a/tests/bin/test-integration.sh
+++ b/tests/bin/test-integration.sh
@@ -17,6 +17,11 @@ source $THIS_DIR/test-setup.sh
 trap cleanup EXIT
 trap dump_logs ERR
 
+log_phase "Running documentation tests"
+
+# test building documentation
+make -C docs/ test
+
 log_phase "Building from current source tree"
 
 # build all docker images and client binaries
@@ -24,11 +29,6 @@ make build
 
 # use the built client binaries
 export PATH=$DEIS_ROOT/deisctl:$DEIS_ROOT/client/dist:$PATH
-
-log_phase "Running documentation tests"
-
-# test building documentation
-make -C docs/ test
 
 log_phase "Running unit and functional tests"
 

--- a/tests/bin/test-smoke.sh
+++ b/tests/bin/test-smoke.sh
@@ -17,6 +17,11 @@ source $THIS_DIR/test-setup.sh
 trap cleanup EXIT
 trap dump_logs ERR
 
+log_phase "Running documentation tests"
+
+# test building documentation
+make -C docs/ test
+
 log_phase "Building from current source tree"
 
 # build all docker images and client binaries
@@ -24,10 +29,6 @@ make build
 
 # use the built client binaries
 export PATH=$DEIS_ROOT/deisctl:$DEIS_ROOT/client/dist:$PATH
-
-log_phase "Running test-smoke"
-
-make -C docs/ test
 
 log_phase "Running unit and functional tests"
 


### PR DESCRIPTION
An error in the [reStructuredText](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html) sources under `docs/` is a hard error that will stop the tests, but the test scripts will needlessly build all the docker images before finding that out. 

This change tests the docs first, then moves on to component tests.
