### PR TITLE
feat(router): support customized server_names_hash_bucket_size setting

### DIFF
--- a/docs/customizing_deis/router_settings.rst
+++ b/docs/customizing_deis/router_settings.rst
@@ -55,6 +55,8 @@ setting                                      description
 /deis/router/gzipVary                        nginx gzipVary setting (default: on)
 /deis/router/gzipDisable                     nginx gzipDisable setting (default: "msie6")
 /deis/router/gzipTypes                       nginx gzipTypes setting (default: "application/x-javascript application/xhtml+xml application/xml application/xml+rss application/json text/css text/javascript text/plain text/xml")
+/deis/router/serverNameHashMaxSize           nginx server_names_hash_max_size setting (default: 512)
+/deis/router/serverNameHashBucketSize        nginx server_names_hash_bucket_size (default: 64)
 /deis/router/sslCert                         cluster-wide SSL certificate
 /deis/router/sslKey                          cluster-wide SSL private key
 /deis/services/*                             healthy application containers reported by deis/publisher

--- a/router/templates/nginx.conf
+++ b/router/templates/nginx.conf
@@ -16,8 +16,10 @@ http {
     tcp_nopush on;
     tcp_nodelay on;
     keepalive_timeout 65;
+
     types_hash_max_size 2048;
-    server_names_hash_bucket_size 64;
+    server_names_hash_max_size {{ or (.deis_router_serverNameHashMaxSize) "512" }};
+    server_names_hash_bucket_size {{ or (.deis_router_serverNameHashBucketSize) "64" }};
 
     include /opt/nginx/conf/mime.types;
     default_type application/octet-stream;


### PR DESCRIPTION
Long domain names have trouble with the default settings for
server_names_hash_bucket_size and server_names_hash_max_size. This
commit makes these settings configurable based on etcd keys.

See http://nginx.org/en/docs/http/server_names.html for details
on these settings.
