### PR TITLE
chore(*): bump CoreOS to 490.0.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,7 @@ else
   $vb_cpus = 1
 end
 
-COREOS_VERSION = "472.0.0"
+COREOS_VERSION = "490.0.0"
 
 if File.exist?(CONFIG)
   require CONFIG

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -84,14 +84,16 @@
 
   "Mappings" : {
     "CoreOSAMIs" : {
-      "us-east-1"      : { "PV" : "ami-52db613a", "HVM" : "ami-50db6138" },
-      "us-west-2"      : { "PV" : "ami-77410e47", "HVM" : "ami-75410e45" },
-      "us-west-1"      : { "PV" : "ami-810411c4", "HVM" : "ami-830411c6" },
-      "eu-west-1"      : { "PV" : "ami-7eb91609", "HVM" : "ami-7cb9160b" },
-      "ap-southeast-1" : { "PV" : "ami-ec5071be", "HVM" : "ami-925071c0" },
-      "ap-southeast-2" : { "PV" : "ami-07b0dd3d", "HVM" : "ami-05b0dd3f" },
-      "ap-northeast-1" : { "PV" : "ami-c73504c6", "HVM" : "ami-c93504c8" },
-      "sa-east-1"      : { "PV" : "ami-6b8d3976", "HVM" : "ami-698d3974" }
+      "eu-central-1"   : { "PV" : "ami-54ccfa49", "HVM" : "ami-56ccfa4b" },
+      "ap-northeast-1" : { "PV" : "ami-f7b08ff6", "HVM" : "ami-f9b08ff8" },
+      "sa-east-1"      : { "PV" : "ami-1304b30e", "HVM" : "ami-1104b30c" },
+      "ap-southeast-2" : { "PV" : "ami-0f117e35", "HVM" : "ami-09117e33" },
+      "ap-southeast-1" : { "PV" : "ami-c04f6c92", "HVM" : "ami-c24f6c90" },
+      "us-east-1"      : { "PV" : "ami-7ae66812", "HVM" : "ami-66e6680e" },
+      "us-west-2"      : { "PV" : "ami-e18dc5d1", "HVM" : "ami-ff8dc5cf" },
+      "us-west-1"      : { "PV" : "ami-45fbec00", "HVM" : "ami-bbfcebfe" },
+      "eu-west-1"      : { "PV" : "ami-a27fd5d5", "HVM" : "ami-a47fd5d3" }
+
     },
     "RootDevices" : {
       "HVM" : { "Name": "/dev/xvda" },

--- a/contrib/rackspace/provision-rackspace-cluster.sh
+++ b/contrib/rackspace/provision-rackspace-cluster.sh
@@ -42,8 +42,9 @@ $CONTRIB_DIR/util/check-user-data.sh
 
 i=1 ; while [[ $i -le $DEIS_NUM_INSTANCES ]] ; do \
     echo_yellow "Provisioning deis-$i..."
-    # this image is CoreOS 452.0.0
-    supernova production boot --image 7f116bdd-9b17-410c-b049-eb1bca1b7087 --flavor $FLAVOR --key-name $1 --user-data ../coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
+    # This image is CoreOS 459.0.0, the most recent provided by Rackspace
+    # Deis requires at least CoreOS 471.1.0
+    supernova production boot --image 325a1c78-78e1-4367-be7a-1334b088018a --flavor $FLAVOR --key-name $1 --user-data ../coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
     ((i = i + 1)) ; \
 done
 

--- a/docs/installing_deis/baremetal.rst
+++ b/docs/installing_deis/baremetal.rst
@@ -102,7 +102,7 @@ Start the installation
 
 
 This will install the latest `CoreOS`_ alpha release to disk. To specify a specific CoreOS version,
-append the ``-V`` parameter to the install command, e.g. ``-V 472.0.0``.
+append the ``-V`` parameter to the install command, e.g. ``-V 490.0.0``.
 
 After the installation has finished, reboot your server. Once your machine is back up, you should
 be able to log in as the `core` user using the `deis` ssh key.

--- a/docs/installing_deis/gce.rst
+++ b/docs/installing_deis/gce.rst
@@ -117,7 +117,7 @@ Launch 3 instances. You can choose another starting CoreOS image from the listin
 
 .. code-block:: console
 
-    $ for num in 1 2 3; do gcutil addinstance --image projects/coreos-cloud/global/images/coreos-alpha-472-0-0-v20141017 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
+    $ for num in 1 2 3; do gcutil addinstance --image projects/coreos-cloud/global/images/coreos-alpha-490-0-0-v20141104 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
 
     Table of resources:
 


### PR DESCRIPTION
See https://coreos.com/releases/#490.0.0

Notably, the 3.17 kernel is recommended for Ceph, as it supposedly has fixes for Ceph FS stability: http://lists.ceph.com/pipermail/ceph-users-ceph.com/2014-October/043749.html
