### PR TITLE
fix(deisctl): prevent build on windows

### DIFF
--- a/deisctl/deisctl.go
+++ b/deisctl/deisctl.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package main
 
 import (


### PR DESCRIPTION
On windows the deisctl client will build, but it runs into a lot of problems at runtime due to limitations in fleetctl. It depends on the ssh-agent domain socket which cannot exist in windows as windows does not support the idea of domain sockets.

This will prevent issues at runtime at the expense of being able to build and run deisctl in windows.
