### PR TITLE
Client: add pull shortcut to global help

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -33,6 +33,7 @@ Developer shortcut commands::
   logs          view aggregated log info for the app
   run           run a command in an ephemeral app container
   destroy       destroy an application
+  pull          imports an image and deploys as a new release
 
 Use ``git push deis master`` to deploy to an application.
 


### PR DESCRIPTION
`deis pull` is awesome, but it's kind of hidden on the client. This adds the `pull` shortcut to the global help, alongside other developer shortcuts.
