### PR TITLE
fix(deisctl): handle "deisctl help <command>" consistently

### DIFF
--- a/deisctl/client/client.go
+++ b/deisctl/client/client.go
@@ -10,18 +10,18 @@ import (
 
 // DeisCtlClient manages Deis components, configuration, and related tasks.
 type DeisCtlClient interface {
-	Config() error
-	Install(targets []string) error
-	Journal(targets []string) error
-	List() error
-	RefreshUnits() error
-	Restart(targets []string) error
-	Scale(targets []string) error
-	Start(targets []string) error
-	Status(targets []string) error
-	Stop(targets []string) error
-	Uninstall(targets []string) error
-	Update() error
+	Config(argv []string) error
+	Install(argv []string) error
+	Journal(argv []string) error
+	List(argv []string) error
+	RefreshUnits(argv []string) error
+	Restart(argv []string) error
+	Scale(argv []string) error
+	Start(argv []string) error
+	Status(argv []string) error
+	Stop(argv []string) error
+	Uninstall(argv []string) error
+	Update(argv []string) error
 }
 
 // Client uses a backend to implement the DeisCtlClient interface.
@@ -56,61 +56,63 @@ func NewClient(requestedBackend string) (*Client, error) {
 // A configuration value is stored and retrieved from a key/value store (in this case, etcd)
 // at /deis/<component>/<config>. Configuration values are typically used for component-level
 // configuration, such as enabling TLS for the routers.
-func (c *Client) Config() error {
-	return cmd.Config()
+func (c *Client) Config(argv []string) error {
+	return cmd.Config(argv)
 }
 
-// Install loads components' definitions from local unit files.
-func (c *Client) Install(targets []string) error {
-	return cmd.Install(c.Backend, targets)
+// Install loads the definitions of components from local unit files.
+// After Install, the components will be available to Start.
+func (c *Client) Install(argv []string) error {
+	return cmd.Install(argv, c.Backend)
 }
 
 // Journal prints log output for the specified components.
-func (c *Client) Journal(targets []string) error {
-	return cmd.Journal(c.Backend, targets)
+func (c *Client) Journal(argv []string) error {
+	return cmd.Journal(argv, c.Backend)
 }
 
 // List prints a summary of installed components.
-func (c *Client) List() error {
-	return cmd.ListUnits(c.Backend)
+func (c *Client) List(argv []string) error {
+	return cmd.ListUnits(argv, c.Backend)
 }
 
 // RefreshUnits overwrites local unit files with those requested.
-func (c *Client) RefreshUnits() error {
-	return cmd.RefreshUnits()
+func (c *Client) RefreshUnits(argv []string) error {
+	return cmd.RefreshUnits(argv)
 }
 
 // Restart stops and then starts components.
-func (c *Client) Restart(targets []string) error {
-	return cmd.Restart(c.Backend, targets)
+func (c *Client) Restart(argv []string) error {
+	return cmd.Restart(argv, c.Backend)
 }
 
 // Scale grows or shrinks the number of running components.
-func (c *Client) Scale(targets []string) error {
-	return cmd.Scale(c.Backend, targets)
+func (c *Client) Scale(argv []string) error {
+	return cmd.Scale(argv, c.Backend)
 }
 
 // Start activates the specified components.
-func (c *Client) Start(targets []string) error {
-	return cmd.Start(c.Backend, targets)
+func (c *Client) Start(argv []string) error {
+	return cmd.Start(argv, c.Backend)
 }
 
-// Status prints the current state of components.
-func (c *Client) Status(targets []string) error {
-	return cmd.Status(c.Backend, targets)
+// Status prints the current status of components.
+func (c *Client) Status(argv []string) error {
+	return cmd.Status(argv, c.Backend)
 }
 
 // Stop deactivates the specified components.
-func (c *Client) Stop(targets []string) error {
-	return cmd.Stop(c.Backend, targets)
+func (c *Client) Stop(argv []string) error {
+	return cmd.Stop(argv, c.Backend)
 }
 
-// Uninstall unloads components' definitions.
-func (c *Client) Uninstall(targets []string) error {
-	return cmd.Uninstall(c.Backend, targets)
+// Uninstall unloads the definitions of the specified components.
+// After Uninstall, the components will be unavailable until Install is called.
+func (c *Client) Uninstall(argv []string) error {
+	return cmd.Uninstall(argv, c.Backend)
 }
 
 // Update changes the platform version on a cluster host.
-func (c *Client) Update() error {
-	return cmd.Update()
+func (c *Client) Update(argv []string) error {
+	return cmd.Update(argv)
 }

--- a/deisctl/config/config.go
+++ b/deisctl/config/config.go
@@ -5,27 +5,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strings"
-
-	docopt "github.com/docopt/docopt-go"
 )
 
 // Config runs the config subcommand
-func Config() error {
-	usage := `Deis Cluster Configuration
-
-    Usage:
-    deisctl config <target> get [<key>...] [options]
-    deisctl config <target> set <key=val>... [options]
-
-    Options:
-    --verbose                   print out the request bodies [default: false]
-    `
-	// parse command-line arguments
-	args, err := docopt.Parse(usage, nil, true, "", true)
-	if err != nil {
-		return err
-	}
-	err = setConfigFlags(args)
+func Config(args map[string]interface{}) error {
+	err := setConfigFlags(args)
 	if err != nil {
 		return err
 	}

--- a/deisctl/deisctl.go
+++ b/deisctl/deisctl.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/deis/deis/deisctl/backend/fleet"
 	"github.com/deis/deis/deisctl/client"
@@ -17,11 +18,182 @@ const (
 	Version string = "0.15.1+git"
 )
 
-func exit(err error, code int) {
-	fmt.Printf("Error: %v\n", err)
-	os.Exit(code)
+// main exits with the return value of Command(os.Args[1:]), deferring all logic to
+// a func we can test.
+func main() {
+	os.Exit(Command(nil))
 }
 
+// Command executes the given deisctl command line.
+func Command(argv []string) int {
+	deisctlMotd := utils.DeisIfy("Deis Control Utility")
+	usage := deisctlMotd + `
+Usage: deisctl <command> [<args>...] [options]
+
+Commands, use "deisctl help <command>" to learn more:
+  install           install components, or the entire platform
+  uninstall         uninstall components
+  list              list installed components
+  start             start compnents
+  stop              stop components
+  restart           stop, then start components
+  scale             grow or shrink the number of routers
+  journal           print the log output of a component
+  config            set platform or component values
+  update            run the update engine
+  refresh-units     refresh unit files from GitHub
+  help              show the help screen for a command
+
+Options:
+  -h --help                   show this help screen
+  --endpoint=<url>            etcd endpoint for fleet [default: http://127.0.0.1:4001]
+  --etcd-cafile=<path>        etcd CA file authentication [default: ]
+  --etcd-certfile=<path>      etcd cert file authentication [default: ]
+  --etcd-key-prefix=<path>    keyspace for fleet data in etcd [default: /_coreos.com/fleet/]
+  --etcd-keyfile=<path>       etcd key file authentication [default: ]
+  --known-hosts-file=<path>   where to store remote fingerprints [default: ~/.ssh/known_hosts]
+  --request-timeout=<secs>    seconds before a request is considered failed [default: 10.0]
+  --strict-host-key-checking  verify SSH host keys [default: true]
+  --tunnel=<host>             SSH tunnel for communication with fleet and etcd [default: ]
+  --version                   print the version of deisctl
+`
+	// pre-parse command-line arguments
+	argv, helpFlag := parseArgs(argv)
+	// give docopt an optional final false arg so it doesn't call os.Exit()
+	args, err := docopt.Parse(usage, argv, false, Version, false, false)
+	if err != nil || len(args) == 0 {
+		if helpFlag {
+			fmt.Print(usage)
+			return 0
+		} else {
+			return 1
+		}
+	}
+	command := args["<command>"]
+	setTunnel := true
+	// "--help" and "refresh-units" doesn't need SSH tunneling
+	if helpFlag || command == "refresh-units" {
+		setTunnel = false
+	}
+	setGlobalFlags(args, setTunnel)
+	// clean up the args so subcommands don't need to reparse them
+	argv = removeGlobalArgs(argv)
+	// construct a client
+	c, err := client.NewClient("fleet")
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return 1
+	}
+	// Dispatch the command, passing the argv through so subcommands can
+	// re-parse it according to their usage strings.
+	switch command {
+	case "list":
+		err = c.List(argv)
+	case "scale":
+		err = c.Scale(argv)
+	case "start":
+		err = c.Start(argv)
+	case "restart":
+		err = c.Restart(argv)
+	case "stop":
+		err = c.Stop(argv)
+	case "status":
+		err = c.Status(argv)
+	case "journal":
+		err = c.Journal(argv)
+	case "install":
+		err = c.Install(argv)
+	case "uninstall":
+		err = c.Uninstall(argv)
+	case "config":
+		err = c.Config(argv)
+	case "update":
+		err = c.Update(argv)
+	case "refresh-units":
+		err = c.RefreshUnits(argv)
+	case "help":
+		fmt.Print(usage)
+		return 0
+	default:
+		fmt.Println(`Found no matching command, try "deisctl help"
+Usage: deisctl <command> [<args>...] [options]`)
+		return 1
+	}
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// isGlobalArg returns true if a string looks like it is a global deisctl option flag,
+// such as "--tunnel".
+func isGlobalArg(arg string) bool {
+	prefixes := []string{
+		"--endpoint=",
+		"--etcd-key-prefix=",
+		"--etcd-keyfile=",
+		"--etcd-certfile=",
+		"--etcd-cafile=",
+		// "--experimental-api=",
+		"--known-hosts-file=",
+		"--strict-host-key-checking=",
+		"--request-timeout=",
+		"--tunnel",
+	}
+	for _, p := range prefixes {
+		if strings.HasPrefix(arg, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseArgs returns the provided args with "--help" as the last arg if need be,
+// and a boolean to indicate whether help was requested.
+func parseArgs(argv []string) ([]string, bool) {
+	if argv == nil {
+		argv = os.Args[1:]
+	}
+
+	if len(argv) == 1 {
+		// rearrange "deisctl --help" as "deisctl help"
+		if argv[0] == "--help" || argv[0] == "-h" {
+			argv[0] = "help"
+		}
+	}
+
+	if len(argv) >= 2 {
+		// rearrange "deisctl help <command>" as "deisctl <command> --help"
+		if argv[0] == "help" || argv[0] == "--help" || argv[0] == "-h" {
+			argv = append(argv[1:], "--help")
+		}
+	}
+
+	helpFlag := false
+	for _, a := range argv {
+		if a == "help" || a == "--help" || a == "-h" {
+			helpFlag = true
+			break
+		}
+	}
+
+	return argv, helpFlag
+}
+
+// removeGlobalArgs returns the given args without any global option flags, to make
+// re-parsing by subcommands easier.
+func removeGlobalArgs(argv []string) []string {
+	v := make([]string, 0)
+	for _, a := range argv {
+		if !isGlobalArg(a) {
+			v = append(v, a)
+		}
+	}
+	return v
+}
+
+// setGlobalFlags sets fleet provider options based on deisctl global flags.
 func setGlobalFlags(args map[string]interface{}, setTunnel bool) {
 	fleet.Flags.Endpoint = args["--endpoint"].(string)
 	fleet.Flags.EtcdKeyPrefix = args["--etcd-key-prefix"].(string)
@@ -40,98 +212,5 @@ func setGlobalFlags(args map[string]interface{}, setTunnel bool) {
 		} else {
 			fleet.Flags.Tunnel = os.Getenv("DEISCTL_TUNNEL")
 		}
-	}
-}
-
-func main() {
-	deisctlMotd := utils.DeisIfy("Deis Control Utility")
-	usage := deisctlMotd + `
-Usage:
-  deisctl <command> [<target>...] [options]
-
-Commands:
-  deisctl install [<service> | platform]
-  deisctl uninstall [<service> | platform]
-  deisctl list
-  deisctl scale [<service>=<num>]
-  deisctl start [<service> | platform]
-  deisctl stop [<service> | platform]
-  deisctl restart [<service> | platform]
-  deisctl journal <service>
-  deisctl config <component> <get|set> <args>
-  deisctl update
-  deisctl refresh-units
-
-Example Commands:
-  deisctl install platform
-  deisctl uninstall builder
-  deisctl scale router=2
-  deisctl start router@2
-  deisctl stop router builder
-  deisctl status controller
-  deisctl journal controller
-
-Options:
-  --version                   print version and exit
-  --endpoint=<url>            etcd endpoint for fleet [default: http://127.0.0.1:4001]
-  --etcd-key-prefix=<path>    keyspace for fleet data in etcd [default: /_coreos.com/fleet/]
-  --etcd-keyfile=<path>       etcd key file authentication [default: ]
-  --etcd-certfile=<path>      etcd cert file authentication [default: ]
-  --etcd-cafile=<path>        etcd CA file authentication [default: ]
-  --known-hosts-file=<path>   file used to store remote machine fingerprints [default: ~/.ssh/known_hosts]
-  --strict-host-key-checking  verify SSH host keys [default: true]
-  --tunnel=<host>             establish an SSH tunnel for communication with fleet and etcd [default: ]
-  --request-timeout=<secs>    amount of time to allow a single request before considering it failed. [default: 10.0]
-`
-	// parse command-line arguments
-	args, err := docopt.Parse(usage, nil, true, Version, true)
-	if err != nil {
-		exit(err, 2)
-	}
-	command := args["<command>"]
-	targets := args["<target>"].([]string)
-	setTunnel := true
-	// refresh-units doesn't need SSH tunneling
-	if command == "refresh-units" {
-		setTunnel = false
-	}
-	setGlobalFlags(args, setTunnel)
-	// construct a client
-	c, err := client.NewClient("fleet")
-	if err != nil {
-		exit(err, 1)
-	}
-	// dispatch the command
-	switch command {
-	case "list":
-		err = c.List()
-	case "scale":
-		err = c.Scale(targets)
-	case "start":
-		err = c.Start(targets)
-	case "restart":
-		err = c.Restart(targets)
-	case "stop":
-		err = c.Stop(targets)
-	case "status":
-		err = c.Status(targets)
-	case "journal":
-		err = c.Journal(targets)
-	case "install":
-		err = c.Install(targets)
-	case "uninstall":
-		err = c.Uninstall(targets)
-	case "config":
-		err = c.Config()
-	case "update":
-		err = c.Update()
-	case "refresh-units":
-		err = c.RefreshUnits()
-	default:
-		fmt.Printf(usage)
-		os.Exit(2)
-	}
-	if err != nil {
-		exit(err, 1)
 	}
 }

--- a/deisctl/update/update.go
+++ b/deisctl/update/update.go
@@ -10,7 +10,6 @@ import (
 	update "github.com/coreos/updateservicectl/client/update/v1"
 	"github.com/deis/deis/deisctl/constant"
 	"github.com/deis/deis/deisctl/utils"
-	docopt "github.com/docopt/docopt-go"
 )
 
 const (
@@ -102,26 +101,8 @@ func setUpdateFlags(args map[string]interface{}) error {
 }
 
 // Update runs the Deis update engine daemon
-func Update() error {
-	usage := `Deis Update Daemon
-
-	Usage:
-	deisctl update [options]
-
-	Options:
-	--verbose                   print out the request bodies [default: false]
-	--min-sleep=<sec>           minimum time between update checks [default: 10]
-	--max-sleep=<sec>           maximum time between update checks [default: 30]
-	--server=<server>           alternate update server URL (optional)
-	`
-	// parse command-line arguments
-	args, err := docopt.Parse(usage, nil, true, "", true)
-	if err != nil {
-		return err
-	}
-	fmt.Printf("args: %v\n", args)
-	err = setUpdateFlags(args)
-	if err != nil {
+func Update(args map[string]interface{}) error {
+	if err := setUpdateFlags(args); err != nil {
 		return err
 	}
 	fmt.Printf("flags: %v\n", Flags)


### PR DESCRIPTION
This change reworks the DeisCtlClient interface and our usage of `docopt` in order to handle `--help`, `-h`, and `help <command>` consistently, and to give each subcommand its own usage string. This change should also make it possible to write go unit tests against the new `Command()` func; previously `docopt` would have called `os.Exit()` and killed all tests. In short, this should make `docopt` self-documenting as the `deis` CLI is.

Closes #2083, #2356.
