### PR TITLE
ref(*): never use etcdctl with --no-sync

### DIFF
--- a/builder/bin/boot
+++ b/builder/bin/boot
@@ -17,7 +17,7 @@ export ETCD_TTL=${ETCD_TTL:-10}
 export STORAGE_DRIVER=${STORAGE_DRIVER:-btrfs}
 
 # wait for etcd to be available
-until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do
+until etcdctl -C $ETCD ls >/dev/null 2>&1; do
 	echo "waiting for etcd at $ETCD..."
 	sleep $(($ETCD_TTL/2))  # sleep for half the TTL
 done
@@ -26,7 +26,7 @@ done
 sleep $(($ETCD_TTL+1))
 
 function etcd_safe_mkdir {
-  etcdctl --no-sync -C $ETCD mkdir $1 >/dev/null 2>&1 || true
+  etcdctl -C $ETCD mkdir $1 >/dev/null 2>&1 || true
 }
 
 etcd_safe_mkdir $ETCD_PATH/users
@@ -94,8 +94,8 @@ if [[ ! -z $EXTERNAL_PORT ]]; then
 
 	# while the port is listening, publish to etcd
 	while [[ ! -z $(netstat -lnt | awk "\$6 == \"LISTEN\" && \$4 ~ \".$PORT\" && \$1 ~ \"$PROTO.?\"") ]] ; do
-		etcdctl --no-sync -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
-		etcdctl --no-sync -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
+		etcdctl -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
+		etcdctl -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
 		sleep $(($ETCD_TTL/2)) # sleep for half the TTL
 	done
 

--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -16,7 +16,7 @@ export ETCD_PATH=${ETCD_PATH:-/deis/controller}
 export ETCD_TTL=${ETCD_TTL:-10}
 
 # wait for etcd to be available
-until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do
+until etcdctl -C $ETCD ls >/dev/null 2>&1; do
 	echo "waiting for etcd at $ETCD..."
 	sleep $(($ETCD_TTL/2))  # sleep for half the TTL
 done
@@ -25,11 +25,11 @@ done
 sleep $(($ETCD_TTL+1))
 
 function etcd_set_default {
-  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
+  etcdctl -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
 }
 
 function etcd_safe_mkdir {
-  etcdctl --no-sync -C $ETCD mkdir $1 >/dev/null 2>&1 || true
+  etcdctl -C $ETCD mkdir $1 >/dev/null 2>&1 || true
 }
 
 etcd_set_default protocol ${DEIS_PROTOCOL:-http}
@@ -91,8 +91,8 @@ if [[ ! -z $EXTERNAL_PORT ]]; then
 
 	# while the port is listening, publish to etcd
 	while [[ ! -z $(netstat -lnt | awk "\$6 == \"LISTEN\" && \$4 ~ \".$PORT\" && \$1 ~ \"$PROTO.?\"") ]] ; do
-		etcdctl --no-sync -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
-		etcdctl --no-sync -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
+		etcdctl -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
+		etcdctl -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
 		sleep $(($ETCD_TTL/2)) # sleep for half the TTL
 	done
 

--- a/database/bin/boot
+++ b/database/bin/boot
@@ -22,7 +22,7 @@ export BACKUPS_TO_RETAIN=${BACKUPS_TO_RETAIN:-5}
 export BACKUP_FREQUENCY=${BACKUP_FREQUENCY:-2160}
 
 # wait for etcd to be available
-until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do
+until etcdctl -C $ETCD ls >/dev/null 2>&1; do
 	echo "database: waiting for etcd at $ETCD..."
 	sleep $(($ETCD_TTL/2))  # sleep for half the TTL
 done
@@ -31,7 +31,7 @@ done
 sleep $(($ETCD_TTL+1))
 
 function etcd_set_default {
-  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
+  etcdctl -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
 }
 
 etcd_set_default engine postgresql_psycopg2
