### PR TITLE
Revert "fix(coreos): tune etcd to address high disk i/o environments"

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -8,15 +8,15 @@ coreos:
     addr: $private_ipv4:4001
     peer-addr: $private_ipv4:7001
     # give etcd more time if it's under heavy load - prevent leader election thrashing
-    peer-election-timeout: 5000
+    peer-election-timeout: 2000
     # heartbeat interval should ideally be 1/4 or 1/5 of peer election timeout
-    peer-heartbeat-interval: 1000
+    peer-heartbeat-interval: 500
   fleet:
     # We have to set the public_ip here so this works on Vagrant -- otherwise, Vagrant VMs
     # will all publish the same private IP. This is harmless for cloud providers.
     public-ip: $private_ipv4
     # allow etcd to slow down at times
-    etcd_request_timeout: 5
+    etcd_request_timeout: 3
   units:
   - name: etcd.service
     command: start


### PR DESCRIPTION
In testing, this commit causes more harm than good, and
results in etcd/fleet going haywire.

This reverts commit 4f95cb82c87e75c6492ce0084961d57b0d70ae31.
