### PR TITLE
feat(*): provision using CoreOS beta channel

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ CONFIG = File.join(File.dirname(__FILE__), "config.rb")
 
 # Defaults for config options defined in CONFIG
 $num_instances = 1
-$update_channel = "alpha"
+$update_channel = "beta"
 $enable_serial_logging = false
 $vb_gui = false
 $vb_memory = 1024
@@ -35,28 +35,23 @@ else
   $vb_cpus = 1
 end
 
-COREOS_VERSION = "509.1.0"
-
 if File.exist?(CONFIG)
   require CONFIG
 end
 
 Vagrant.configure("2") do |config|
-  # config.vm.box = "coreos-%s" % $update_channel
-  # config.vm.box_version = ">= 308.0.1"
-  # config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
-  config.vm.box = "coreos-#{COREOS_VERSION}"
-  config.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/#{COREOS_VERSION}/coreos_production_vagrant.box"
-
-  config.vm.provider :vmware_fusion do |vb, override|
-    # override.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json" % $update_channel
-    override.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/#{COREOS_VERSION}/coreos_production_vagrant_vmware_fusion.box"
-  end
+  config.vm.box = "coreos-%s" % $update_channel
+  config.vm.box_version = ">= 494.1.0"
+  config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
 
   config.vm.provider :virtualbox do |vb, override|
     # Use paravirtualized network adapters
     vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
     vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
+  end
+
+  config.vm.provider :vmware_fusion do |vb, override|
+    override.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json" % $update_channel
   end
 
   config.vm.provider :virtualbox do |v|

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -84,15 +84,15 @@
 
   "Mappings" : {
     "CoreOSAMIs" : {
-      "eu-central-1"   : { "PV" : "ami-9623128b", "HVM" : "ami-94231289" },
-      "ap-northeast-1" : { "PV" : "ami-d6999dd7", "HVM" : "ami-d8999dd9" },
-      "sa-east-1"      : { "PV" : "ami-79a41564", "HVM" : "ami-7fa41562" },
-      "ap-southeast-2" : { "PV" : "ami-e1dfb1db", "HVM" : "ami-e3dfb1d9" },
-      "ap-southeast-1" : { "PV" : "ami-7598ba27", "HVM" : "ami-7b98ba29" },
-      "us-east-1"      : { "PV" : "ami-00158768", "HVM" : "ami-0215876a" },
-      "us-west-2"      : { "PV" : "ami-d92377e9", "HVM" : "ami-d72377e7" },
-      "us-west-1"      : { "PV" : "ami-a7adbce2", "HVM" : "ami-a5adbce0" },
-      "eu-west-1"      : { "PV" : "ami-c6e858b1", "HVM" : "ami-d8e858af" }
+      "eu-central-1"   : { "PV" : "ami-5e221343", "HVM" : "ami-58221345" },
+      "ap-northeast-1" : { "PV" : "ami-96a0a497", "HVM" : "ami-94a0a495" },
+      "sa-east-1"      : { "PV" : "ami-31a9182c", "HVM" : "ami-37a9182a" },
+      "ap-southeast-2" : { "PV" : "ami-89dab4b3", "HVM" : "ami-8fdab4b5" },
+      "ap-southeast-1" : { "PV" : "ami-879ebcd5", "HVM" : "ami-859ebcd7" },
+      "us-east-1"      : { "PV" : "ami-4a0a9822", "HVM" : "ami-4c0a9824" },
+      "us-west-2"      : { "PV" : "ami-ff2a7ecf", "HVM" : "ami-fd2a7ecd" },
+      "us-west-1"      : { "PV" : "ami-a7aebfe2", "HVM" : "ami-a1aebfe4" },
+      "eu-west-1"      : { "PV" : "ami-acd363db", "HVM" : "ami-aad363dd" }
 
     },
     "RootDevices" : {

--- a/contrib/rackspace/provision-rackspace-cluster.sh
+++ b/contrib/rackspace/provision-rackspace-cluster.sh
@@ -48,8 +48,8 @@ $CONTRIB_DIR/util/check-user-data.sh
 
 i=1 ; while [[ $i -le $DEIS_NUM_INSTANCES ]] ; do \
     echo_yellow "Provisioning deis-$i..."
-    # TODO: update to CoreOS 509.1.0 when it is available at Rackspace
-    # This image is CoreOS 494.0.0
+    # TODO: update to CoreOS 494.1.0 when it is available in beta channel at Rackspace
+    # This image is CoreOS 494.0.0 in their alpha channel
     supernova $ENV boot --image 1c423602-ea76-4263-b56b-0a2fa3e8c663 --flavor $FLAVOR --key-name $1 --user-data ../coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
     ((i = i + 1)) ; \
 done

--- a/docs/installing_deis/baremetal.rst
+++ b/docs/installing_deis/baremetal.rst
@@ -16,7 +16,7 @@ machine running entirely from RAM. Then, you can `install CoreOS to disk`_.
 
 .. important::
 
-    Deis requires CoreOS version 472.0.0 or more recent.
+    Deis requires CoreOS version 494.1.0 or more recent.
 
 
 Check System Requirements
@@ -95,12 +95,12 @@ Start the installation
 
 .. code-block:: console
 
-    coreos-install -C alpha -c /tmp/config -d /dev/sda
+    coreos-install -C beta -c /tmp/config -d /dev/sda
 
 
-This will install the latest `CoreOS`_ alpha release to disk. The Deis provision scripts for other
-platforms typically specify a CoreOS version - currently, ``509.1.0``. To specify a specific CoreOS
-version, append the ``-V`` parameter to the install command, e.g. ``-V 509.1.0``.
+This will install the latest `CoreOS`_ beta release to disk. The Deis provision scripts for other
+platforms typically specify a CoreOS version - currently, ``494.1.0``. To specify a CoreOS
+version, append the ``-V`` parameter to the install command, e.g. ``-V 494.1.0``.
 
 After the installation has finished, reboot your server. Once your machine is back up, you should
 be able to log in as the `core` user using the `deis` ssh key.

--- a/docs/installing_deis/gce.rst
+++ b/docs/installing_deis/gce.rst
@@ -119,7 +119,7 @@ Launch 3 instances. You can choose another starting CoreOS image from the listin
 
 .. code-block:: console
 
-    $ for num in 1 2 3; do gcutil addinstance --image projects/coreos-cloud/global/images/coreos-alpha-509-1-0-v20141124 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
+    $ for num in 1 2 3; do gcutil addinstance --image projects/coreos-cloud/global/images/coreos-beta-494-1-0-v20141124 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
 
     Table of resources:
 


### PR DESCRIPTION
With CoreOS 494.1.0 including Docker 1.3.2 and landing in their beta channel, Deis may be able to formally begin tracking beta now. This change just reworks the Vagrantfile to track beta and be more similar to the upstream coreos-vagrant version, updates provider IDs to use CoreOS beta 494.1.0, and specifies that as our minimum requirement.