@@ -127,8 +127,8 @@ if [[ ! -z $EXTERNAL_PORT ]]; then
 
 	# while the port is listening, publish to etcd
 	while [[ ! -z $(netstat -lnt | awk "\$6 == \"LISTEN\" && \$4 ~ \".$PORT\" && \$1 ~ \"$PROTO.?\"") ]] ; do
-		etcdctl --no-sync -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
-		etcdctl --no-sync -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
+		etcdctl -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
+		etcdctl -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
 
     # perform a backup whenever we hit BACKUP_FREQUENCY
     # we really need cron :(

--- a/registry/bin/boot
+++ b/registry/bin/boot
@@ -21,7 +21,7 @@ export REGISTRY_PORT=${PORT:-5000}
 export BUCKET_NAME=${BUCKET_NAME:-registry}
 
 # wait for etcd to be available
-until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do
+until etcdctl -C $ETCD ls >/dev/null 2>&1; do
 	echo "waiting for etcd at $ETCD..."
 	sleep $(($ETCD_TTL/2))  # sleep for half the TTL
 done
@@ -30,7 +30,7 @@ done
 sleep $(($ETCD_TTL+1))
 
 function etcd_set_default {
-  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
+  etcdctl -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
 }
 
 # seed initial service configuration if necessary
@@ -80,8 +80,8 @@ if [[ ! -z $EXTERNAL_PORT ]]; then
 
 	# while the port is listening, publish to etcd
 	while [[ ! -z $(netstat -lnt | awk "\$6 == \"LISTEN\" && \$4 ~ \".$PORT\" && \$1 ~ \"$PROTO.?\"") ]] ; do
-		etcdctl --no-sync -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
-		etcdctl --no-sync -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
+		etcdctl -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
+		etcdctl -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
 		sleep $(($ETCD_TTL/2)) # sleep for half the TTL
 	done
 

--- a/store/daemon/bin/boot
+++ b/store/daemon/bin/boot
@@ -7,7 +7,7 @@ ETCD="$HOST:$ETCD_PORT"
 HOSTNAME=`hostname`
 OSD_ID=''
 
-until etcdctl --no-sync -C $ETCD get /deis/store/monSetupComplete >/dev/null 2>&1 ; do
+until etcdctl -C $ETCD get /deis/store/monSetupComplete >/dev/null 2>&1 ; do
   echo "store-daemon: waiting for monitor setup to complete..."
   sleep 5
 done
@@ -17,7 +17,7 @@ until confd -onetime -node $ETCD -config-file /app/confd.toml >/dev/null 2>&1 ; 
   sleep 5
 done
 
-if ! etcdctl --no-sync -C $ETCD get /deis/store/osds/$HOST >/dev/null 2>&1 ; then
+if ! etcdctl -C $ETCD get /deis/store/osds/$HOST >/dev/null 2>&1 ; then
   echo "store-daemon: creating OSD..."
 
   OSD_ID=`ceph osd create 2>/dev/null`
@@ -30,11 +30,11 @@ if ! etcdctl --no-sync -C $ETCD get /deis/store/osds/$HOST >/dev/null 2>&1 ; the
   fi
 
   echo "store-daemon: created OSD ${OSD_ID}"
-  etcdctl --no-sync -C $ETCD set /deis/store/osds/$HOST ${OSD_ID} >/dev/null
+  etcdctl -C $ETCD set /deis/store/osds/$HOST ${OSD_ID} >/dev/null
 fi
 
 if [ -z "${OSD_ID}" ]; then
-  OSD_ID=`etcdctl --no-sync -C $ETCD get /deis/store/osds/${HOST}`
+  OSD_ID=`etcdctl -C $ETCD get /deis/store/osds/${HOST}`
 fi
 
 # Make sure osd directory exists

--- a/store/gateway/bin/boot
+++ b/store/gateway/bin/boot
@@ -16,7 +16,7 @@ export ETCD_PATH=${ETCD_PATH:-/deis/store/gateway}
 export ETCD_TTL=${ETCD_TTL:-10}
 
 # wait for etcd to be available
