### PR TITLE
chore(controller): update djangorestframework to 2.4.4

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -9,7 +9,7 @@ git+https://github.com/deis/django-fsm@propagate-false
 django-cors-headers==0.13
 django-guardian==1.2.4
 django-json-field==0.5.7
-djangorestframework==2.4.3
+djangorestframework==2.4.4
 docker-py==0.4.0
 gunicorn==19.1.1
 paramiko==1.14.1

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -13,7 +13,7 @@ git+https://github.com/deis/django-fsm@propagate-false
 django-cors-headers==0.13
 django-guardian==1.2.4
 django-json-field==0.5.7
-djangorestframework==2.4.3
+djangorestframework==2.4.4
 docker-py==0.4.0
 gunicorn==19.1.1
 paramiko==1.14.1


### PR DESCRIPTION
See http://www.django-rest-framework.org/topics/release-notes#24x-series
and https://github.com/tomchristie/django-rest-framework/compare/2.4.3...2.4.4

Looks like bug fixes and one security fix in DRF 2.4.4, but I don't consider this essential for the 0.16 release.
