### PR TITLE
fix(client): log python requests errors

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -2034,8 +2034,8 @@ def _dispatch_cmd(method, args):
     try:
         method(args)
     except requests.exceptions.ConnectionError as err:
-        logger.error("Couldn't connect to the Deis Controller. Make sure that the Controller URI is \
-correct and the server is running.")
+        logger.error("Couldn't connect to the Deis Controller:\n{}\nMake sure that the Controller URI is \
+correct and the server is running.".format(err))
         sys.exit(1)
     except EnvironmentError as err:
         logger.error(err.args[0])


### PR DESCRIPTION
In debugging #2616 I noticed that the CLI swallows python requests lib errors, and in at least one case this masked a simple "bad password" error and made it look like a more fundamental connectivity issue.

This change just logs the error received in `dispatch_cmd`.
