### PR TITLE
fix(contrib/userdata): nse uses `docker exec`

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -61,7 +61,7 @@ write_files:
     permissions: '0755'
     content: |
       function nse() {
-        sudo nsenter --pid --uts --mount --ipc --net --target $(docker inspect --format="{{ .State.Pid }}" $1)
+        docker exec -it $1 bash
       }
   - path: /run/deis/bin/get_image
     permissions: '0755'


### PR DESCRIPTION
Fixes shells into the container not having the correct envvars
