### PR TITLE
chore(release): update release version in master to v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+### v1.0.1 -> v1.0.2
+
+#### Fixes
+
+- [`02dacee`](https://github.com/deis/deis/commit/02dacee1e49c88e1497e5b7c62672743414a7dc7) builder: explicitly call out $TMP_DIR on `docker cp`
+- [`3502595`](https://github.com/deis/deis/commit/3502595c3310e982f81f0914fe04b6ee0d96e0d1) contrib/coreos: fix usage of --insecure-registry
+- [`c3cede8`](https://github.com/deis/deis/commit/c3cede829ea4256c22130d08d7b3a22cfc402676) contrib: add other RFC1918 private addresses
+- [`eb70b77`](https://github.com/deis/deis/commit/eb70b772825f597bff73455ed6cb88e5a1fd580f) contrib: add --insecure-registry flag for docker 1.3.2
+
+#### Documentation
+
+- [`3f1b7f4`](https://github.com/deis/deis/commit/3f1b7f475f4bbfe50c625b744c32715d39fbf8d0) managing_deis: add warning to CoreOS upgrade
+- [`67c1dfb`](https://github.com/deis/deis/commit/67c1dfb29fcb4cb1725a196f0a3a91b6a84ee599) contributing: clean up insecure-registry language
+- [`10af173`](https://github.com/deis/deis/commit/10af1737f1acc3702d04141e10093f0ba5654583) installing_deis: add private network address requirement
+
+#### Maintenance
+
+- [`7940582`](https://github.com/deis/deis/commit/79405825588b03b1705de9a071242f3b60d57060) release: update version to v1.0.2
+- [`df93f71`](https://github.com/deis/deis/commit/df93f7150501dcee1ca82057de010d039fe7207a) builder: bump Docker to 1.3.2
+- [`bdc1d72`](https://github.com/deis/deis/commit/bdc1d722016bd42a0a1fae932b175296348987fa) (all): bump CoreOS to 509.1.0 for Docker vulnerability
+
 ### v1.0.0 -> v1.0.1
 
 #### Features
@@ -21,6 +42,7 @@
 
 #### Maintenance
 
+ - [`37711ed`](https://github.com/deis/deis/commit/37711edf676bab7776de5eee40476709c643dedb) release: update version to v1.0.1
  - [`8932a0b`](https://github.com/deis/deis/commit/8932a0bd6e16177e82808625b579fb9bdfb95b7b) release: update version in master to v1.0.0+git
 
 ### v0.15.1 -> v1.0.0

--- a/client/setup.py
+++ b/client/setup.py
@@ -28,7 +28,7 @@ else:
 
 
 setup(name='deis',
-      version='1.0.1',
+      version='1.0.2',
       license=APACHE_LICENSE,
       description='Command-line Client for Deis, the open PaaS',
       author='OpDemand',

--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -40,11 +40,11 @@ coreos:
 
       [Service]
       Type=oneshot
-      ExecStart=/usr/bin/sh -c 'curl -sSL --retry 5 --retry-delay 2 http://deis.io/deisctl/install.sh | sh -s 1.0.1'
+      ExecStart=/usr/bin/sh -c 'curl -sSL --retry 5 --retry-delay 2 http://deis.io/deisctl/install.sh | sh -s 1.0.2'
 write_files:
   - path: /etc/deis-release
     content: |
-      DEIS_RELEASE=v1.0.1
+      DEIS_RELEASE=v1.0.2
   - path: /etc/motd
     content: " \e[31m* *    \e[34m*   \e[32m*****    \e[39mddddd   eeeeeee iiiiiii   ssss\n\e[31m*   *  \e[34m* *  \e[32m*   *     \e[39md   d   e    e    i     s    s\n \e[31m* *  \e[34m***** \e[32m*****     \e[39md    d  e         i    s\n\e[32m*****  \e[31m* *    \e[34m*       \e[39md     d e         i     s\n\e[32m*   * \e[31m*   *  \e[34m* *      \e[39md     d eee       i      sss\n\e[32m*****  \e[31m* *  \e[34m*****     \e[39md     d e         i         s\n  \e[34m*   \e[32m*****  \e[31m* *      \e[39md    d  e         i          s\n \e[34m* *  \e[32m*   * \e[31m*   *     \e[39md   d   e    e    i    s    s\n\e[34m***** \e[32m*****  \e[31m* *     \e[39mddddd   eeeeeee iiiiiii  ssss\n\n\e[39mWelcome to Deis\t\t\tPowered by Core\e[38;5;45mO\e[38;5;206mS\e[39m\n"
   - path: /etc/profile.d/nse-function.sh

--- a/docs/installing_deis/install-deisctl.rst
+++ b/docs/installing_deis/install-deisctl.rst
@@ -18,9 +18,9 @@ and run the latest installer:
 .. code-block:: console
 
     $ cd ~/bin
-    $ curl -sSL http://deis.io/deisctl/install.sh | sh -s 1.0.1
+    $ curl -sSL http://deis.io/deisctl/install.sh | sh -s 1.0.2
 
-This installs ``deisctl`` version 1.0.1 to the current directory, and downloads the matching
+This installs ``deisctl`` version 1.0.2 to the current directory, and downloads the matching
 Deis systemd unit files used to schedule the components. Link ``deisctl`` into /usr/local/bin, so
 it will be in your ``$PATH``:
 
@@ -31,10 +31,10 @@ it will be in your ``$PATH``:
 To change installation options, save the installer directly:
 
 .. image:: download-linux-brightgreen.svg
-   :target: https://s3-us-west-2.amazonaws.com/opdemand/deisctl-1.0.1-linux-amd64.run
+   :target: https://s3-us-west-2.amazonaws.com/opdemand/deisctl-1.0.2-linux-amd64.run
 
 .. image:: download-osx-brightgreen.svg
-   :target: https://s3-us-west-2.amazonaws.com/opdemand/deisctl-1.0.1-darwin-amd64.run
+   :target: https://s3-us-west-2.amazonaws.com/opdemand/deisctl-1.0.2-darwin-amd64.run
 
 Then run the downloaded file as a shell script. Append ``--help`` to see what options
 are available.

--- a/docs/installing_deis/install-platform.rst
+++ b/docs/installing_deis/install-platform.rst
@@ -14,7 +14,7 @@ First check that you have ``deisctl`` installed and the version is correct.
 .. code-block:: console
 
     $ deisctl --version
-    1.0.1
+    1.0.2
 
 If not, follow instructions to :ref:`install_deisctl`.
 

--- a/docs/managing_deis/upgrading-deis.rst
+++ b/docs/managing_deis/upgrading-deis.rst
@@ -32,7 +32,7 @@ Use the following steps to perform an in-place upgrade of your Deis cluster.
 .. code-block:: console
 
     $ deisctl stop platform && deisctl uninstall platform
-    $ deisctl config platform set version=v1.0.1
+    $ deisctl config platform set version=v1.0.2
     $ deisctl install platform
     $ deisctl start platform
 

--- a/docs/troubleshooting_deis/index.rst
+++ b/docs/troubleshooting_deis/index.rst
@@ -144,7 +144,7 @@ If you built ``deisctl`` locally or didn't use its installer, you may see an err
 
 This is because ``deisctl`` could not find unit files for Deis locally. Run
 ``deisctl help refresh-units`` to see where ``deisctl`` searches, and then run a command such as
-``deisctl refresh-units --tag=v1.0.1``, or set the ``$DEISCTL_UNITS`` environment variable to a directory
+``deisctl refresh-units --tag=v1.0.2``, or set the ``$DEISCTL_UNITS`` environment variable to a directory
 containing the unit files.
 
 Other issues


### PR DESCRIPTION
See also #2586. This does _not_ update the version resources that #2586 changes to `1.1.0-dev`, so these two PRs should be merged close to each other.
