### PR TITLE
docs(disable-registration): adds documentation on how to disable user registration

### DIFF
--- a/docs/managing_deis/operational_tasks.rst
+++ b/docs/managing_deis/operational_tasks.rst
@@ -29,6 +29,15 @@ You can use the ``deis perms`` command to promote a user to an administrator:
 
     $ deis perms:create john --admin
 
+Disabling user registration
+---------------------------
+
+You can disallow all users from registering with the deis cluster using the following command.
+
+.. code-block:: console
+
+    $ deisctl config controller set registrationEnabled=0
+
 
 Re-issuing User Authentication Tokens
 -------------------------------------


### PR DESCRIPTION
I had to dig through Github issues to find this command to disable user registration, so I thought it would help to have it in the docs until there is better administrative functionality to prevent Joe Schmo from creating a user in a deis cluster.
