### PR TITLE
fix(Makefile): remove CLIENTS from release task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ set-image:
 
 release: check-registry
 	@$(foreach C, $(COMPONENTS), $(MAKE) -C $(C) release &&) echo done
-	@$(foreach C, $(CLIENTS), $(MAKE) -C $(C) release &&) echo done
 
 deploy: build dev-release restart
 


### PR DESCRIPTION
Both deis client and deisctl do not have release tasks.
