### PR TITLE
fix(docs): restore "make zipfile" target for pypi docs

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -6,6 +6,7 @@
 Django==1.6.8
 # FIXME: switch to upstream pending merge of https://github.com/kmmbvnr/django-fsm/pull/59
 git+https://github.com/deis/django-fsm@propagate-false
+django-cors-headers==0.13
 django-guardian==1.2.4
 django-json-field==0.5.7
 djangorestframework==2.4.3
@@ -18,4 +19,3 @@ PyYAML==3.11
 redis==2.9.1
 static==1.0.2
 South==1.0
-django-cors-headers==0.13

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -75,6 +75,9 @@ test: clean
 	@echo
 	@echo "Test finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
+zipfile: dirhtml
+	cd $(BUILDDIR)/dirhtml; zip -r -D -o ../../docs.zip .
+
 singlehtml:
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -10,6 +10,7 @@
 Django==1.6.8
 # FIXME: switch to upstream pending merge of https://github.com/kmmbvnr/django-fsm/pull/59
 git+https://github.com/deis/django-fsm@propagate-false
+django-cors-headers==0.13
 django-guardian==1.2.4
 django-json-field==0.5.7
 djangorestframework==2.4.3
@@ -19,7 +20,6 @@ paramiko==1.14.1
 psycopg2==2.5.4
 python-etcd==0.3.0
 South==1.0
-django-cors-headers==0.13
 
 # Deis client requirements
 docopt==0.6.2


### PR DESCRIPTION
In our [release docs](http://docs.deis.io/en/latest/contributing/releases/#documentation) we mention `make -C docs/ zipfile` which makes an archive of our HTML documentation suitable for uploading to pypi.python.org. That is effectively our backup documentation site: https://pythonhosted.org/deis/

I accidentally refactored out the `make zipfile` target a while ago, so I've done this by hand for a couple releases. This restores the zipfile target and re-alphabetizes the python requirements files for CORS.
