### PR TITLE
fix(docs): use /deis/logs/host|port, not /deis/logger/

### DIFF
--- a/docs/managing_deis/logger_settings.rst
+++ b/docs/managing_deis/logger_settings.rst
@@ -22,8 +22,8 @@ The following etcd keys are set by the database component, typically in its /bin
 ===========================              =================================================================================
 setting                                  description
 ===========================              =================================================================================
-/deis/logger/host                        IP address of the host running logger
-/deis/logger/port                        port used by the logger service (default: 514)
+/deis/logs/host                          IP address of the host running logger
+/deis/logs/port                          port used by the logger service (default: 514)
 ===========================              =================================================================================
 
 Settings used by logger

--- a/logger/README.md
+++ b/logger/README.md
@@ -19,7 +19,7 @@ install, and start **deis/logger**.
 * **ETCD_PORT** sets the TCP port on which to connect to the local etcd
   daemon (default: *4001*)
 * **ETCD_PATH** sets the etcd directory where the logger announces
-  its configuration (default: */deis/logger*)
+  its configuration (default: */deis/logs*)
 * **ETCD_TTL** sets the time-to-live before etcd purges a configuration
   value, in seconds (default: *10*)
 * **PORT** sets the TCP port on which the logger listens (default: *514*)


### PR DESCRIPTION
Apparently this wasn't updated with the logspout refactoring.
