### PR TITLE
feat(database): disable copy on write to improve performance

### DIFF
--- a/database/bin/boot
+++ b/database/bin/boot
@@ -72,6 +72,9 @@ if [[ ! -f /var/lib/postgresql/9.3/main/initialized ]]; then
   if [[ `envdir /etc/wal-e.d/env wal-e --terse backup-list | wc -l` -gt "1" ]]; then
     echo "database: restoring from backup..."
     rm -rf /var/lib/postgresql/9.3/main
+    mkdir -p /var/lib/postgresql/9.3/main
+    # disable copy-on-write
+    chattr -R +C /var/lib/postgresql/9.3/main
     sudo -u postgres envdir /etc/wal-e.d/env wal-e backup-fetch /var/lib/postgresql/9.3/main LATEST
     chown -R postgres:postgres /var/lib/postgresql/9.3/main
     chmod 0700 /var/lib/postgresql/9.3/main


### PR DESCRIPTION
https://coreos.com/docs/cluster-management/debugging/btrfs-troubleshooting/#disable-copy-on-write

Is not possible to use NOCOW on existing files that's why this only can be done after the first boot in an empty directory.
