### PR TITLE
fix(deisctl): unit test should also use main version package

### DIFF
--- a/deisctl/deisctl_test.go
+++ b/deisctl/deisctl_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/deis/deis/version"
 )
 
 // commandOutput returns stdout for a deisctl command line as a string.
@@ -54,7 +56,7 @@ func TestUsage(t *testing.T) {
 func TestVersion(t *testing.T) {
 	args := []string{"--version"}
 	out := commandOutput(args)
-	if !strings.HasPrefix(out, Version) {
+	if !strings.HasPrefix(out, version.Version) {
 		t.Error(out)
 	}
 }


### PR DESCRIPTION
The deisctl unit tests broke when #2777 was merged, but we didn't catch it because they were not wired into the test-integration.sh script. They are now, and this change fixes this unit test error:

``` console
$ make -C deisctl/ test-unit
godep go test -v -cover ./...
# github.com/deis/deis/deisctl
./deisctl_test.go:57: undefined: Version
FAIL    github.com/deis/deis/deisctl [build failed]
```
