### PR TITLE
fix(router): Increased connect timeout

### DIFF
--- a/router/templates/nginx.conf
+++ b/router/templates/nginx.conf
@@ -75,7 +75,7 @@ http {
     server {
         server_name ~^deis-store\.(?<domain>.+)$;
         include deis.conf;
-        
+
         client_max_body_size            0;
 
         location / {
@@ -112,7 +112,7 @@ http {
             {{ end }}
             proxy_set_header            X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_redirect              off;
-            proxy_connect_timeout       10s;
+            proxy_connect_timeout       30s;
             proxy_send_timeout          1200s;
             proxy_read_timeout          1200s;
             proxy_http_version          1.1;


### PR DESCRIPTION
Heroku terminates requests after 30 seconds and the nginx default is 60 seconds.

This might fix https://github.com/deis/deis/issues/2287, fixes #2490
