### PR TITLE
fix(deisctl/units): remove extra commands in store-volume Start-Pre

### DIFF
--- a/deisctl/units/deis-store-volume.service
+++ b/deisctl/units/deis-store-volume.service
@@ -5,7 +5,7 @@ Description=deis-store-volume
 EnvironmentFile=/etc/environment
 ExecStartPre=/usr/bin/mkdir -p /var/lib/deis/store
 ExecStartPre=/bin/sh -c "echo waiting for store-monitor... && until etcdctl get /deis/store/monSetupComplete >/dev/null 2>&1; do sleep 2; done"
-ExecStartPre=/bin/bash -c "HOSTS=`etcdctl ls /deis/store/hosts | cut -d/ -f5 | etcdctl ls /deis/store/hosts | cut -d/ -f5 | awk '{if(NR == 1) {printf $0} else {printf \",\"$0}}'` && mount -t ceph $HOSTS:/ /var/lib/deis/store -o name=admin,secret=`etcdctl get /deis/store/adminKeyring | grep 'key =' | cut -d' ' -f3`"
+ExecStartPre=/bin/bash -c "HOSTS=`etcdctl ls /deis/store/hosts | cut -d/ -f5 | awk '{if(NR == 1) {printf $0} else {printf \",\"$0}}'` && mount -t ceph $HOSTS:/ /var/lib/deis/store -o name=admin,secret=`etcdctl get /deis/store/adminKeyring | grep 'key =' | cut -d' ' -f3`"
 ExecStart=/usr/bin/tail -f /dev/null
 ExecStartPost=/bin/sh -c "test -d /var/lib/deis/store/logs || mkdir -p /var/lib/deis/store/logs"
 ExecStopPost=-/usr/bin/umount /var/lib/deis/store


### PR DESCRIPTION
This seems to be a benign copy / paste error. I noticed it when debugging #2300.
