### PR TITLE
docs(deisctl): add examples and sshPrivateKey=path to config usage

### DIFF
--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -579,12 +579,20 @@ A configuration value is stored and retrieved from a key/value store
 values are typically used for component-level configuration, such as
 enabling TLS for the routers.
 
+Note: "deisctl config platform set sshPrivateKey=" expects a path
+to a private key.
+
 Usage:
   deisctl config <target> get [<key>...] [options]
   deisctl config <target> set <key=val>... [options]
 
 Options:
   --verbose		print out the request bodies [default: false]
+
+Examples:
+  deisctl config platform set domain=mydomain.com
+  deisctl config platform set sshPrivateKey=$HOME/.ssh/deis
+  deisctl config controller get webEnabled
 `
 	// parse command-line arguments
 	args, err := docopt.Parse(usage, argv, true, "", false)


### PR DESCRIPTION
This change makes `deisctl help config` explicit that sshPrivateKey is special because it expects a path on `set`, and provides usage examples that will keep me from searching http://docs.deis.io/ all the time.

Closes #2629.
