### PR TITLE
feat(contrib/coreos): disable transparent huge pages

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -66,6 +66,16 @@ coreos:
       ExecStartPre=/usr/bin/curl -sSL -o /opt/bin/jq http://stedolan.github.io/jq/download/linux64/jq
       ExecStartPre=/usr/bin/chmod +x /opt/bin/jq
       ExecStart=/usr/bin/bash -c "while true; do curl -sL http://127.0.0.1:4001/v2/stats/leader | /opt/bin/jq . ; sleep 1 ; done"
+  - name: disable-transparent-huge-pages.service
+    command: start
+    content: |
+      [Unit]
+      Description=Disable Transparent Huge Pages
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/bin/echo never > /sys/kernel/mm/transparent_hugepage/enabled
+      ExecStart=/usr/bin/echo never > /sys/kernel/mm/transparent_hugepage/defrag
 write_files:
   - path: /etc/deis-release
     content: |

--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -74,8 +74,9 @@ coreos:
 
       [Service]
       Type=oneshot
-      ExecStart=/usr/bin/echo never > /sys/kernel/mm/transparent_hugepage/enabled
-      ExecStart=/usr/bin/echo never > /sys/kernel/mm/transparent_hugepage/defrag
+      ExecStart=/bin/sh -c "until (echo 'Waiting for sys mount...' && cat /sys/kernel/mm/transparent_hugepage/enabled >/dev/null 2>&1); do sleep 1; done"
+      ExecStart=/bin/sh -c "echo never | tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null 2>&1"
+      ExecStart=/bin/sh -c "echo never | tee /sys/kernel/mm/transparent_hugepage/defrag >/dev/null 2>&1"
 write_files:
   - path: /etc/deis-release
     content: |

--- a/tests/user_data_test.go
+++ b/tests/user_data_test.go
@@ -1,0 +1,30 @@
+// +build integration
+
+package tests
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/deis/deis/tests/utils"
+)
+
+// check disable-transparent-huge-pages.service
+func checkIfTHPAreDisabled(t *testing.T, cfg *utils.DeisTestConfig) {
+	thp := "/sys/kernel/mm/transparent_hugepage/enabled"
+
+	cmd := "sudo cat " + thp
+	sshCmd := exec.Command("ssh",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "PasswordAuthentication=no",
+		"core@deis."+cfg.Domain, cmd)
+	out, err := sshCmd.Output()
+	if err != nil {
+		t.Fatal(out, err)
+	}
+	if !strings.Contains(string(out), "[never]") {
+		t.Fatalf("Expected 'always madvise [never]' as selected value in %s but '%s' was returned", thp, string(out))
+	}
+}


### PR DESCRIPTION
To test the execution, this should be the output:
```
$ more /sys/kernel/mm/transparent_hugepage/enabled
always madvise [never]
```