### PR TITLE
docs(LICENSE): update copyright notices for 2014

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2013 OpDemand LLC
+Copyright 2013, 2014 OpDemand LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ assistance with common issues.
 
 ## License
 
-Copyright 2014, OpDemand LLC
+Copyright 2013, 2014 OpDemand LLC
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at <http://www.apache.org/licenses/LICENSE-2.0>
 

--- a/cache/LICENSE
+++ b/cache/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014 OpDemand LLC
+Copyright 2013, 2014 OpDemand LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/LICENSE
+++ b/client/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2013 OpDemand LLC
+Copyright 2013, 2014 OpDemand LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/database/LICENSE
+++ b/database/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014 OpDemand LLC
+Copyright 2013, 2014 OpDemand LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/deisctl/LICENSE
+++ b/deisctl/LICENSE
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an AS IS BASIS,
+distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ master_doc = 'toctree'
 
 # General information about the project.
 project = u'deis'
-copyright = u'2013, OpDemand LLC'
+copyright = u'2013, 2014 OpDemand LLC'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/registry/LICENSE
+++ b/registry/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014 OpDemand LLC
+Copyright 2013, 2014 OpDemand LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updates Deis LICENSE files to be consistent about copyright assertion years, ping @JoshuaSchnell.

`deisctl` and `store` LICENSE files' dates were not updated, since neither module existed in 2013, they were left asserting 2014.

Closes #2338.
