### PR TITLE
fix(router/Makefile): use pwd since "docker cp" no longer allows "."

### DIFF
--- a/router/Makefile
+++ b/router/Makefile
@@ -7,7 +7,7 @@ BUILD_IMAGE = $(COMPONENT)-build
 
 build: check-docker
 	docker build -t $(BUILD_IMAGE) parent
-	docker cp `docker run -d $(BUILD_IMAGE)`:/nginx.tgz .
+	docker cp `docker run -d $(BUILD_IMAGE)`:/nginx.tgz `pwd`
 	docker cp `docker run -d $(BUILD_IMAGE)`:/go/bin/boot bin/
 	docker build -t $(IMAGE) .
 	rm nginx.tgz


### PR DESCRIPTION
This fixes the problem when doing "make build" using [Docker 1.3.2](https://docs.docker.com/release-notes/#version-132). Docker began erroring on "docker cp source ." as of this commit: https://github.com/docker/docker/commit/31d1d733037b22591e2dd2edfe6c4d2d4b8086cc. Luckily the workaround is not difficult and is backward-compatible.

See also b5ba7c498ff7dc18b01cdb4746caa080672c10f4 for a similar change we had to make in **deis-builder**.

fixes #2594
