### PR TITLE
chore(controller): update South to 1.0.1

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -18,4 +18,4 @@ python-etcd==0.3.2
 PyYAML==3.11
 redis==2.9.1
 static==1.0.2
-South==1.0
+South==1.0.1

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -19,7 +19,7 @@ gunicorn==19.1.1
 paramiko==1.14.1
 psycopg2==2.5.4
 python-etcd==0.3.2
-South==1.0
+South==1.0.1
 
 # Deis client requirements
 docopt==0.6.2


### PR DESCRIPTION
See http://south.readthedocs.org/en/latest/releasenotes/1.0.1.html
and https://bitbucket.org/andrewgodwin/south/commits/tag/1.0.1

Two future-proofing bug fixes we should have, but not essential for the 0.16 release.
