### PR TITLE
fix(client): encode unicode properly for apps:run

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -680,7 +680,7 @@ class DeisClient(object):
                                   json.dumps(body))
         if response.status_code == requests.codes.ok:
             rc, output = json.loads(response.content)
-            sys.stdout.write(output)
+            sys.stdout.write(encode(output))
             sys.stdout.flush()
             sys.exit(rc)
         else:

--- a/controller/scheduler/fleet.py
+++ b/controller/scheduler/fleet.py
@@ -116,6 +116,9 @@ class FleetHTTPClient(object):
         entrypoint = kwargs.get('entrypoint')
         if entrypoint:
             l.update({'entrypoint': '{}'.format(entrypoint)})
+        # encode command as utf-8
+        if isinstance(l.get('command'), basestring):
+            l['command'] = l['command'].encode('utf-8')
         # construct unit from template
         for f in unit:
             f['value'] = f['value'].format(**l)

--- a/tests/apps_test.go
+++ b/tests/apps_test.go
@@ -15,7 +15,7 @@ var (
 	appsCreateCmdNoRemote  = "apps:create {{.AppName}} --no-remote"
 	appsCreateCmdBuildpack = "apps:create {{.AppName}} --buildpack https://example.com"
 	appsListCmd            = "apps:list"
-	appsRunCmd             = "apps:run echo hello"
+	appsRunCmd             = "apps:run echo Hello, 世界"
 	appsOpenCmd            = "apps:open --app={{.AppName}}"
 	appsLogsCmd            = "apps:logs --app={{.AppName}}"
 	appsInfoCmd            = "apps:info --app={{.AppName}}"
@@ -111,7 +111,7 @@ func appsRunTest(t *testing.T, params *utils.DeisTestConfig) {
 	if err := utils.Chdir(params.ExampleApp); err != nil {
 		t.Fatal(err)
 	}
-	utils.Execute(t, cmd, params, false, "hello")
+	utils.CheckList(t, cmd, params, "Hello, 世界", false)
 	utils.Execute(t, "apps:run env", params, true, "GIT_SHA")
 	// run a REALLY large command to test https://github.com/deis/deis/issues/2046
 	largeString := randomString(1024)


### PR DESCRIPTION
I reviewed the deis.py client code as well but didn't see other instances where `encode()` was required to handle unicode input or output.

Closes #2801.
