### PR TITLE
ref(tests): switch to example-dockerfile-http app

### DIFF
--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -96,7 +96,7 @@ test-integration.sh
     >>> Preparing test environment <<<
 
     DEIS_ROOT=/Users/matt/Projects/src/github.com/deis/deis
-    DEIS_TEST_APP=example-go
+    DEIS_TEST_APP=example-dockerfile-http
     ...
     >>> Running integration suite <<<
 

--- a/tests/bin/test-setup.sh
+++ b/tests/bin/test-setup.sh
@@ -18,7 +18,7 @@ echo "DEIS_ROOT=$DEIS_ROOT"
 export PATH=${GOPATH}/bin:$PATH
 
 # the application under test
-export DEIS_TEST_APP=${DEIS_TEST_APP:-example-go}
+export DEIS_TEST_APP=${DEIS_TEST_APP:-example-dockerfile-http}
 echo "DEIS_TEST_APP=$DEIS_TEST_APP"
 
 # SSH key name used for testing

--- a/tests/utils/itutils.go
+++ b/tests/utils/itutils.go
@@ -312,6 +312,7 @@ func GetRandomApp() string {
 		"example-python-flask",
 		"example-ruby-sinatra",
 		"example-scala",
+		"example-dockerfile-http",
 	}
 	return apps[rand.Intn(len(apps))]
 }


### PR DESCRIPTION
This application's final image size is significantly smaller than
example-go's, which should dramatically increase integration test times:

```
REPOSITORY                                    TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
10.132.162.4:5000/example-go                  v2                  363636be7289        3 minutes ago       957.1 MB
10.132.162.4:5000/example-dockerfile-http     v2                  6b7c19477ae5        49 minutes ago      2.433 MB
```

Source at https://github.com/deis/example-dockerfile-http
