### PR TITLE
feat(router): listen on port 80 for platform SSL

### DIFF
--- a/router/image/templates/deis.conf
+++ b/router/image/templates/deis.conf
@@ -2,6 +2,7 @@ server_name_in_redirect off;
 port_in_redirect off;
 
 {{ if .deis_router_sslCert }}
+listen 80;
 listen 443 ssl spdy;
 ssl_certificate /etc/ssl/deis.cert;
 ssl_certificate_key /etc/ssl/deis.key;


### PR DESCRIPTION
With this change, applications can both listen on port 80 and port 443
when application SSL is enabled. Applications can use the guide at
https://help.openshift.com/hc/en-us/articles/202398810-How-to-redirect-traffic-to-HTTPS-
to redirect applications to their respective protocol.

refs #2786