### PR TITLE
chore(*): Added editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.go]
+indent_style = tab


### PR DESCRIPTION
editorconfig configures editors to use the correct indent size and
style.

Replaces #2347
