### PR TITLE
chore(controller): update docker-py to 0.6.0

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -10,7 +10,7 @@ django-cors-headers==0.13
 django-guardian==1.2.4
 django-json-field==0.5.7
 djangorestframework==2.4.4
-docker-py==0.4.0
+docker-py==0.6.0
 gunicorn==19.1.1
 paramiko==1.14.1
 psycopg2==2.5.4

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -14,7 +14,7 @@ django-cors-headers==0.13
 django-guardian==1.2.4
 django-json-field==0.5.7
 djangorestframework==2.4.4
-docker-py==0.4.0
+docker-py==0.6.0
 gunicorn==19.1.1
 paramiko==1.14.1
 psycopg2==2.5.4


### PR DESCRIPTION
The controller uses only the `utils.parse_repository_tag()` function, which has not changed, so this merely keeps _requirements.txt_ and our python toolbox up to date.

Not essential for the 0.16 release, just housekeeping.
