### PR TITLE
fix(router): only add x-forwarded-proto on https

### DIFF
--- a/router/templates/nginx.conf
+++ b/router/templates/nginx.conf
@@ -91,6 +91,7 @@ http {
     ## end deis-store-gateway
 
     ## start service definitions for each application
+    {{ $useSSL := or .deis_router_sslCert "false" }}
     {{ $domains := .deis_domains }}{{ range $service := .deis_services }}{{ if $service.Nodes }}
     upstream {{ Base $service.Key }} {
         {{ range $upstream := $service.Nodes }}server {{ $upstream.Value }};
@@ -104,7 +105,9 @@ http {
         location / {
             proxy_buffering             off;
             proxy_set_header            Host $host;
+            {{ if ne $useSSL "false" }}
             proxy_set_header            X-Forwarded-Proto $scheme;
+            {{ end }}
             proxy_set_header            X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_redirect              off;
             proxy_connect_timeout       10s;


### PR DESCRIPTION
Prior to 1f74eeb, sending decrypted https traffic to port 80 worked fine
in the case that there was an https endpoint/load balancer in front of
the cluster. In this example, the addition of X-Forwarded-Proto changes
the forwarded protocol from https to http. Making the prototype only
available when an SSL certificate and key is installed fixes this.

closes #2381
