### PR TITLE
feat(contrib/ec2): add optional support for IAM instance profiles

### DIFF
--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -17,6 +17,11 @@
       "Description": "Number of nodes in cluster (3-12).",
       "Type": "Number"
     },
+    "IamInstanceProfile" : {
+      "Description" : "(Optional) Set IAM instance profile for Deis hosts (default: none)",
+      "Type" : "String",
+      "Default": ""
+    },
     "SSHFrom" : {
       "Description" : "Lockdown SSH access to the Deis hosts (default: can be accessed from anywhere)",
       "Type" : "String",
@@ -103,6 +108,17 @@
       "VPC"     : { "CIDR" : "10.21.0.0/16" },
       "Subnet1" : { "CIDR" : "10.21.1.0/24" },
       "Subnet2" : { "CIDR" : "10.21.2.0/24" }
+    }
+  },
+
+  "Conditions" : {
+    "UseIamInstanceProfile" : {
+      "Fn::Not" : [{
+        "Fn::Equals" : [
+          { "Ref" : "IamInstanceProfile" },
+           ""
+        ]
+      }]
     }
   },
 
@@ -221,6 +237,13 @@
       "Properties": {
         "ImageId" : { "Fn::FindInMap" : [ "CoreOSAMIs", { "Ref" : "AWS::Region" }, { "Ref" : "EC2VirtualizationType" }]},
         "InstanceType": {"Ref": "InstanceType"},
+        "IamInstanceProfile" : {
+          "Fn::If" : [
+            "UseIamInstanceProfile",
+            { "Ref" : "IamInstanceProfile" },
+            { "Ref" : "AWS::NoValue" }
+          ]
+        },
         "KeyName": {"Ref": "KeyPair"},
         "UserData" : { "Fn::Base64": { "Fn::Join": [ "", [ ] ] } },
         "AssociatePublicIpAddress": {"Ref": "AssociatePublicIP"},


### PR DESCRIPTION
This supersedes #2539 by fixing/extending a5119b1 to allow the IAM instance profiles (more frequently referred to as [IAM roles for Amazon EC2](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)) to be optional - it is implemented by means of [conditional CloudFormation resources](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-conditions.html), see https://github.com/deis/deis/pull/2539#issuecomment-64896466 for more details.

I've tested the resulting template with and without specifying an IAM instance profile and the Deis cluster has been created successfully for both variations.
