### PR TITLE
docs(managing_deis): add warning to CoreOS upgrade

### DIFF
--- a/docs/managing_deis/upgrading-deis.rst
+++ b/docs/managing_deis/upgrading-deis.rst
@@ -149,9 +149,22 @@ Once all applications have been validated, the old cluster can be retired.
 Upgrading CoreOS
 ----------------
 
-Sometimes you may need to update CoreOS manually in order to get Deis to work. For example, Deis
-requires a minimum of CoreOS v472.0.0. To update CoreOS, run the following
-commands:
+By default, Deis disables CoreOS automatic updates. This is partially because of problems we've seen
+with etcd/fleet version incompatibilities as hosts in the cluster are upgraded one-by-one.
+Additionally, because Deis customizes the CoreOS cloud-config file, upgrading the CoreOS host to
+a new version without accounting for changes in the cloud-config file could cause Deis to stop
+functioning properly.
+
+While not recommended, it is possible to trigger an update of a CoreOS machine.
+
+.. important::
+
+  Enabling updates for CoreOS will result in the machine upgrading to the latest CoreOS release
+  available in a particular channel. Sometimes, new CoreOS releases make changes that will break
+  Deis. It is always recommended to provision a Deis release with the CoreOS version specified
+  in that release's provision scripts or documentation.
+
+To update CoreOS, run the following commands:
 
 .. code-block:: console
 


### PR DESCRIPTION
@danielfarrell mentioned in IRC today that he followed our instructions to upgrade CoreOS, and ran into the insecure registry issue we're addressing in #2579. He pointed out that we have no warnings of any kind around the upgrading CoreOS documentation, which is potentially destructive (such as this case, where we haven't yet caught up to CoreOS's changes). This PR fleshes out the issue of upgrading CoreOS and adds an appropriate warning.

closes #2581
