### PR TITLE
feat(Makefile): add dev-cluster command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ dev-registry: check-docker
 	@echo "To use local boot2docker registry for Deis development:"
 	@echo "    export DEV_REGISTRY=`boot2docker ip 2>/dev/null`:5000"
 
+dev-cluster: discovery-url
+	vagrant up
+	ssh-add ~/.vagrant.d/insecure_private_key
+	deisctl config platform set sshPrivateKey=$(HOME)/.vagrant.d/insecure_private_key
+	deisctl config platform set domain=local3.deisapp.com
+	deisctl install platform
+
 discovery-url:
 	sed -e "s,# discovery:,discovery:," -e "s,discovery: https://discovery.etcd.io/.*,discovery: $$(curl -s -w '\n' https://discovery.etcd.io/new)," contrib/coreos/user-data.example > contrib/coreos/user-data
 

--- a/docs/contributing/hacking.rst
+++ b/docs/contributing/hacking.rst
@@ -74,6 +74,16 @@ Test connectivity using ``deisctl list``:
 
     $ deisctl list
 
+Start Up a Development Cluster
+------------------------------
+
+To start up and configure a local vagrant cluster for development, you can use the ``dev-cluster`` target.
+This requires that ``deisctl`` and ``vagrant`` are installed.
+
+.. code-block:: console
+
+    $ make dev-cluster
+
 Configure a Docker Registry
 ---------------------------
 


### PR DESCRIPTION
### AUTOMATE ALL OF THE THINGS!

Now for working development setup:

``` console
$ export DEISCTL_TUNNEL=172.17.8.100
$ export DEV_REGISTRY=192.168.59.103:5000 # OR YOUR IP
$ make dev-cluster
$ make dev-registry
$ make deploy
```

I think is super useful so I no longer have to set up the vagrant cluster. I'm open to debate on the exact commands being used. I opted not to include `deisctl start platform` because I figured it would mostly be used for development and you would want to deploy from the local registry anyway.
