### PR TITLE
chore(*): update base CoreOS to 494.5.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,7 @@ end
 
 Vagrant.configure("2") do |config|
   config.vm.box = "coreos-%s" % $update_channel
-  config.vm.box_version = ">= 494.4.0"
+  config.vm.box_version = ">= 494.5.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
 
   config.vm.provider :virtualbox do |vb, override|

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -84,15 +84,15 @@
 
   "Mappings" : {
     "CoreOSAMIs" : {
-      "eu-central-1"   : { "PV" : "ami-12c0f10f", "HVM" : "ami-10c0f10d" },
-      "ap-northeast-1" : { "PV" : "ami-dc6566dd", "HVM" : "ami-da6566db" },
-      "sa-east-1"      : { "PV" : "ami-9bda6a86", "HVM" : "ami-99da6a84" },
-      "ap-southeast-2" : { "PV" : "ami-abc8a191", "HVM" : "ami-a9c8a193" },
-      "ap-southeast-1" : { "PV" : "ami-977559c5", "HVM" : "ami-957559c7" },
-      "us-east-1"      : { "PV" : "ami-f469f29c", "HVM" : "ami-f669f29e" },
-      "us-west-2"      : { "PV" : "ami-dbf8afeb", "HVM" : "ami-d9f8afe9" },
-      "us-west-1"      : { "PV" : "ami-af0516ea", "HVM" : "ami-ad0516e8" },
-      "eu-west-1"      : { "PV" : "ami-f6853881", "HVM" : "ami-f4853883" }
+      "eu-central-1"   : { "PV" : "ami-4e7d4d53", "HVM" : "ami-487d4d55" },
+      "ap-northeast-1" : { "PV" : "ami-dccfc0dd", "HVM" : "ami-decfc0df" },
+      "sa-east-1"      : { "PV" : "ami-c904b4d4", "HVM" : "ami-cb04b4d6" },
+      "ap-southeast-2" : { "PV" : "ami-d7e981ed", "HVM" : "ami-d1e981eb" },
+      "ap-southeast-1" : { "PV" : "ami-81406fd3", "HVM" : "ami-83406fd1" },
+      "us-east-1"      : { "PV" : "ami-7e5d3d16", "HVM" : "ami-705d3d18" },
+      "us-west-2"      : { "PV" : "ami-4fd4857f", "HVM" : "ami-4dd4857d" },
+      "us-west-1"      : { "PV" : "ami-15fae850", "HVM" : "ami-17fae852" },
+      "eu-west-1"      : { "PV" : "ami-7a3a840d", "HVM" : "ami-783a840f" }
 
     },
     "RootDevices" : {

--- a/contrib/rackspace/provision-rackspace-cluster.sh
+++ b/contrib/rackspace/provision-rackspace-cluster.sh
@@ -48,9 +48,9 @@ $CONTRIB_DIR/util/check-user-data.sh
 
 i=1 ; while [[ $i -le $DEIS_NUM_INSTANCES ]] ; do \
     echo_yellow "Provisioning deis-$i..."
-    # TODO: update to CoreOS 494.4.0 when it's in the stable channel at Rackspace
-    # This image is CoreOS 494.0.0 in their alpha channel
-    supernova $ENV boot --image 1c423602-ea76-4263-b56b-0a2fa3e8c663 --flavor $FLAVOR --key-name $1 --user-data $CONTRIB_DIR/coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
+    # TODO: update to CoreOS 494.5.0 when it's in the stable channel at Rackspace
+    # This image is CoreOS 494.1.0 in their beta channel
+    supernova $ENV boot --image 0c9c575e-6af8-4acd-96b0-c04ff0184718 --flavor $FLAVOR --key-name $1 --user-data $CONTRIB_DIR/coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
     ((i = i + 1)) ; \
 done
 

--- a/docs/installing_deis/baremetal.rst
+++ b/docs/installing_deis/baremetal.rst
@@ -16,7 +16,7 @@ machine running entirely from RAM. Then, you can `install CoreOS to disk`_.
 
 .. important::
 
-    Deis runs on CoreOS version 494.4.0 or later in the Stable channel.
+    Deis runs on CoreOS version 494.5.0 or later in the Stable channel.
 
 
 Check System Requirements
@@ -99,8 +99,8 @@ Start the installation
 
 
 This will install the latest `CoreOS`_ stable release to disk. The Deis provision scripts for other
-platforms typically specify a CoreOS version - currently, ``494.4.0``. To specify a CoreOS
-version, append the ``-V`` parameter to the install command, e.g. ``-V 494.4.0``.
+platforms typically specify a CoreOS version - currently, ``494.5.0``. To specify a CoreOS
+version, append the ``-V`` parameter to the install command, e.g. ``-V 494.5.0``.
 
 After the installation has finished, reboot your server. Once your machine is back up, you should
 be able to log in as the `core` user using the `deis` ssh key.

--- a/docs/installing_deis/gce.rst
+++ b/docs/installing_deis/gce.rst
@@ -119,7 +119,7 @@ Launch 3 instances. You can choose another starting CoreOS image from the listin
 
 .. code-block:: console
 
-    $ for num in 1 2 3; do gcutil addinstance --image projects/coreos-cloud/global/images/coreos-stable-494-4-0-v20141204 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
+    $ for num in 1 2 3; do gcutil addinstance --image projects/coreos-cloud/global/images/coreos-stable-494-5-0-v20141215 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
 
     Table of resources:
 


### PR DESCRIPTION
Includes Docker 1.3.3 with several security fixes.
See https://coreos.com/releases/#494.5.0 and #2729.

Double-check IDs at https://coreos.com/docs/running-coreos/cloud-providers/ec2/ and https://coreos.com/docs/running-coreos/cloud-providers/google-compute-engine/.