-until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do
+until etcdctl -C $ETCD ls >/dev/null 2>&1; do
     echo "waiting for etcd at $ETCD..."
     sleep $(($ETCD_TTL/2))  # sleep for half the TTL
 done
@@ -31,15 +31,15 @@ until confd -onetime -node $ETCD -config-file /app/confd.toml >/dev/null 2>/dev/
 done
 
 # we generate a key for the gateway. we can do this because we have the client key templated out
-if ! etcdctl --no-sync -C $ETCD get /deis/store/gatewayKeyring >/dev/null 2>&1 ; then
+if ! etcdctl -C $ETCD get /deis/store/gatewayKeyring >/dev/null 2>&1 ; then
   ceph-authtool --create-keyring /etc/ceph/ceph.client.radosgw.keyring
   chmod +r /etc/ceph/ceph.client.radosgw.keyring
   ceph-authtool /etc/ceph/ceph.client.radosgw.keyring -n client.radosgw.gateway --gen-key
   ceph-authtool -n client.radosgw.gateway --cap osd 'allow rwx' --cap mon 'allow rwx' /etc/ceph/ceph.client.radosgw.keyring
   ceph -k /etc/ceph/ceph.client.admin.keyring auth add client.radosgw.gateway -i /etc/ceph/ceph.client.radosgw.keyring
-  etcdctl --no-sync -C $ETCD set /deis/store/gatewayKeyring < /etc/ceph/ceph.client.radosgw.keyring >/dev/null
+  etcdctl -C $ETCD set /deis/store/gatewayKeyring < /etc/ceph/ceph.client.radosgw.keyring >/dev/null
 else
-  etcdctl --no-sync -C $ETCD get /deis/store/gatewayKeyring > /etc/ceph/ceph.client.radosgw.keyring
+  etcdctl -C $ETCD get /deis/store/gatewayKeyring > /etc/ceph/ceph.client.radosgw.keyring
   chmod +r /etc/ceph/ceph.client.radosgw.keyring
 fi
 
@@ -48,8 +48,8 @@ if ! radosgw-admin user info --uid=deis >/dev/null 2>&1 ; then
   # store the access key and secret key for consumption by other services
   ACCESS_KEY=`cat /etc/ceph/user.json | python -c 'import json,sys;obj=json.load(sys.stdin);print json.dumps(obj["keys"][0]["access_key"]);' | tr -d '"'`
   SECRET_KEY=`cat /etc/ceph/user.json | python -c 'import json,sys;obj=json.load(sys.stdin);print json.dumps(obj["keys"][0]["secret_key"]);' | tr -d '"'`
-  etcdctl --no-sync -C $ETCD set $ETCD_PATH/accessKey ${ACCESS_KEY} >/dev/null
-  etcdctl --no-sync -C $ETCD set $ETCD_PATH/secretKey ${SECRET_KEY} >/dev/null
+  etcdctl -C $ETCD set $ETCD_PATH/accessKey ${ACCESS_KEY} >/dev/null
+  etcdctl -C $ETCD set $ETCD_PATH/secretKey ${SECRET_KEY} >/dev/null
 fi
 
 # spawn the service in the background
@@ -87,8 +87,8 @@ if [[ ! -z $EXTERNAL_PORT ]]; then
 
   # while the port is listening, publish to etcd
   while [[ ! -z $(netstat -lnt | awk "\$6 == \"LISTEN\" && \$4 ~ \".$PUBLISH\" && \$1 ~ \"$PROTO.?\"") ]] ; do
-    etcdctl --no-sync -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
-    etcdctl --no-sync -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
+    etcdctl -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
+    etcdctl -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
     sleep $(($ETCD_TTL/2)) # sleep for half the TTL
   done
 

--- a/store/monitor/bin/boot
+++ b/store/monitor/bin/boot
@@ -11,14 +11,14 @@ PG_NUM=${PG_NUM:-128} # default for 3 OSDs
 HOSTNAME=`hostname`
 
 function etcd_set_default {
-  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
+  etcdctl -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1 || true
 }
 
