### PR TITLE
docs(managing_deis): add note for public cloud environments

### DIFF
--- a/docs/installing_deis/digitalocean.rst
+++ b/docs/installing_deis/digitalocean.rst
@@ -37,7 +37,6 @@ Generate a New Discovery URL
 
 Please refer to :ref:`generate_discovery_url` for generating a new Discovery URL.
 
-
 Create CoreOS Droplets
 ----------------------
 
@@ -120,6 +119,19 @@ For convenience, you can also set up DNS records for each node:
 
 If you need help using the DNS control panel, check out `this tutorial`_ on DigitalOcean's
 community site.
+
+Apply Security Group Settings
+-----------------------------
+
+Because DigitalOcean does not have a security group feature, we'll need to add some custom
+``iptables`` rules so our components are not accessible from the outside world. To do this, there
+is a script in ``contrib/`` which will help us with that. To run it, use:
+
+.. code-block:: console
+
+    $ for i in 1 2 3; do ssh core@deis-$i.example.com 'bash -s' < contrib/util/custom-firewall.sh; done
+
+Our components should now be locked down from external sources.
 
 Install Deis Platform
 ---------------------

--- a/docs/managing_deis/add_remove_host.rst
+++ b/docs/managing_deis/add_remove_host.rst
@@ -98,6 +98,11 @@ We're back in a ``HEALTH_OK``, and note the following:
 
 We have 4 monitors, OSDs, and metadata servers. Hooray!
 
+.. note::
+
+    If you have applied the `custom firewall script`_ to your cluster, you will have to run this
+    script again and reboot your nodes for iptables to remove the duplicate rules.
+
 Removing a node
 ---------------
 
@@ -273,6 +278,7 @@ Removing the host from etcd
 The etcd cluster still has an entry for the host we've removed, so we'll need to remove this entry.
 This can be achieved by making a request to the etcd API. See `remove machines`_ for details.
 
+.. _`custom firewall script`: https://github.com/deis/deis/blob/master/contrib/util/custom-firewall.sh
 .. _`remove machines`: https://coreos.com/docs/distributed-configuration/etcd-api/#remove-machines
 .. _`removing monitors`: http://ceph.com/docs/giant/rados/operations/add-or-rm-mons/#removing-monitors
 .. _`removing OSDs`: http://docs.ceph.com/docs/giant/rados/operations/add-or-rm-osds/#removing-osds-manual

--- a/docs/managing_deis/security_considerations.rst
+++ b/docs/managing_deis/security_considerations.rst
@@ -51,4 +51,21 @@ environment by using ```deis tags set environment=production```. Deis will pass 
 along to the scheduler, and your applications in different environments on running on separate
 hardware.
 
+.. _deis_on_public_clouds:
+
+Running Deis on Public Clouds
+-----------------------------
+If you are running on a public cloud without security group features, you will have to set up
+security groups yourself through either ``iptables`` or a similar tool. The only ports that should
+be exposed to the public are:
+
+ - 22: for remote SSH
+ - 80: for the routers
+ - 443: (optional) routers w/ SSL enabled
+ - 2222: for the builder
+
+For providers that do not supply a security group feature, please try
+`contrib/util/custom-firewall.sh`_.
+
 .. _`#986`: https://github.com/deis/deis/issues/986
+.. _`contrib/util/custom-firewall.sh`: https://github.com/deis/deis/blob/master/contrib/util/custom-firewall.sh


### PR DESCRIPTION
refs #2479, as it is a good way to document security concerns in a public setting but requires a larger discussion on the possibility of automating these steps through `deisctl`.
