### PR TITLE
feat(contrib): add PREFIX option to digitalocean script

### DIFF
--- a/contrib/digitalocean/provision-do-cluster.sh
+++ b/contrib/digitalocean/provision-do-cluster.sh
@@ -18,11 +18,16 @@ CONTRIB_DIR=$(dirname $THIS_DIR)
 REGION_SLUG=$1
 SSH_ID=$2
 SIZE=$3
+PREFIX=$4
+
+if [ -z "$PREFIX" ]; then
+  PREFIX="deis"
+fi
 
 source $CONTRIB_DIR/utils.sh
 
 if [ -z "$3" ]; then
-  echo_red 'Usage: provision-do-cluster.sh <REGION_SLUG> <SSH_ID> <SIZE>'
+  echo_red 'Usage: provision-do-cluster.sh <REGION_SLUG> <SSH_ID> <SIZE> [PREFIX]'
   exit 1
 fi
 
@@ -58,7 +63,7 @@ fi
 
 # launch the Deis cluster on DigitalOcean
 i=1 ; while [[ $i -le $DEIS_NUM_INSTANCES ]] ; do \
-    NAME=deis-$i
+    NAME="$PREFIX-$i"
     echo_yellow "Provisioning ${NAME}..."
     docl create $NAME $BASE_IMAGE_ID $SIZE $REGION_SLUG --key=$SSH_ID --private-networking --user-data=$CONTRIB_DIR/coreos/user-data --wait
     ((i = i + 1)) ; \


### PR DESCRIPTION
When provisioning new nodes, they are prefixed with a name of "deis-$i",
where $i is the node ID. Adding a prefix option allows us to prefix
the name with something other than "deis" such that we can discern
between different clusters on the same DO account.
