### PR TITLE
chore(store): remove redundant Makefile task

### DIFF
--- a/store/Makefile
+++ b/store/Makefile
@@ -21,16 +21,6 @@ build: check-docker
 		rm $(I)/Dockerfile ; \
 	)
 
-push: check-docker check-registry check-deisctl
-	$(foreach I, $(BUILT_IMAGES), \
-		docker tag deis/store-$(I):$(BUILD_TAG) $(REGISTRY)/deis/store-$(I):$(BUILD_TAG) ; \
-		docker push $(REGISTRY)/deis/store-$(I):$(BUILD_TAG) ; \
-	)
-
-	$(foreach I, $(TEMPLATE_IMAGES), \
-		deisctl config store-$(I) set image=$(REGISTRY)/deis/store-$(I):$(BUILD_TAG) ; \
-	)
-
 clean: check-docker check-registry
 	$(foreach I, $(BUILT_IMAGES), \
 		docker rmi deis/store-$(I):$(BUILD_TAG) ; \


### PR DESCRIPTION
We noticed two `push` tasks in `store/Makefile`.

Thanks @karlo57.
