### PR TITLE
fix(contrib): use 1GB per VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,15 +30,6 @@ else
   $num_instances = 3
 end
 
-# VM sizing for Deis
-if $num_instances == 1
-  $vb_memory = 4096
-  $vb_cpus = 2
-else
-  $vb_memory = 2048
-  $vb_cpus = 1
-end
-
 if File.exist?(CONFIG)
   require CONFIG
 end


### PR DESCRIPTION
Most modern laptops have ~8GB of memory available to them. On OSX, this is stretched even thinner due to boot2docker (which takes up 2GB of memory). Lowering the memory requirement for each host back to CoreOS' default memory requirements should allow us to use Vagrant on machines with less than 16GB of memory.

closes #2731 
