### PR TITLE
fix(tests): destroy without --app flag to remove git remote

### DIFF
--- a/tests/apps_test.go
+++ b/tests/apps_test.go
@@ -20,6 +20,7 @@ var (
 	appsLogsCmd            = "apps:logs --app={{.AppName}}"
 	appsInfoCmd            = "apps:info --app={{.AppName}}"
 	appsDestroyCmd         = "apps:destroy --app={{.AppName}} --confirm={{.AppName}}"
+	appsDestroyCmdNoApp    = "apps:destroy --confirm={{.AppName}}"
 )
 
 func randomString(n int) string {
@@ -59,7 +60,7 @@ func appsCreateTest(t *testing.T, params *utils.DeisTestConfig) {
 	}
 	// TODO: move --buildpack to client unit tests
 	utils.Execute(t, appsCreateCmdBuildpack, params, false, "BUILDPACK_URL")
-	utils.Execute(t, appsDestroyCmd, params, false, "")
+	utils.Execute(t, appsDestroyCmdNoApp, params, false, "")
 	utils.Execute(t, appsCreateCmd, params, false, "")
 	utils.Execute(t, appsCreateCmd, params, true, "App with this Id already exists")
 }


### PR DESCRIPTION
The `deis` CLI change in 0ad398f2c16f553427f393b1331f061544875c50 created a problem for the integration tests: apps_test.go expected the `git` remote to be removed, which it intentionally was not after that change. This adds a variant of the command without the `--app` flag which then acts as expected using the current `deis` CLI.

It's not clear to me how the previous change slipped by testing, but this fixes it.
