### PR TITLE
fix(store): don't output secretKey and accessKey

### DIFF
--- a/store/gateway/bin/boot
+++ b/store/gateway/bin/boot
@@ -83,7 +83,7 @@ else
 fi
 
 if ! radosgw-admin user info --uid=deis >/dev/null 2>&1 ; then
-  radosgw-admin user create --uid=deis --display-name="Deis"
+  radosgw-admin user create --uid=deis --display-name="Deis" >/dev/null
 fi
 
 radosgw-admin user info --uid=deis >/etc/ceph/user.json


### PR DESCRIPTION
In 33fb20e7f94afe164f2ceeb34fc5f2379934f3f7, the removal of the
output redirect for `radosgw-admin user create` means that the
accessKey and secretKey are output in the journal when the user
is created. As these are secrets, they shouldn't ever be printed.

This commit redirects the output of this command to /dev/null.
