### PR TITLE
re-revert "ref(tests): switch to example-dockerfile-http app"

### DIFF
--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -96,7 +96,7 @@ test-integration.sh
     >>> Preparing test environment <<<
 
     DEIS_ROOT=/Users/matt/Projects/src/github.com/deis/deis
-    DEIS_TEST_APP=example-go
+    DEIS_TEST_APP=example-dockerfile-http
     ...
     >>> Running integration suite <<<
 

--- a/tests/bin/test-setup.sh
+++ b/tests/bin/test-setup.sh
@@ -18,7 +18,7 @@ echo "DEIS_ROOT=$DEIS_ROOT"
 export PATH=${GOPATH}/bin:$PATH
 
 # the application under test
-export DEIS_TEST_APP=${DEIS_TEST_APP:-example-go}
+export DEIS_TEST_APP=${DEIS_TEST_APP:-example-dockerfile-http}
 echo "DEIS_TEST_APP=$DEIS_TEST_APP"
 
 # SSH key name used for testing

--- a/tests/utils/itutils.go
+++ b/tests/utils/itutils.go
@@ -312,6 +312,7 @@ func GetRandomApp() string {
 		"example-python-flask",
 		"example-ruby-sinatra",
 		"example-scala",
+		"example-dockerfile-http",
 	}
 	return apps[rand.Intn(len(apps))]
 }


### PR DESCRIPTION
example-dockerfile-http has switched over to ubuntu:trusty for better
compatibility with apps:run (busybox does not ship with bash). It's not a significant jump like the `busybox` image, but it does shave off about 700MB from the app image and should speed up integration tests.

This reverts commit ebded177705e257d8227a836bade85331d56f8d7.
