### PR TITLE
fix(*): Handling of unavailable services

### DIFF
--- a/router/templates/nginx.conf
+++ b/router/templates/nginx.conf
@@ -36,7 +36,7 @@ http {
     client_max_body_size {{ or (.deis_router_bodySize) "1m" }};
 
     log_format upstreaminfo '[$time_local] - $remote_addr - $remote_user - $status - "$request" - $bytes_sent - "$http_referer" - "$http_user_agent" - "$server_name" - $upstream_addr';
-    
+
     # send logs to STDOUT so they can be seen using 'docker logs'
     access_log /opt/nginx/logs/access.log upstreaminfo;
     error_log  /opt/nginx/logs/error.log;
@@ -51,11 +51,13 @@ http {
     upstream deis-controller {
         server {{ .deis_controller_host }}:{{ .deis_controller_port }};
     }
+    {{ end }}
 
     server {
         server_name ~^deis\.(?<domain>.+)$;
         include deis.conf;
 
+        {{ if .deis_controller_host }}
         location / {
             proxy_buffering             off;
             proxy_set_header            Host $host;
@@ -67,7 +69,12 @@ http {
 
             proxy_pass                  http://deis-controller;
         }
-    }{{ end }}
+        {{ else }}
+        location / {
+            return 503;
+        }
+        {{ end }}
+    }
     ## end deis-controller
 
     ## start deis-store-gateway
@@ -75,6 +82,7 @@ http {
     upstream deis-store-gateway {
         server {{ .deis_store_gateway_host }}:{{ .deis_store_gateway_port }};
     }
+    {{ end }}
 
     server {
         server_name ~^deis-store\.(?<domain>.+)$;
@@ -82,6 +90,7 @@ http {
 
         client_max_body_size            0;
 
+        {{ if .deis_store_gateway_host }}
         location / {
             proxy_buffering             off;
             proxy_set_header            Host $host;
@@ -93,7 +102,12 @@ http {
 
             proxy_pass                  http://deis-store-gateway;
         }
-    }{{ end }}
+        {{ else }}
+        location / {
+            return 503;
+        }
+        {{ end }}
+    }
     ## end deis-store-gateway
 
     ## start service definitions for each application
@@ -103,11 +117,13 @@ http {
         {{ range $upstream := $service.Nodes }}server {{ $upstream.Value }};
         {{ end }}
     }
+    {{ end }}
 
     server {
         server_name ~^{{ Base $service.Key }}\.(?<domain>.+)${{ range $app_domains := $domains }}{{ if eq (Base $service.Key) (Base $app_domains.Key) }} {{ $app_domains.Value }}{{ end }}{{ end }};
         include deis.conf;
 
+        {{ if $service.Nodes }}
         location / {
             proxy_buffering             off;
             proxy_set_header            Host $host;
@@ -129,8 +145,13 @@ http {
 
             proxy_pass                  http://{{ Base $service.Key }};
         }
+        {{ else }}
+        location / {
+            return 503;
+        }
+        {{ end }}
     }
-    {{ end }}{{ end }}
+    {{ end }}
     ## end service definitions for each application
 
     # healthcheck

--- a/tests/ps_test.go
+++ b/tests/ps_test.go
@@ -12,15 +12,19 @@ import (
 )
 
 var (
-	psListCmd  = "ps:list --app={{.AppName}}"
-	psScaleCmd = "ps:scale web={{.ProcessNum}} --app={{.AppName}}"
+	psListCmd      = "ps:list --app={{.AppName}}"
+	psScaleCmd     = "ps:scale web={{.ProcessNum}} --app={{.AppName}}"
+	psDownScaleCmd = "ps:scale web=0 --app={{.AppName}}"
 )
 
 func TestPs(t *testing.T) {
 	params := psSetup(t)
-	psScaleTest(t, params)
+	psScaleTest(t, params, psScaleCmd)
 	appsOpenTest(t, params)
 	psListTest(t, params, false)
+	psScaleTest(t, params, psDownScaleCmd)
+	utils.CurlWithFail(t, params, true, "503")
+
 	utils.AppsDestroyTest(t, params)
 	utils.Execute(t, psScaleCmd, params, true, "404 NOT FOUND")
 	// ensure we can choose our preferred beverage
@@ -55,8 +59,7 @@ func psListTest(t *testing.T, params *utils.DeisTestConfig, notflag bool) {
 	utils.CheckList(t, psListCmd, params, output, notflag)
 }
 
-func psScaleTest(t *testing.T, params *utils.DeisTestConfig) {
-	cmd := psScaleCmd
+func psScaleTest(t *testing.T, params *utils.DeisTestConfig, cmd string) {
 	if strings.Contains(params.ExampleApp, "dockerfile") {
 		cmd = strings.Replace(cmd, "web", "cmd", 1)
 	}


### PR DESCRIPTION
Send http code 503 for not running services.

This improves messaging when a service is temporarily unavailable and fails app health checks pinging `/` when all instances of an app are offline.

Example with a stopped controller you receive now:

```
$ deis apps
503 Service Temporarily Unavailable
<html>
<head><title>503 Service Temporarily Unavailable</title></head>
<body bgcolor="white">
<center><h1>503 Service Temporarily Unavailable</h1></center>
<hr><center>nginx/1.6.2</center>
</body>
</html>
```

Fixes #2161