-if ! etcdctl --no-sync -C $ETCD get ${ETCD_PATH}/monSetupComplete >/dev/null 2>&1 ; then
+if ! etcdctl -C $ETCD get ${ETCD_PATH}/monSetupComplete >/dev/null 2>&1 ; then
   echo "store-monitor: Ceph hasn't yet been deployed. Trying to deploy..."
   # let's rock and roll. we need to obtain a lock so we can ensure only one machine is trying to deploy the cluster
-  if etcdctl --no-sync -C $ETCD mk ${ETCD_PATH}/monSetupLock $HOSTNAME >/dev/null 2>&1 \
-  || [[ `etcdctl --no-sync -C $ETCD get ${ETCD_PATH}/monSetupLock` == "$HOSTNAME" ]] ; then
+  if etcdctl -C $ETCD mk ${ETCD_PATH}/monSetupLock $HOSTNAME >/dev/null 2>&1 \
+  || [[ `etcdctl -C $ETCD get ${ETCD_PATH}/monSetupLock` == "$HOSTNAME" ]] ; then
     echo "store-monitor: obtained the lock to proceed with setting up."
 
     # set some defaults in etcd if they're not passed in as environment variables
@@ -35,19 +35,19 @@ if ! etcdctl --no-sync -C $ETCD get ${ETCD_PATH}/monSetupComplete >/dev/null 2>&
     ceph-authtool /etc/ceph/ceph.mon.keyring --create-keyring --gen-key -n mon. --cap mon 'allow *'
 
     fsid=$(uuidgen)
-    etcdctl --no-sync -C $ETCD set ${ETCD_PATH}/fsid ${fsid} >/dev/null
+    etcdctl -C $ETCD set ${ETCD_PATH}/fsid ${fsid} >/dev/null
 
     # Generate initial monitor map
     monmaptool --create --add ${HOSTNAME} ${HOST} --fsid ${fsid} /etc/ceph/monmap
 
-    etcdctl --no-sync -C $ETCD set ${ETCD_PATH}/monKeyring < /etc/ceph/ceph.mon.keyring >/dev/null
-    etcdctl --no-sync -C $ETCD set ${ETCD_PATH}/adminKeyring < /etc/ceph/ceph.client.admin.keyring >/dev/null
+    etcdctl -C $ETCD set ${ETCD_PATH}/monKeyring < /etc/ceph/ceph.mon.keyring >/dev/null
+    etcdctl -C $ETCD set ${ETCD_PATH}/adminKeyring < /etc/ceph/ceph.client.admin.keyring >/dev/null
 
     # mark setup as complete
     echo "store-monitor: setup complete."
-    etcdctl --no-sync -C $ETCD set ${ETCD_PATH}/monSetupComplete youBetcha >/dev/null
+    etcdctl -C $ETCD set ${ETCD_PATH}/monSetupComplete youBetcha >/dev/null
   else
-    until etcdctl --no-sync -C $ETCD get ${ETCD_PATH}/monSetupComplete >/dev/null 2>&1 ; do
+    until etcdctl -C $ETCD get ${ETCD_PATH}/monSetupComplete >/dev/null 2>&1 ; do
       echo "store-monitor: waiting for another monitor to complete setup..."
       sleep 5
     done


### PR DESCRIPTION
@aledbf brought up a good point - when using etcdctl, we connect
to only one etcd daemon in the cluster and use the `--no-sync`
flag so the daemon doesn't have to sync with the other cluster
members. However, this can be dangerous when we're dealing with larger
clusters that have etcd daemons in standby mode (i.e. not peers).

See https://github.com/coreos/etcd/blob/master/Documentation/api.md#cluster-config
and https://github.com/coreos/etcd/blob/master/Documentation/design/standbys.md
for details on standby nodes.

This isn't an issue for most clusters as the activeSize by default appears
to be 9:

``` console
ore@deis-1 ~ $ curl -L http://127.0.0.1:7001/v2/admin/config
{"activeSize":9,"removeDelay":1800,"syncInterval":5}
```

However, we definitely don't want to run into issues on larger clusters.
