### PR TITLE
fix(controller): update App.structure field correctly after scaling

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -18,6 +18,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models import Count
 from django.db.models import Max
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
@@ -201,7 +202,8 @@ class App(UuidAuditedModel):
             if to_remove:
                 self._destroy_containers(to_remove)
         # save new structure to the database
-        self.structure = structure
+        vals = self.container_set.values('type').annotate(Count('pk')).order_by()
+        self.structure = {v['type']: v['pk__count'] for v in vals}
         self.save()
         return changed
 

--- a/controller/api/tests/test_container.py
+++ b/controller/api/tests/test_container.py
@@ -107,7 +107,12 @@ class ContainerTest(TransactionTestCase):
         self.assertEqual(response.status_code, 201)
         # scale up
         url = "/v1/apps/{app_id}/scale".format(**locals())
-        body = {'web': 4, 'worker': 2}
+        # test setting one proc type at a time
+        body = {'web': 4}
+        response = self.client.post(url, json.dumps(body), content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.assertEqual(response.status_code, 204)
+        body = {'worker': 2}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 204)
@@ -118,6 +123,9 @@ class ContainerTest(TransactionTestCase):
         url = "/v1/apps/{app_id}".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
+        # ensure the structure field is up-to-date
+        self.assertEqual(response.data['structure']['web'], 4)
+        self.assertEqual(response.data['structure']['worker'], 2)
         # test listing/retrieving container info
         url = "/v1/apps/{app_id}/containers/web".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -130,6 +138,7 @@ class ContainerTest(TransactionTestCase):
         self.assertEqual(response.data['num'], num)
         # scale down
         url = "/v1/apps/{app_id}/scale".format(**locals())
+        # test setting two proc types at a time
         body = {'web': 2, 'worker': 1}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -142,6 +151,9 @@ class ContainerTest(TransactionTestCase):
         url = "/v1/apps/{app_id}".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
+        # ensure the structure field is up-to-date
+        self.assertEqual(response.data['structure']['web'], 2)
+        self.assertEqual(response.data['structure']['worker'], 1)
         # scale down to 0
         url = "/v1/apps/{app_id}/scale".format(**locals())
         body = {'web': 0, 'worker': 0}


### PR DESCRIPTION
While the scaling logic is correct, we were naively using the requested scaling values to update the App.structure JSON field, rather than counting the actual containers in existence after scaling. This was cosmetic only, but is fixed by a SQL aggregate query and python dict comprehension. Includes regression unit tests, which I made sure were failing before I wrote any code to make them pass.

The issue was that the last scale operation "wins," at least in terms of the structure field:

``` console
$ deis scale web=2
$ deis info
=== kingly-playroom Application
{
  "updated": "2014-12-05T21:58:54UTC", 
  "uuid": "c08e226e-2f83-4f80-91b3-7c33d850f3a4", 
  "created": "2014-12-05T21:01:06UTC", 
  "url": "kingly-playroom.deis.rocks", 
  "owner": "matt", 
  "id": "kingly-playroom", 
  "structure": {
    "web": 2
  }
}

=== kingly-playroom Processes

--- test: 
test.1 up (v7)
test.2 up (v7)
test.3 up (v7)
test.4 up (v7)

--- web: 
web.1 up (v7)
web.2 up (v7)

=== kingly-playroom Domains
No domains
```

(And yes, `deis.rocks` is now my domain. :smile:)
