### PR TITLE
fix(deis.template.json): Instance SSH port.

### DIFF
--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -279,7 +279,7 @@
             "Protocol": "HTTP"
           },
           {
-            "InstancePort": "2222",
+            "InstancePort": "22",
             "InstanceProtocol": "TCP",
             "LoadBalancerPort": "2222",
             "Protocol": "TCP"


### PR DESCRIPTION
Changes the property which sets the SSH listeners port forwarding to 2222.

BREAKING CHANGE: Fixing consistency in template and further connection to ELB instances.
