### PR TITLE
docs(managing_deis): provide login instructions

### DIFF
--- a/docs/troubleshooting_deis/index.rst
+++ b/docs/troubleshooting_deis/index.rst
@@ -8,6 +8,20 @@ Troubleshooting Deis
 
 Common issues that users have run into when provisioning Deis are detailed below.
 
+Logging in to the cluster
+-------------------------
+
+Deis runs on CoreOS, so connecting is as simple as using ``ssh``.
+
+CoreOS's default username is ``core``. Use the SSH key you provisioned the cluster with.
+
+Connect to the public IP address of one of your nodes (or use "convenience" DNS records if you've set them up).
+
+.. code-block:: console
+
+    $ ssh core@deis-1.example.com -i ~/.ssh/deis.pub
+
+
 A deis-store component fails to start
 -------------------------------------
 


### PR DESCRIPTION
Add a section to troubleshooting docs to define explicitly how to connect to a cluster. Replaces #2524 because we already made @rjocoleman jump through enough hoops--thanks again!.

Closes #2523.
