### PR TITLE
fix(builder): allow users to cat slugfile

### DIFF
--- a/builder/image/slugbuilder/builder/build.sh
+++ b/builder/image/slugbuilder/builder/build.sh
@@ -3,12 +3,12 @@ set -eo pipefail
 
 
 if [[ "$1" == "-" ]]; then
-	slug_file="$1"
+    slug_file="$1"
 else
-	slug_file=/tmp/slug.tgz
-	if [[ "$1" ]]; then
-		put_url="$1"
-	fi
+    slug_file=/tmp/slug.tgz
+    if [[ "$1" ]]; then
+        put_url="$1"
+    fi
 fi
 
 
@@ -23,37 +23,36 @@ mkdir -p $buildpack_root
 mkdir -p $build_root/.profile.d
 
 function output_redirect() {
-	if [[ "$slug_file" == "-" ]]; then
-		cat - 1>&2
-	else
-		cat -
-	fi
+    if [[ "$slug_file" == "-" ]]; then
+        cat - 1>&2
+    else
+        cat -
+    fi
 }
 
 function echo_title() {
-  echo $'\e[1G----->' $* | output_redirect
+    echo $'\e[1G----->' $* | output_redirect
 }
 
 function echo_normal() {
-  echo $'\e[1G      ' $* | output_redirect
+    echo $'\e[1G      ' $* | output_redirect
 }
 
 function ensure_indent() {
-  while read line; do
-    if [[ "$line" == --* ]]; then
-      echo $'\e[1G'$line | output_redirect
-    else
-      echo $'\e[1G      ' "$line" | output_redirect
-    fi
-
-  done
+    while read line; do
+        if [[ "$line" == --* ]]; then
+            echo $'\e[1G'$line | output_redirect
+        else
+            echo $'\e[1G      ' "$line" | output_redirect
+        fi
+    done
 }
 
 ## Copy application code over
 if [ -d "/tmp/app" ]; then
-	cp -rf /tmp/app/. $app_dir
+    cp -rf /tmp/app/. $app_dir
 else
-	cat | tar -xmC $app_dir
+    cat | tar -xmC $app_dir
 fi
 
 # In heroku, there are two separate directories, and some
@@ -73,24 +72,24 @@ buildpacks=($buildpack_root/*)
 selected_buildpack=
 
 if [[ -n "$BUILDPACK_URL" ]]; then
-	echo_title "Fetching custom buildpack"
+    echo_title "Fetching custom buildpack"
 
-	buildpack="$buildpack_root/custom"
-	rm -fr "$buildpack"
-	git clone --quiet --depth=1 "$BUILDPACK_URL" "$buildpack"
-	selected_buildpack="$buildpack"
-	buildpack_name=$($buildpack/bin/detect "$build_root") && selected_buildpack=$buildpack
+    buildpack="$buildpack_root/custom"
+    rm -fr "$buildpack"
+    git clone --quiet --depth=1 "$BUILDPACK_URL" "$buildpack"
+    selected_buildpack="$buildpack"
+    buildpack_name=$($buildpack/bin/detect "$build_root") && selected_buildpack=$buildpack
 else
     for buildpack in "${buildpacks[@]}"; do
-    	buildpack_name=$($buildpack/bin/detect "$build_root") && selected_buildpack=$buildpack && break
+        buildpack_name=$($buildpack/bin/detect "$build_root") && selected_buildpack=$buildpack && break
     done
 fi
 
 if [[ -n "$selected_buildpack" ]]; then
-	echo_title "$buildpack_name app detected"
-	else
-	echo_title "Unable to select a buildpack"
-	exit 1
+    echo_title "$buildpack_name app detected"
+    else
+    echo_title "Unable to select a buildpack"
+    exit 1
 fi
 
 ## Buildpack compile
@@ -103,29 +102,29 @@ $selected_buildpack/bin/release "$build_root" "$cache_root" > $build_root/.relea
 
 echo_title "Discovering process types"
 if [[ -f "$build_root/Procfile" ]]; then
-	types=$(ruby -e "require 'yaml';puts YAML.load_file('$build_root/Procfile').keys().join(', ')")
-	echo_normal "Procfile declares types -> $types"
+    types=$(ruby -e "require 'yaml';puts YAML.load_file('$build_root/Procfile').keys().join(', ')")
+    echo_normal "Procfile declares types -> $types"
 fi
 default_types=""
 if [[ -s "$build_root/.release" ]]; then
-	default_types=$(ruby -e "require 'yaml';puts (YAML.load_file('$build_root/.release')['default_process_types'] || {}).keys().join(', ')")
-	[[ $default_types ]] && echo_normal "Default process types for $buildpack_name -> $default_types"
+    default_types=$(ruby -e "require 'yaml';puts (YAML.load_file('$build_root/.release')['default_process_types'] || {}).keys().join(', ')")
+    [[ $default_types ]] && echo_normal "Default process types for $buildpack_name -> $default_types"
 fi
 
 
 ## Produce slug
 
 if [[ -f "$build_root/.slugignore" ]]; then
-	tar -z --exclude='.git' -X "$build_root/.slugignore" -C $build_root -cf $slug_file . | cat
+    tar -z --exclude='.git' -X "$build_root/.slugignore" -C $build_root -cf $slug_file . | cat
 else
-	tar -z --exclude='.git' -C $build_root -cf $slug_file . | cat
+    tar -z --exclude='.git' -C $build_root -cf $slug_file . | cat
 fi
 
 if [[ "$slug_file" != "-" ]]; then
-	slug_size=$(du -Sh "$slug_file" | cut -f1)
-	echo_title "Compiled slug size is $slug_size"
+    slug_size=$(du -Sh "$slug_file" | cut -f1)
+    echo_title "Compiled slug size is $slug_size"
 
-	if [[ $put_url ]]; then
-		curl -0 -s -o /dev/null -X PUT -T $slug_file "$put_url"
-	fi
+    if [[ $put_url ]]; then
+        curl -0 -s -o /dev/null -X PUT -T $slug_file "$put_url"
+    fi
 fi


### PR DESCRIPTION
partially reverts deis/slugbuilder@b872515 to allow `git archive master | docker run -ia stdin -a stdout deis/slugbuilder - > slug.tgz`.

also threw in a commit to convert tabs to spaces to follow our code guidelines.

fixes #2740
