### PR TITLE
fix(*): etcd_set_default and etcd_safe_mkdir raise some errors

### DIFF
--- a/builder/bin/boot
+++ b/builder/bin/boot
@@ -26,7 +26,13 @@ done
 sleep $(($ETCD_TTL+1))
 
 function etcd_safe_mkdir {
-  etcdctl --no-sync -C $ETCD mkdir $1 >/dev/null 2>&1 || true
+	set +e
+	etcdctl --no-sync -C $ETCD mkdir $1 >/dev/null 2>&1
+	if [[ $? -ne 0 && $? -ne 4 ]]; then
+		echo "etcd_safe_mkdir: an etcd error occurred. aborting..."
+		exit 1
+	fi
+	set -e
 }
 
 etcd_safe_mkdir $ETCD_PATH/users

--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -25,11 +25,23 @@ done
 sleep $(($ETCD_TTL+1))
 
 function etcd_set_default {
-  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
+	set +e
+	etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1
+	if [[ $? -ne 0 && $? -ne 4 ]]; then
+		echo "etcd_set_default: an etcd error occurred. aborting..."
+		exit 1
+	fi
+	set -e
 }
 
 function etcd_safe_mkdir {
-  etcdctl --no-sync -C $ETCD mkdir $1 >/dev/null 2>&1 || true
+	set +e
+	etcdctl --no-sync -C $ETCD mkdir $1 >/dev/null 2>&1
+	if [[ $? -ne 0 && $? -ne 4 ]]; then
+		echo "etcd_safe_mkdir: an etcd error occurred. aborting..."
+		exit 1
+	fi
+	set -e
 }
 
 etcd_set_default protocol ${DEIS_PROTOCOL:-http}

--- a/database/bin/boot
+++ b/database/bin/boot
@@ -31,7 +31,13 @@ done
 sleep $(($ETCD_TTL+1))
 
 function etcd_set_default {
-  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
+  set +e
+  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1
+  if [[ $? -ne 0 && $? -ne 4 ]]; then
+    echo "etcd_set_default: an etcd error occurred. aborting..."
+    exit 1
+  fi
+  set -e
 }
 
 etcd_set_default engine postgresql_psycopg2

--- a/registry/bin/boot
+++ b/registry/bin/boot
@@ -30,7 +30,13 @@ done
 sleep $(($ETCD_TTL+1))
 
 function etcd_set_default {
-  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
+  set +e
+  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1
+  if [[ $? -ne 0 && $? -ne 4 ]]; then
+    echo "etcd_set_default: an etcd error occurred. aborting..."
+    exit 1
+  fi
+  set -e
 }
 
 # seed initial service configuration if necessary

--- a/store/monitor/bin/boot
+++ b/store/monitor/bin/boot
@@ -11,7 +11,13 @@ PG_NUM=${PG_NUM:-128} # default for 3 OSDs
 HOSTNAME=`hostname`
 
 function etcd_set_default {
-  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
+  set +e
+  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1
+  if [[ $? -ne 0 && $? -ne 4 ]]; then
+    echo "etcd_set_default: an etcd error occurred. aborting..."
+    exit 1
+  fi
+  set -e
 }
 
 if ! etcdctl --no-sync -C $ETCD get ${ETCD_PATH}/monSetupComplete >/dev/null 2>&1 ; then


### PR DESCRIPTION
Currently, both `etcd_set_default` and `etcd_safe_mkdir` in
the /bin/boot scripts never fail due to `|| true`. This is usually
desired because if the key already exists, we don't want to overwrite
it. However, if there is an underlying error connecting to etcd, we
swallow that as well.

This commit exploits the fact that `etcdctl` has different exit codes
for key errors and etcd errors to swallow only the errors we wish to.

fixes #2214
