### PR TITLE
feat(*): Scalable registry

### DIFF
--- a/deisctl/README.md
+++ b/deisctl/README.md
@@ -43,7 +43,7 @@ deis-store-gateway.service: loaded
 Control plane...
 deis-cache.service: loaded
 deis-database.service: loaded
-deis-registry.service: loaded
+deis-registry@1.service: loaded
 deis-controller.service: loaded
 deis-builder.service: loaded
 Data plane...
@@ -70,7 +70,7 @@ deis-store-gateway.service: running
 Control plane...
 deis-cache.service: running
 deis-database.service: running
-deis-registry.service: running
+deis-registry@1.service: running
 deis-controller.service: running
 deis-builder.service: running
 Data plane...
@@ -84,7 +84,7 @@ Done.
 
 Note that the default start command activates 1 of each component.
 You can scale components with `deisctl scale router=3`, for example.
-The router is the only component that _currently_ scales beyond 1 unit.
+The router and the registry are the only component that _currently_ scales beyond 1 unit.
 
 You can also use the `deisctl uninstall` command to destroy platform units:
 
@@ -103,7 +103,7 @@ deis-controller.service: inactive
 deis-builder.service: inactive
 deis-cache.service: inactive
 deis-database.service: inactive
-deis-registry.service: inactive
+deis-registry@1.service: inactive
 Storage subsystem...
 deis-store-gateway.service: inactive
 Logging subsystem...
@@ -140,7 +140,7 @@ deis-cache.service  		f936b7a5.../172.17.8.100	loaded	active	running
 deis-controller.service	    f936b7a5.../172.17.8.100	loaded	active	running
 deis-database.service		f936b7a5.../172.17.8.100	loaded	active	running
 deis-logger.service	    	f936b7a5.../172.17.8.100	loaded	active	running
-deis-registry.service		f936b7a5.../172.17.8.100	loaded	active	running
+deis-registry@1.service		f936b7a5.../172.17.8.100	loaded	active	running
 deis-router@1.service		f936b7a5.../172.17.8.100	loaded	active	running
 ```
 

--- a/deisctl/deisctl.go
+++ b/deisctl/deisctl.go
@@ -37,7 +37,7 @@ Commands, use "deisctl help <command>" to learn more:
   start             start compnents
   stop              stop components
   restart           stop, then start components
-  scale             grow or shrink the number of routers
+  scale             grow or shrink the number of routers or registries
   journal           print the log output of a component
   config            set platform or component values
   refresh-units     refresh unit files from GitHub

--- a/deisctl/units/deis-registry.service
+++ b/deisctl/units/deis-registry.service
@@ -13,3 +13,6 @@ RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
+
+[X-Fleet]
+Conflicts=deis-registry@*.service

--- a/registry/bin/boot
+++ b/registry/bin/boot
@@ -13,6 +13,7 @@ set -eo pipefail
 export ETCD_PORT=${ETCD_PORT:-4001}
 export ETCD="$HOST:$ETCD_PORT"
 export ETCD_PATH=${ETCD_PATH:-/deis/registry}
+export HOST_ETCD_PATH=${HOST_ETCD_PATH:-/deis/registry/hosts/$HOST}
 export ETCD_TTL=${ETCD_TTL:-10}
 
 # run.sh requires $REGISTRY_PORT
@@ -86,8 +87,15 @@ if [[ ! -z $EXTERNAL_PORT ]]; then
 
 	# while the port is listening, publish to etcd
 	while [[ ! -z $(netstat -lnt | awk "\$6 == \"LISTEN\" && \$4 ~ \".$PORT\" && \$1 ~ \"$PROTO.?\"") ]] ; do
-		etcdctl --no-sync -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
-		etcdctl --no-sync -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
+		if etcdctl --no-sync -C $ETCD mk ${ETCD_PATH}/masterLock $HOSTNAME --ttl $ETCD_TTL >/dev/null 2>&1 \
+		|| [[ `etcdctl --no-sync -C $ETCD get ${ETCD_PATH}/masterLock` == "$HOSTNAME" ]] ; then
+			etcdctl --no-sync -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
+			etcdctl --no-sync -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
+			etcdctl --no-sync -C $ETCD update ${ETCD_PATH}/masterLock $HOSTNAME --ttl $ETCD_TTL >/dev/null 
+		fi
+		etcdctl --no-sync -C $ETCD set $HOST_ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
+		etcdctl --no-sync -C $ETCD set $HOST_ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
+
 		sleep $(($ETCD_TTL/2)) # sleep for half the TTL
 	done
 


### PR DESCRIPTION
Allow the deis registry to be scaled across multiple cluster nodes. For now one registry will receive a master lock and only this registry is used by other deis components. All other registries are fast failover slaves in case the node hosting the master registry fails.

This improves app reboot times on node failures.
