### PR TITLE
fix(controller): allow users to override `cmd` process types

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -401,15 +401,13 @@ class Container(UuidAuditedModel):
     _scheduler = property(_get_scheduler)
 
     def _get_command(self):
-        # handle special case for Dockerfile deployments
-        if self.type == 'cmd':
-            return ''
         try:
             # ensure they cannot break out and run commands on the host
             return "bash -c '{}'".format(self.release.build.procfile[self.type])
         # if the key is not present or if a parent attribute is None
-        except (KeyError, TypeError):
-            return 'start {}'.format(self.type)
+        except (KeyError, TypeError, AttributeError):
+            # handle special case for Dockerfile deployments
+            return '' if self.type == 'cmd' else 'start {}'.format(self.type)
 
     _command = property(_get_command)
 

--- a/controller/api/tests/test_container.py
+++ b/controller/api/tests/test_container.py
@@ -462,12 +462,15 @@ class ContainerTest(TransactionTestCase):
                                      type='web',
                                      num=1)
         self.assertEqual(c._command, "bash -c 'node server.js'")
+        c.type = 'cmd'
+        self.assertEqual(c._command, '')
+        # ensure we can override the cmd process type in a Procfile
+        build.procfile['cmd'] = 'node server.js'
+        self.assertEqual(c._command, "bash -c 'node server.js'")
         c.type = 'worker'
         self.assertEqual(c._command, "bash -c 'node worker.js'")
         c.release.build.procfile = None
         self.assertEqual(c._command, 'start worker')
-        c.type = 'cmd'
-        self.assertEqual(c._command, '')
 
     def test_run_command_good(self):
         """Test the run command for each container workflow"""


### PR DESCRIPTION
fixes #2668 
fixes #2665
