### PR TITLE
docs(manage-application): fixed bad example command

### DIFF
--- a/docs/using_deis/manage-application.rst
+++ b/docs/using_deis/manage-application.rst
@@ -45,7 +45,9 @@ Use ``deis run`` to execute commands on the deployed application.
 
 .. code-block:: console
 
-    $ deis run ls -l
+    $ deis run 'ls -l'
+    Running `ls -l`...
+    
     total 28
     -rw-r--r-- 1 root root  553 Dec  2 23:59 LICENSE
     -rw-r--r-- 1 root root   60 Dec  2 23:59 Procfile


### PR DESCRIPTION
the example for running ls -l was bad, it needs quotes or else deis thinks the flag was for it.
