### PR TITLE
fix(2650): config:set runs as the app owner instead of issuing user

### DIFF
--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -289,7 +289,6 @@ class AppConfigViewSet(BaseAppViewSet):
         previous_config = config.app.config_set.latest()
         config.owner = self.request.user
         if previous_config:
-            config.owner = previous_config.owner
             for attr in ['cpu', 'memory', 'tags', 'values']:
                 # Guard against migrations from older apps without fixes to
                 # JSONField encoding.


### PR DESCRIPTION
Trivial fix to have config:set run as the issuing user. See #2650 for details.
