### PR TITLE
fix(deisctl): "deisctl scale router=N" also starts units

### DIFF
--- a/deisctl/backend/fleet/scale.go
+++ b/deisctl/backend/fleet/scale.go
@@ -42,6 +42,11 @@ func scaleUp(c *FleetClient, component string, numExistingContainers, numTimesTo
 		target := component + "@" + strconv.Itoa(numExistingContainers+i+1)
 		c.Create([]string{target}, wg, outchan, errchan)
 	}
+	wg.Wait()
+	for i := 0; i < numTimesToScale; i++ {
+		target := component + "@" + strconv.Itoa(numExistingContainers+i+1)
+		c.Start([]string{target}, wg, outchan, errchan)
+	}
 }
 
 func scaleDown(c *FleetClient, component string, numExistingContainers, numTimesToScale int,


### PR DESCRIPTION
This change fixes logic in `Destroy` to poll until `cAPI.UnitStates()` no longer contains the requested unit, and adds similar logic to `Create` to poll until the unit has a state. This allows both functions to be truly synchronous, which made chaining `Create` and `Start` together in `Scale` trivial.

The side effect is that `deisctl [un]install platform` is a bit slower, but now it is using actual states instead of planned ones.

Closes #2075, #2168. ping @tobyhede.

``` console
$ time deisctl scale router=3 && time deisctl scale router=0
deis-router@1.service: loaded                                 
deis-router@2.service: loaded                                 
deis-router@3.service: loaded                                 
deis-router@1.service: active/running                                 
deis-router@3.service: active/running                                 
deis-router@2.service: active/running                                 

real    0m8.152s
user    0m0.072s
sys 0m0.023s
deis-router@3.service: destroyed                                 
deis-router@1.service: destroyed                                 
deis-router@2.service: destroyed                                 

real    0m4.996s
user    0m0.065s
sys 0m0.018s
```
