### PR TITLE
docs(customizing_deis): remove slugbuilder/slugrunner settings

### DIFF
--- a/docs/customizing_deis/builder_settings.rst
+++ b/docs/customizing_deis/builder_settings.rst
@@ -39,8 +39,6 @@ setting                                   description
 /deis/registry/host                       host of the controller component (set by registry)
 /deis/registry/port                       port of the controller component (set by registry)
 /deis/services/*                          healthy application containers reported by deis/publisher
-/deis/slugbuilder/image                   slugbuilder image to use (default: deis/slugbuilder:latest)
-/deis/slugrunner/image                    slugrunner image to use (default: deis/slugrunner:latest)
 ====================================      ===========================================================
 
 Using a custom builder image


### PR DESCRIPTION
These were removed in a builder refactor and are no longer respected.

closes #2797
