### PR TITLE
feat(coreos): use custom image in toolbox

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -108,3 +108,9 @@ write_files:
       deisctl list
       etcdctl ls --recursive /deis
       printf "\n"
+  - path: /home/core/.toolboxrc
+    owner: core
+    content: |
+      TOOLBOX_DOCKER_IMAGE=ubuntu-debootstrap
+      TOOLBOX_DOCKER_TAG=14.04
+      TOOLBOX_USER=root


### PR DESCRIPTION
Use the same image than the rest of the project when `toolbox` is executed
https://coreos.com/docs/cluster-management/debugging/install-debugging-tools/

this is the output:

``` console
core@nodo-1 ~ $ toolbox
ubuntu-debootstrap:14.04: The image you are pulling has been verified
511136ea3c5a: Already exists
e2471713634c: Already exists
21530629f1e1: Already exists
Status: Image is up to date for ubuntu-debootstrap:14.04
core-ubuntu-debootstrap-14.04
Spawning container core-ubuntu-debootstrap-14.04 on /var/lib/toolbox/core-ubuntu-debootstrap-14.04.
Press ^] three times within 1s to kill container.
root@nodo-1:~#
```
