### PR TITLE
fix(controller): handle partial deletion of domains

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -863,7 +863,12 @@ def _etcd_publish_domains(**kwargs):
 
 def _etcd_purge_domains(**kwargs):
     app = kwargs['instance'].app
-    _etcd_client.delete('/deis/domains/{}'.format(app))
+    app_domains = app.domain_set.all()
+    if app_domains:
+        _etcd_client.write('/deis/domains/{}'.format(app),
+                           ' '.join(str(d.domain) for d in app_domains))
+    else:
+        _etcd_client.delete('/deis/domains/{}'.format(app))
 
 
 # Log significant app-related events


### PR DESCRIPTION
This PR fixes `domains:remove` logic to allow partial deletion.  We do not have integration tests for domains (since we can't really test CNAMEs) so no tests were included.

Fixes #2181 
Fixes #2279 
