### PR TITLE
fix docker builds

### DIFF
--- a/builder/templates/builder
+++ b/builder/templates/builder
@@ -179,5 +179,5 @@ echo
 # cleanup
 cd $REPO_DIR
 git gc &>/dev/null
-docker rm -f $JOB &>/dev/null
+[ $JOB ] && docker rm -f $JOB &>/dev/null
 docker rmi -f $TMP_IMAGE &>/dev/null


### PR DESCRIPTION
$JOB is only define for slug builds

`116     # build the application and attach to the process`
`117     JOB=$(docker run $BUILD_OPTS deis/slugbuilder)`

line below makes pre-receive hook to decline the push

`182 docker rm -f $JOB &>/dev/null`
