### PR TITLE
fix(*): Corrected required cores version

### DIFF
--- a/docs/installing_deis/baremetal.rst
+++ b/docs/installing_deis/baremetal.rst
@@ -12,7 +12,7 @@ machine running entirely from RAM. Then, you can `install CoreOS to disk`_.
 
 .. important::
 
-    Deis requires CoreOS version 471.1.0 or more recent for Ceph FS support in the kernel.
+    Deis requires CoreOS version 472.0.0 or more recent.
 
 
 Generate SSH key

--- a/docs/managing_deis/upgrading-deis.rst
+++ b/docs/managing_deis/upgrading-deis.rst
@@ -153,7 +153,7 @@ Upgrading CoreOS
 ----------------
 
 Sometimes you may need to update CoreOS manually in order to get Deis to work. For example, Deis
-requires a minimum of CoreOS v471.1.0 for Ceph FS support. To update CoreOS, run the following
+requires a minimum of CoreOS v472.0.0. To update CoreOS, run the following
 commands:
 
 .. code-block:: console


### PR DESCRIPTION
Deis uses now `docker exec`, which landed in docker 1.3. 472 was the first coreos release, which included docker 1.3

The required coreos release is now defined by docker and not ceph https://github.com/deis/deis/issues/2421#issuecomment-62199890
//cc @carmstrong 
