### PR TITLE
chore(builder): update Docker to 1.3.3

### DIFF
--- a/builder/image/Dockerfile
+++ b/builder/image/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F9
 RUN apt-get update && apt-get install -yq \
     openssh-server git \
     aufs-tools iptables lxc \
-    lxc-docker-1.3.2
+    lxc-docker-1.3.3
 
 # configure ssh server
 RUN rm /etc/ssh/ssh_host_*


### PR DESCRIPTION
Updates Docker inside deis-builder to version 1.3.3, which addresses several vulnerabilities. Details are at https://groups.google.com/d/msg/docker-user/nFAz-B-n4Bw/0wr3wvLsnUwJ

I also updated to Docker 1.3.3 on Jenkins node4 and ran tests to ensure `make build`, `make push`, and friends are compatible with this Docker patch release, and everything passes.
