### PR TITLE
feat(controller): introduce dockerignore

### DIFF
--- a/controller/.dockerignore
+++ b/controller/.dockerignore
@@ -1,0 +1,2 @@
+venv
+logs


### PR DESCRIPTION
This file prevents the python virtual environment and unit test droppings from being sent into docker's builder, produced via `make test-unit`.
