### PR TITLE
feat(contrib/coreos): enable time synchronization on startup

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -41,26 +41,21 @@ coreos:
       [Service]
       Type=oneshot
       ExecStart=/usr/bin/sh -c 'curl -sSL --retry 5 --retry-delay 2 http://deis.io/deisctl/install.sh | sh -s 1.0.2'
-  - name: ntpd.service
-    command: start
   - name: ntpdate.service
     command: start
-  - name: enable-ntp-synchronization.service
+  - name: timedate-ntp-synchronization.service
     command: start
     content: |
       [Unit]
       Description=Synchronize system clock
-      Before=ntpd.service
+      After=ntpdate.service
 
       [Service]
       ExecStart=/usr/bin/timedatectl set-timezone UTC
       ExecStart=/usr/bin/timedatectl set-ntp true
-      ExecStart=/sbin/hwclock --systohc
+      ExecStart=/sbin/hwclock --systohc --utc
       RemainAfterExit=yes
       Type=oneshot
-
-      [Install]
-      WantedBy=multi-user.target
 write_files:
   - path: /etc/deis-release
     content: |


### PR DESCRIPTION
Before:

```
core@deis-1 ~ $ systemctl status ntpd
● ntpd.service - Network Time Service
   Loaded: loaded (/usr/lib64/systemd/system/ntpd.service; disabled)
   Active: active (running) since Wed 2014-11-26 17:58:17 UTC; 5min ago
 Main PID: 456 (ntpd)
   CGroup: /system.slice/ntpd.service
           └─456 /usr/sbin/ntpd -g -n -u ntp:ntp -f /var/lib/ntp/ntp.drift

Nov 26 17:58:17 localhost ntpd[471]: signal_no_reset: signal 17 had flags 4000000
Nov 26 17:58:19 localhost ntpd_intres[471]: DNS 0.pool.ntp.org -> 50.7.72.4
Nov 26 17:58:19 localhost ntpd_intres[471]: DNS 1.pool.ntp.org -> 129.250.35.250
Nov 26 17:58:20 localhost ntpd_intres[471]: DNS 2.pool.ntp.org -> 72.20.40.62
Nov 26 17:58:20 localhost ntpd[456]: Listen normally on 4 eth0 10.0.2.15 UDP 123
Nov 26 17:58:20 localhost ntpd[456]: Listen normally on 5 eth1 fe80::a00:27ff:fe67:71cd UDP 123
Nov 26 17:58:20 localhost ntpd[456]: Listen normally on 6 eth0 fe80::a00:27ff:fe5f:bc80 UDP 123
Nov 26 17:58:20 localhost ntpd[456]: peers refreshed
Nov 26 17:58:25 deis-1 ntpd[456]: Listen normally on 7 eth1 172.17.8.100 UDP 123
Nov 26 17:58:25 deis-1 ntpd[456]: peers refreshed
core@deis-1 ~ $ timedatectl
      Local time: Wed 2014-11-26 18:04:43 UTC
  Universal time: Wed 2014-11-26 18:04:43 UTC
        RTC time: Wed 2014-11-26 18:04:42
       Time zone: UTC (UTC, +0000)
     NTP enabled: no
NTP synchronized: no
 RTC in local TZ: no
      DST active: n/a
```

After:

```
core@deis-1 ~ $ systemctl status ntpd
● ntpd.service - Network Time Service
   Loaded: loaded (/usr/lib64/systemd/system/ntpd.service; enabled)
   Active: active (running) since Wed 2014-11-26 18:22:16 UTC; 1min 12s ago
 Main PID: 457 (ntpd)
   CGroup: /system.slice/ntpd.service
           └─457 /usr/sbin/ntpd -g -n -u ntp:ntp -f /var/lib/ntp/ntp.drift

Nov 26 18:22:18 localhost ntpd_intres[481]: DNS 0.pool.ntp.org -> 129.250.35.251
Nov 26 18:22:18 localhost ntpd_intres[481]: DNS 1.pool.ntp.org -> 108.61.194.85
Nov 26 18:22:19 localhost ntpd_intres[481]: DNS 2.pool.ntp.org -> 208.75.88.4
Nov 26 18:22:19 localhost ntpd[457]: Listen normally on 4 eth0 10.0.2.15 UDP 123
Nov 26 18:22:19 localhost ntpd[457]: Listen normally on 5 eth1 fe80::a00:27ff:fe38:48a3 UDP 123
Nov 26 18:22:19 localhost ntpd[457]: Listen normally on 6 eth0 fe80::a00:27ff:fe5f:bc80 UDP 123
Nov 26 18:22:19 localhost ntpd[457]: peers refreshed
Nov 26 18:22:23 deis-1 systemd[1]: Started Network Time Service.
Nov 26 18:22:23 deis-1 ntpd[457]: Listen normally on 7 eth1 172.17.8.100 UDP 123
Nov 26 18:22:23 deis-1 ntpd[457]: peers refreshed
core@deis-1 ~ $ timedatectl
      Local time: Wed 2014-11-26 18:23:38 UTC
  Universal time: Wed 2014-11-26 18:23:38 UTC
        RTC time: Wed 2014-11-26 18:23:37
       Time zone: UTC (UTC, +0000)
     NTP enabled: yes
NTP synchronized: yes
 RTC in local TZ: no
      DST active: n/a
```

replaces #2563
