### PR TITLE
fix(Vagrantfile): disable replacing of default insecure key

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,6 +44,9 @@ if File.exist?(CONFIG)
 end
 
 Vagrant.configure("2") do |config|
+  # always use Vagrants insecure key
+  config.ssh.insert_key = false
+
   config.vm.box = "coreos-%s" % $update_channel
   config.vm.box_version = ">= 494.4.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel


### PR DESCRIPTION
In [Vagrant 1.7](https://github.com/mitchellh/vagrant/blob/v1.7.0/CHANGELOG.md#170-december-9-2014), using the default `~/.vagrant.d/insecure_private_key` now triggers the generation of a different key as a security feature. This breaks our vagrant workflow since `ssh-add ~/.vagrant.d/insecure_private_key` will not provide auth for `deisctl`. We should also document how to add a specific private key to a `config.rb` file for a more secure setup, but this will fix things for now.

Thanks to @bcwaldon for pointing out this fix in coreos/coreos-vagrant#192. (We try to minimize the diff between Deis' Vagrantfile and that one, but we don't maintain a proper fork right now since it led some users astray from the main project.)

Closes #2727.
