### PR TITLE
fix(router): reload nginx after enabling SSL

### DIFF
--- a/router/conf.d/deis.cert.toml
+++ b/router/conf.d/deis.cert.toml
@@ -7,3 +7,4 @@ mode  = "0644"
 keys = [
   "/deis/router",
 ]
+reload_cmd = "/opt/nginx/sbin/nginx -s reload"

--- a/router/conf.d/deis.conf.toml
+++ b/router/conf.d/deis.conf.toml
@@ -7,3 +7,4 @@ mode  = "0644"
 keys = [
   "/deis/router",
 ]
+reload_cmd = "/opt/nginx/sbin/nginx -s reload"

--- a/router/conf.d/deis.key.toml
+++ b/router/conf.d/deis.key.toml
@@ -7,3 +7,4 @@ mode  = "0644"
 keys = [
   "/deis/router",
 ]
+reload_cmd = "/opt/nginx/sbin/nginx -s reload"


### PR DESCRIPTION
#2194 claimed to enable SSL support to the router, but a change to `deis.conf` never triggered an nginx reload to take the new change. Only through other changes to the template did one get lucky and have nginx take this change.

This PR makes changes to `deis.conf` trigger an nginx reload.
