### PR TITLE
fix(.gitignore): hide local vagrant config.rb from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,6 @@ contrib/ec2/cloudformation.json
 # GCE generated user-data
 contrib/gce/gce-user-data
 
-# vagrant being vagrant
+# vagrant local config and droppings
+/config.rb
 .vagrant


### PR DESCRIPTION
A local `config.rb` file overrides items from the `Vagrantfile`, but we forgot to exclude it from version control in #1881 when aligning with [coreos-vagrant](https://github.com/coreos/coreos-vagrant).

See https://github.com/coreos/coreos-vagrant#configuration and https://github.com/coreos/coreos-vagrant/blob/master/config.rb.sample for more info.
