### PR TITLE
fix(contrib/util): use /usr/bin/env shebang for bash scripts

### DIFF
--- a/contrib/util/_controller-reset-db.sh
+++ b/contrib/util/_controller-reset-db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 # This code is kept in a separate file from `reste-db.sh` for no other reason than to not have to deal
 # with the nightmare of double escaping all these commands through `vagrant ssh -c "\\\\\\\\\AGH!"`

--- a/contrib/util/add_server_dev_deps.sh
+++ b/contrib/util/add_server_dev_deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd /vagrant/contrib/vagrant/util/
 
 # Use the `coverage' command to signal whether the container has the dev dependencies

--- a/contrib/util/check-user-data.sh
+++ b/contrib/util/check-user-data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 THIS_DIR=$(cd $(dirname $0); pwd) # absolute path
 CONTRIB_DIR=$(dirname $THIS_DIR)

--- a/contrib/util/generate-changelog.sh
+++ b/contrib/util/generate-changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # vim: et tw=0 sw=4 ts=4
 
 usage() {


### PR DESCRIPTION
Changes utility scripts to use a more portable shebang line for `bash`. Thanks @manveru.

Replaces #2538.
