### PR TITLE
fix(docs): update links to Docker documentation

### DIFF
--- a/docs/using_deis/deploy-application.rst
+++ b/docs/using_deis/deploy-application.rst
@@ -57,5 +57,5 @@ Learn how to use deploy applications on Deis :ref:`using-docker-images`.
 
 .. _`twelve-factor methodology`: http://12factor.net/
 .. _`Heroku Buildpacks`: https://devcenter.heroku.com/articles/buildpacks
-.. _`Dockerfiles`: http://docs.docker.io/en/latest/use/builder/
-.. _`Docker Images`: http://docs.docker.io/introduction/understanding-docker/
+.. _`Dockerfiles`: https://docs.docker.com/reference/builder/
+.. _`Docker Images`: https://docs.docker.com/introduction/understanding-docker/

--- a/docs/using_deis/using-docker-images.rst
+++ b/docs/using_deis/using-docker-images.rst
@@ -80,7 +80,7 @@ Deis uses the ``cmd`` process type to refer to this default command.
 Process types other than ``cmd`` are not supported when using Docker images.
 
 
-.. _`Docker Image`: http://docs.docker.io/introduction/understanding-docker/
+.. _`Docker Image`: https://docs.docker.com/introduction/understanding-docker/
 .. _`DockerHub`: https://registry.hub.docker.com/
-.. _`CMD instruction`: http://docs.docker.io/reference/builder/#cmd
+.. _`CMD instruction`: https://docs.docker.com/reference/builder/#cmd
 .. _`issue 1156`: https://github.com/deis/deis/issues/1156

--- a/docs/using_deis/using-dockerfiles.rst
+++ b/docs/using_deis/using-dockerfiles.rst
@@ -124,8 +124,8 @@ Deis also supports scaling other process types as defined in a `Procfile`_.  To 
 2. Include a ``start`` executable that can be called with: ``start <process-type>``
 
 
-.. _`Dockerfile`: http://docs.docker.io/en/latest/use/builder/
-.. _`Docker Image`: http://docs.docker.io/introduction/understanding-docker/
-.. _`CMD instruction`: http://docs.docker.io/reference/builder/#cmd
+.. _`Dockerfile`: https://docs.docker.com/reference/builder/
+.. _`Docker Image`: https://docs.docker.com/introduction/understanding-docker/
+.. _`CMD instruction`:  https://docs.docker.com/reference/builder/#cmd
 .. _`issue 1156`: https://github.com/deis/deis/issues/1156
 .. _`Procfile`: https://devcenter.heroku.com/articles/procfile


### PR DESCRIPTION
It was pointed out that  http://docs.docker.io/en/latest/use/builder/ is a dead link referred to in our docs. This change updates outbound links to Docker's documentation to be current, although I think that was the only actual 404.
