### PR TITLE
fix(client): _logger doesn't exist for settings

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -205,8 +205,8 @@ class Settings(dict):
             with open(self._path, 'w') as f:
                 f.write(data)
         except IOError:
-            self._logger.error("Could not write to settings file at '~/.deis/client.json'. \
-Do you have the right file permissions?")
+            logging.getLogger(__name__).error("Could not write to settings file at \
+'~/.deis/client.json' Do you have the right file permissions?")
             sys.exit(1)
         return data
 


### PR DESCRIPTION
Sorry about this :frowning:. I had this fix but somehow it didn't end up in my final commit of #2386.
