### PR TITLE
fix(store): list all monitors in [global] section of config

### DIFF
--- a/store/base/templates/ceph.conf
+++ b/store/base/templates/ceph.conf
@@ -17,4 +17,3 @@ log file = /dev/stdout
 host = deis-store-gateway
 keyring = /etc/ceph/ceph.client.radosgw.keyring
 rgw socket path = /var/run/ceph/ceph.radosgw.gateway.fastcgi.sock
-log file = /dev/stdout


### PR DESCRIPTION
This is due to a Ceph bug - http://tracker.ceph.com/issues/10012.
Some configuration options aren't read properly if they're not in
the `[global]` section of the Ceph config. This means that the
store-gateway component was only connecting to the initial monitor,
instead of using all the enumerated monitors.

This notation is functionally equivalent, so it'll work just fine
for us.

replaces #2716 
closes #2711
