### PR TITLE
ref(controller): remove redis cache library and settings

### DIFF
--- a/controller/conf.d/confd_settings.toml
+++ b/controller/conf.d/confd_settings.toml
@@ -6,7 +6,6 @@ gid = 1000
 mode  = "0640"
 keys = [
   "/deis/controller",
-  "/deis/cache",
   "/deis/database",
   "/deis/registry",
   "/deis/domains",

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -16,6 +16,5 @@ paramiko==1.14.1
 psycopg2==2.5.4
 python-etcd==0.3.2
 PyYAML==3.11
-redis==2.9.1
 static==1.0.2
 South==1.0.1

--- a/controller/templates/confd_settings.py
+++ b/controller/templates/confd_settings.py
@@ -34,9 +34,6 @@ DATABASES = {
     }
 }
 
-# configure cache
-CACHE_URL = 'redis://{{ .deis_cache_host }}:{{ .deis_cache_port }}/0'
-
 # move log directory out of /app/deis
 DEIS_LOG_DIR = '/data/logs'
 

--- a/controller/tests/controller_test.go
+++ b/controller/tests/controller_test.go
@@ -17,13 +17,10 @@ func TestController(t *testing.T) {
 		"/deis/registry/protocol",
 		"/deis/registry/host",
 		"/deis/registry/port",
-		"/deis/cache/host",
-		"/deis/cache/port",
 		"/deis/platform/domain",
 	}
 	setdir := []string{
 		"/deis/controller",
-		"/deis/cache",
 		"/deis/database",
 		"/deis/registry",
 		"/deis/domains",

--- a/docs/understanding_deis/components.rst
+++ b/docs/understanding_deis/components.rst
@@ -27,8 +27,7 @@ platform state. Backups and WAL logs are pushed to :ref:`Store`.
 
 Cache
 -----
-The cache is an instance of `Redis`_ used by the controller
-and registry.
+The cache is an instance of `Redis`_ used by the registry.
 
 .. _builder:
 


### PR DESCRIPTION
`CACHE_URL` and the python Redis library were not actually being used by the controller. We didn't remove Redis completely in #1834 because I thought it would be trivial to connect. Apparently it requires additional Django middleware and configuration to use Redis for caching. While I have seen session and object caching speed up Django deployments before, this is not a bottleneck for the Deis controller, and simpler == better.
