### PR TITLE
fix(setup-node.sh): create database role for controller unit tests

### DIFF
--- a/tests/bin/setup-node.sh
+++ b/tests/bin/setup-node.sh
@@ -14,13 +14,13 @@ apt-get install -yq openjdk-7-jre-headless
 # install virtualbox 4.3.14
 apt-get install -yq build-essential libgl1 libgl1-mesa-glx libpython2.7 libqt4-network libqt4-opengl \
     libqtcore4 libqtgui4 libsdl1.2debian libvpx1 libxcursor1
-wget http://download.virtualbox.org/virtualbox/4.3.16/virtualbox-4.3_4.3.16-95972~Ubuntu~raring_amd64.deb
-dpkg -i virtualbox-4.3_4.3.16-95972~Ubuntu~raring_amd64.deb && \
-    rm virtualbox-4.3_4.3.16-95972~Ubuntu~raring_amd64.deb
+wget http://download.virtualbox.org/virtualbox/4.3.20/virtualbox-4.3_4.3.20-96996~Ubuntu~raring_amd64.deb
+dpkg -i virtualbox-4.3_4.3.20-96996~Ubuntu~raring_amd64.deb && \
+    rm virtualbox-4.3_4.3.20-96996~Ubuntu~raring_amd64.deb
 
 # install vagrant
-wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.5_x86_64.deb
-dpkg -i vagrant_1.6.5_x86_64.deb && rm vagrant_1.6.5_x86_64.deb
+wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.1_x86_64.deb
+dpkg -i vagrant_1.7.1_x86_64.deb && rm vagrant_1.7.1_x86_64.deb
 
 # install go
 wget -qO- https://storage.googleapis.com/golang/go1.3.3.linux-amd64.tar.gz | tar -C /usr/local -xz
@@ -32,11 +32,6 @@ apt-get install -yq curl mercurial python-dev libpq-dev libyaml-dev git postgres
 RUN curl -sSL https://raw.githubusercontent.com/pypa/pip/1.5.6/contrib/get-pip.py | python -
 pip install virtualenv
 
-# set up PostgreSQL requirements for controller unit tests
-sudo -u postgres createuser --createdb jenkins
-# sudo -u postgres psql
-# postgres=# create database deis owner jenkins
-
 # create jenkins user and install node bootstrap script
 useradd -G docker,vboxusers -s /bin/bash -m jenkins
 mkdir -p /home/jenkins/bin
@@ -44,6 +39,9 @@ wget -x -O /home/jenkins/bin/start-node.sh \
     https://raw.githubusercontent.com/deis/deis/master/tests/bin/start-node.sh
 chmod +x /home/jenkins/bin/start-node.sh
 chown -R jenkins:jenkins /home/jenkins/bin
+
+# set up PostgreSQL role for controller unit tests
+sudo -u postgres psql -c "CREATE ROLE deis WITH CREATEDB PASSWORD 'changeme123';"
 
 # now the jenkins user has to export some envvars to start as a node
 echo "Remaining setup:"


### PR DESCRIPTION
This change to the script we use for setting up CI nodes also updates the VirtualBox and vagrant packages to match those we use in testing.

Closes #1721.
