### PR TITLE
fix(client): update PyInstaller to package requests lib properly

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -1,6 +1,6 @@
 
 build: setup-venv
-	venv/bin/pip install docopt==0.6.2 python-dateutil==2.2 PyYAML==3.11 requests==2.4.3 pyinstaller==2.1 termcolor==1.1.0
+	venv/bin/pip install docopt==0.6.2 python-dateutil==2.2 PyYAML==3.11 requests==2.4.3 git+https://github.com/pyinstaller/pyinstaller@7413317 termcolor==1.1.0
 	venv/bin/pyinstaller deis.spec
 	chmod +x dist/deis
 

--- a/controller/dev_requirements.txt
+++ b/controller/dev_requirements.txt
@@ -5,7 +5,7 @@ requests==2.4.3
 termcolor==1.1.0
 
 # PyInstaller builds client binaries
-PyInstaller==2.1
+git+https://github.com/pyinstaller/pyinstaller@7413317
 
 # Deis documentation requirements
 Sphinx>=1.2.3

--- a/tests/bin/build-deis-cli.sh
+++ b/tests/bin/build-deis-cli.sh
@@ -4,5 +4,5 @@
 
 virtualenv --system-site-packages venv
 . venv/bin/activate
-pip install docopt==0.6.2 python-dateutil==2.2 PyYAML==3.11 requests==2.4.3 pyinstaller==2.1 termcolor==1.1.0
+pip install docopt==0.6.2 python-dateutil==2.2 PyYAML==3.11 requests==2.4.3 git+https://github.com/pyinstaller/pyinstaller@7413317 termcolor==1.1.0
 make -C client/ client


### PR DESCRIPTION
The versions of the `deis` CLI created by `make -C client/ build` were using [PyInstaller 2.1](https://github.com/pyinstaller/pyinstaller/releases/tag/v2.1), the current release. This updates PyInstaller used for packaging to [a current SHA](https://github.com/pyinstaller/pyinstaller/commits/7413317176ac5d2b1196f7d7855b796328dd9609) in their development branch, which includes [a hook script](https://github.com/pyinstaller/pyinstaller/blob/develop/PyInstaller/hooks/hook-requests.py) for the python requests library to bundle its data files correctly.

Fixes #2719.
