### PR TITLE
feat(vagrant): check if discovery url is defined

### DIFF
--- a/docs/installing_deis/vagrant.rst
+++ b/docs/installing_deis/vagrant.rst
@@ -18,6 +18,12 @@ Install Prerequisites
 
 Please install `Vagrant`_ v1.6.5+ and `VirtualBox`_.
 
+The ``Vagrantfile`` requires the plugin `vagrant-triggers`_. To install the plugin run:
+
+.. code-block:: console
+
+    $ vagrant plugin install vagrant-triggers
+
 .. note::
 
     For Ubuntu users: the VirtualBox package in Ubuntu has some issues when running in
@@ -78,3 +84,4 @@ start installing the platform.
 
 .. _Vagrant: http://www.vagrantup.com/
 .. _VirtualBox: https://www.virtualbox.org/wiki/Downloads
+.. _vagrant-triggers: https://github.com/emyl/vagrant-triggers


### PR DESCRIPTION
Check that `user-data` exists and that `make discovery-url` was executed before `vagrant up` (discovery is not commented)

It's required the [vagrant-triggers plugin](https://github.com/emyl/vagrant-triggers
 `vagrant plugin install vagrant-triggers`

``` console
$ vagrant up
Bringing machine 'deis-1' up with 'virtualbox' provider...
Bringing machine 'deis-2' up with 'virtualbox' provider...
Bringing machine 'deis-3' up with 'virtualbox' provider...
==> deis-1: Running triggers before up...
Please run "make discovery-url" before "vagrant up"
```

closes #2342
