### PR TITLE
docs(hacking+README): clarify that deis CLI requires python 2.7

### DIFF
--- a/client/README.rst
+++ b/client/README.rst
@@ -68,19 +68,19 @@ Get Started
 
 1. `Install the Client`_:
 
-Your Deis client should match your server's version. For development, an
-easy way to ensure this is to run `client/deis.py` in the code repository
-you used to provision the server. You can make a symlink or shell alias for
-`deis` to that file:
+Your Deis client should match your server's version. For developers, one way
+to ensure this is to use `Python 2.7`_ to install requirements and then run
+``client/deis.py`` in the Deis code repository. Then make a symlink or shell
+alias for ``deis`` to ensure it is found in your ``$PATH``:
 
 .. code-block:: console
 
-    $ pip install docopt==0.6.2 python-dateutil==2.2 PyYAML==3.11 requests==2.4.3 termcolor==1.1.0
+    $ make -C client/ install
     $ sudo ln -fs $(pwd)/client/deis.py /usr/local/bin/deis
     $ deis
     Usage: deis <command> [<args>...]
 
-If you don't have Python_, install the latest `deis` binary executable for
+If you don't have Python 2.7, install the latest `deis` binary executable for
 Linux or Mac OS X with this command:
 
 .. code-block:: console
@@ -140,7 +140,7 @@ somewhere in your $PATH.
 To learn more, use ``deis help`` or browse `the documentation`_.
 
 .. _`Install the Client`: http://docs.deis.io/en/latest/using_deis/install-client/
-.. _`Python`: http://www.python.org/
+.. _`Python 2.7`: https://www.python.org/downloads/release/python-279/
 .. _`Register a User`: http://docs.deis.io/en/latest/using_deis/register-user/
 .. _`Deploy an Application`: http://docs.deis.io/en/latest/using_deis/deploy-application/
 .. _`Manage an Application`: http://docs.deis.io/en/latest/using_deis/manage-application/

--- a/docs/contributing/hacking.rst
+++ b/docs/contributing/hacking.rst
@@ -34,20 +34,19 @@ then clone your fork of the repository:
 
 	$ git clone git@github.com:<username>/deis.git
 	$ cd deis
-	$ export DEIS_DIR=`pwd`  # to use in future commands
 
 Install the Client
 ------------------
 
-In a development environment you'll want to use the latest version of the client. Install
-its dependencies by using the Makefile and symlinking ``client/deis.py`` to ``deis`` on
-your local workstation.
+Your Deis client should match your server's version. For developers, one way
+to ensure this is to use `Python 2.7`_ to install requirements and then run
+``client/deis.py`` in the Deis code repository. Then make a symlink or shell
+alias for ``deis`` to ensure it is found in your ``$PATH``:
 
 .. code-block:: console
 
-    $ cd $DEIS_DIR/client
-    $ make install
-    $ sudo ln -fs $DEIS_DIR/client/deis.py /usr/local/bin/deis
+    $ make -C client/ install
+    $ sudo ln -fs $(pwd)/client/deis.py /usr/local/bin/deis
     $ deis
     Usage: deis <command> [<args>...]
 
@@ -190,5 +189,6 @@ when proposing a change to Deis.
 .. _`easy-fix`: https://github.com/deis/deis/issues?labels=easy-fix&state=open
 .. _`deisctl`: https://github.com/deis/deis/tree/master/deisctl
 .. _`fork the Deis repository`: https://github.com/deis/deis/fork
+.. _`Python 2.7`: https://www.python.org/downloads/release/python-279/
 .. _`running the tests`: https://github.com/deis/deis/tree/master/tests#readme
 .. _`pull request`: https://github.com/deis/deis/pulls


### PR DESCRIPTION
The README.rst file isn't part of the Sphinx documentation, so I wasn't able to use a reStructuredText include and had to repeat a paragraph.

Closes #2320, #2171. We would like to support Python 3, but any rewriting effort for the `deis` CLI at this point would be better spent porting it to Go.
