### PR TITLE
ref(builder): use bash-style substitution

### DIFF
--- a/builder/image/templates/builder
+++ b/builder/image/templates/builder
@@ -7,10 +7,6 @@ set -e
 
 ARGS=3
 
-get_app_name() {
-    echo $1 | awk -F"." '{print $1}'
-}
-
 indent() {
     echo "       $@"
 }
@@ -48,7 +44,7 @@ USER=$1
 REPO=$2
 GIT_SHA=$3
 SHORT_SHA=${GIT_SHA:0:8}
-APP_NAME=$(get_app_name $REPO)
+APP_NAME="${REPO%.*}"
 
 cd $(dirname $0) # ensure we are in the root dir
 


### PR DESCRIPTION
This is already in use at check-repos, which is a fancier way of
stripping the file extension from a string.
