### PR TITLE
Remove controller settings cruft

### DIFF
--- a/controller/deis/settings.py
+++ b/controller/deis/settings.py
@@ -20,9 +20,9 @@ MANAGERS = ADMINS
 
 CONN_MAX_AGE = 60 * 3
 
-# Hosts/domain names that are valid for this site; required if DEBUG is False
-# See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ['localhost']
+# SECURITY: change this to allowed fqdn's to prevent host poisioning attacks
+# https://docs.djangoproject.com/en/1.6/ref/settings/#allowed-hosts
+ALLOWED_HOSTS = ['*']
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
@@ -303,10 +303,6 @@ DATABASES = {
 }
 
 APP_URL_REGEX = '[a-z0-9-]+'
-
-# SECURITY: change this to allowed fqdn's to prevent host poisioning attacks
-# see https://docs.djangoproject.com/en/1.5/ref/settings/#std:setting-ALLOWED_HOSTS
-ALLOWED_HOSTS = ['*']
 
 # Honor HTTPS from a trusted proxy
 # see https://docs.djangoproject.com/en/1.6/ref/settings/#secure-proxy-ssl-header


### PR DESCRIPTION
The `ACCOUNT_*` settings were not removed when django-allauth was in #2024, and `DEFAULT_BUILD` is not referenced anywhere. `ALLOWED_HOSTS` was defined twice, so the first definition was ignored.
