### PR TITLE
feat(*): provision using CoreOS stable channel

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ CONFIG = File.join(File.dirname(__FILE__), "config.rb")
 
 # Defaults for config options defined in CONFIG
 $num_instances = 1
-$update_channel = "beta"
+$update_channel = "stable"
 $enable_serial_logging = false
 $vb_gui = false
 $vb_memory = 1024
@@ -41,7 +41,7 @@ end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "coreos-%s" % $update_channel
-  config.vm.box_version = ">= 494.1.0"
+  config.vm.box_version = ">= 494.4.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
 
   config.vm.provider :virtualbox do |vb, override|

--- a/contrib/digitalocean/provision-do-cluster.sh
+++ b/contrib/digitalocean/provision-do-cluster.sh
@@ -54,7 +54,7 @@ fi
 $CONTRIB_DIR/util/check-user-data.sh
 
 # TODO: Make it follow a specific ID once circumstances allow us to do so.
-BASE_IMAGE_ID='coreos-beta'
+BASE_IMAGE_ID='coreos-stable'
 
 if [ -z "$BASE_IMAGE_ID" ]; then
 	echo_red "DigitalOcean Image not found..."

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -84,15 +84,15 @@
 
   "Mappings" : {
     "CoreOSAMIs" : {
-      "eu-central-1"   : { "PV" : "ami-5e221343", "HVM" : "ami-58221345" },
-      "ap-northeast-1" : { "PV" : "ami-96a0a497", "HVM" : "ami-94a0a495" },
-      "sa-east-1"      : { "PV" : "ami-31a9182c", "HVM" : "ami-37a9182a" },
-      "ap-southeast-2" : { "PV" : "ami-89dab4b3", "HVM" : "ami-8fdab4b5" },
-      "ap-southeast-1" : { "PV" : "ami-879ebcd5", "HVM" : "ami-859ebcd7" },
-      "us-east-1"      : { "PV" : "ami-4a0a9822", "HVM" : "ami-4c0a9824" },
-      "us-west-2"      : { "PV" : "ami-ff2a7ecf", "HVM" : "ami-fd2a7ecd" },
-      "us-west-1"      : { "PV" : "ami-a7aebfe2", "HVM" : "ami-a1aebfe4" },
-      "eu-west-1"      : { "PV" : "ami-acd363db", "HVM" : "ami-aad363dd" }
+      "eu-central-1"   : { "PV" : "ami-12c0f10f", "HVM" : "ami-10c0f10d" },
+      "ap-northeast-1" : { "PV" : "ami-dc6566dd", "HVM" : "ami-da6566db" },
+      "sa-east-1"      : { "PV" : "ami-9bda6a86", "HVM" : "ami-99da6a84" },
+      "ap-southeast-2" : { "PV" : "ami-abc8a191", "HVM" : "ami-a9c8a193" },
+      "ap-southeast-1" : { "PV" : "ami-977559c5", "HVM" : "ami-957559c7" },
+      "us-east-1"      : { "PV" : "ami-f469f29c", "HVM" : "ami-f669f29e" },
+      "us-west-2"      : { "PV" : "ami-dbf8afeb", "HVM" : "ami-d9f8afe9" },
+      "us-west-1"      : { "PV" : "ami-af0516ea", "HVM" : "ami-ad0516e8" },
+      "eu-west-1"      : { "PV" : "ami-f6853881", "HVM" : "ami-f4853883" }
 
     },
     "RootDevices" : {

--- a/contrib/rackspace/provision-rackspace-cluster.sh
+++ b/contrib/rackspace/provision-rackspace-cluster.sh
@@ -48,7 +48,7 @@ $CONTRIB_DIR/util/check-user-data.sh
 
 i=1 ; while [[ $i -le $DEIS_NUM_INSTANCES ]] ; do \
     echo_yellow "Provisioning deis-$i..."
-    # TODO: update to CoreOS 494.1.0 when it is available in beta channel at Rackspace
+    # TODO: update to CoreOS 494.4.0 when it's in the stable channel at Rackspace
     # This image is CoreOS 494.0.0 in their alpha channel
     supernova $ENV boot --image 1c423602-ea76-4263-b56b-0a2fa3e8c663 --flavor $FLAVOR --key-name $1 --user-data $CONTRIB_DIR/coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
     ((i = i + 1)) ; \

--- a/docs/installing_deis/baremetal.rst
+++ b/docs/installing_deis/baremetal.rst
@@ -16,7 +16,7 @@ machine running entirely from RAM. Then, you can `install CoreOS to disk`_.
 
 .. important::
 
-    Deis requires CoreOS version 494.1.0 or more recent.
+    Deis runs on CoreOS version 494.4.0 or later in the Stable channel.
 
 
 Check System Requirements
@@ -95,12 +95,12 @@ Start the installation
 
 .. code-block:: console
 
-    coreos-install -C beta -c /tmp/config -d /dev/sda
+    coreos-install -C stable -c /tmp/config -d /dev/sda
 
 
-This will install the latest `CoreOS`_ beta release to disk. The Deis provision scripts for other
-platforms typically specify a CoreOS version - currently, ``494.1.0``. To specify a CoreOS
-version, append the ``-V`` parameter to the install command, e.g. ``-V 494.1.0``.
+This will install the latest `CoreOS`_ stable release to disk. The Deis provision scripts for other
+platforms typically specify a CoreOS version - currently, ``494.4.0``. To specify a CoreOS
+version, append the ``-V`` parameter to the install command, e.g. ``-V 494.4.0``.
 
 After the installation has finished, reboot your server. Once your machine is back up, you should
 be able to log in as the `core` user using the `deis` ssh key.

--- a/docs/installing_deis/digitalocean.rst
+++ b/docs/installing_deis/digitalocean.rst
@@ -55,7 +55,7 @@ that, create at least three Droplets with the following specifications:
  - All Droplets deployed in the same region
  - Region must have private networking enabled
  - Region must have User Data enabled. Supply the user-data file here
- - Select CoreOS Beta channel
+ - Select CoreOS Stable channel
  - Select your SSH key from the list
 
 If private networking is not available in your region, swap out ``$private_ipv4`` with

--- a/docs/installing_deis/gce.rst
+++ b/docs/installing_deis/gce.rst
@@ -119,7 +119,7 @@ Launch 3 instances. You can choose another starting CoreOS image from the listin
 
 .. code-block:: console
 
-    $ for num in 1 2 3; do gcutil addinstance --image projects/coreos-cloud/global/images/coreos-beta-494-1-0-v20141124 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
+    $ for num in 1 2 3; do gcutil addinstance --image projects/coreos-cloud/global/images/coreos-stable-494-4-0-v20141204 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
 
     Table of resources:
 


### PR DESCRIPTION
[CoreOS 494.4.0](https://coreos.com/releases/#494.4.0) was promoted to stable today, so Deis should be able to settle there. Provider image IDs & AMIs were all updated except Rackspace, which hopefully refreshes later today.

Double-check IDs at https://coreos.com/docs/running-coreos/cloud-providers/ec2/ and https://coreos.com/docs/running-coreos/cloud-providers/google-compute-engine/. Refs #2613 and #2631.

Question: is https://github.com/coreos/coreos-overlay/commit/f6ae1a34d144e3476fb9c31f3c6ff7df9c18c41c going to supercede our `--insecure-registry` settings? Answer: no, but we'll test it of course.
Correct answer: apparently neither one is applied? See https://github.com/coreos/coreos-overlay/commit/f6ae1a34d144e3476fb9c31f3c6ff7df9c18c41c#commitcomment-8833445
