### PR TITLE
feat(builder+docker+user-data): proxy settings

### DIFF
--- a/builder/image/bin/boot
+++ b/builder/image/bin/boot
@@ -6,6 +6,8 @@
 # fail hard and fast even on pipelines
 set -eo pipefail
 
+source /etc/environment_proxy
+
 # set debug based on envvar
 [[ $DEBUG ]] && set -x
 

--- a/builder/image/bin/entry
+++ b/builder/image/bin/entry
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eo pipefail
 
+source /etc/environment_proxy
+
 # START jpetazzo/dind wrapper
 
 # First, make sure that cgroups are mounted correctly.

--- a/builder/image/slugbuilder/builder/build.sh
+++ b/builder/image/slugbuilder/builder/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
+source /etc/environment_proxy
 
 if [[ "$1" == "-" ]]; then
     slug_file="$1"

--- a/builder/image/slugrunner/runner/init
+++ b/builder/image/slugrunner/runner/init
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eo pipefail
 
+source /etc/environment_proxy
+
 ## Load slug from Bind Mount, URL or STDIN
 
 export HOME=/app

--- a/builder/image/templates/builder
+++ b/builder/image/templates/builder
@@ -87,7 +87,7 @@ fi
 
 BUILD_OPTS=()
 BUILD_OPTS+='/usr/bin/docker'
-BUILD_OPTS+=' run '
+BUILD_OPTS+=' run -v /etc/environment_proxy:/etc/environment_proxy'
 # get application configuration
 BUILD_OPTS+=$(echo $RESPONSE | /app/bin/get-app-values)
 

--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -89,6 +89,7 @@ write_files:
   - path: /etc/systemd/system/docker.service.d/50-insecure-registry.conf
     content: |
         [Service]
+        EnvironmentFile=/etc/environment_proxy
         Environment="DOCKER_OPTS=--insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 --insecure-registry 100.64.0.0/10"
   - path: /run/deis/bin/get_image
     permissions: '0755'
@@ -141,3 +142,14 @@ write_files:
       TOOLBOX_DOCKER_IMAGE=ubuntu-debootstrap
       TOOLBOX_DOCKER_TAG=14.04
       TOOLBOX_USER=root
+  - path: /etc/environment_proxy
+    owner: core
+    content: |
+      HTTP_PROXY=
+      HTTPS_PROXY=
+      ALL_PROXY=
+      NO_PROXY=
+      http_proxy=
+      https_proxy=
+      all_proxy=
+      no_proxy=

--- a/deisctl/units/deis-builder.service
+++ b/deisctl/units/deis-builder.service
@@ -8,7 +8,7 @@ ExecStartPre=/bin/sh -c "docker inspect deis-builder-data >/dev/null 2>&1 || doc
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-builder >/dev/null && docker rm -f deis-builder || true"
 ExecStartPre=-/bin/sh -c "/sbin/losetup -f"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker run --name deis-builder --rm -p 2223:22 --volumes-from=deis-builder-data -c 800 -e EXTERNAL_PORT=2223 -e HOST=$COREOS_PRIVATE_IPV4 --privileged $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker run --name deis-builder --rm -p 2223:22 --volumes-from=deis-builder-data -c 800 -e EXTERNAL_PORT=2223 -e HOST=$COREOS_PRIVATE_IPV4 --privileged -v /etc/environment_proxy:/etc/environment_proxy $IMAGE"
 ExecStartPost=/bin/sh -c "echo 'Waiting for builder on 2223/tcp...' && until echo 'dummy-value' | ncat $COREOS_PRIVATE_IPV4 2223 >/dev/null 2>&1; do sleep 1; done"
 ExecStartPost=/usr/bin/docker exec deis-builder /usr/local/bin/push-images
 ExecStopPost=-/usr/bin/docker rm -f deis-builder

--- a/docs/managing_deis/index.rst
+++ b/docs/managing_deis/index.rst
@@ -23,3 +23,4 @@ Managing Deis
     security_considerations
     ssl-endpoints
     upgrading-deis
+    using-a-proxy-server

--- a/docs/managing_deis/using-a-proxy-server.rst
+++ b/docs/managing_deis/using-a-proxy-server.rst
@@ -1,0 +1,67 @@
+:title: Using a Proxy Server
+:description: How to configure Deis to use a proxy server.
+
+.. _using-a-proxy-server:
+
+Using a Proxy Server
+====================
+
+In some environments, HTTP connections must pass through a proxy. The Deis builder component supports
+proxies by respecting the proxy-related environment variables defined in ``/etc/environment_proxy``.
+
+Additionally, Docker is also configured to respect the settings in this file.
+
+By default, ``/etc/environment_proxy`` has all environment variables set to blank values:
+
+.. code-block:: console
+
+    HTTP_PROXY=
+    HTTPS_PROXY=
+    ALL_PROXY=
+    NO_PROXY=
+    http_proxy=
+    https_proxy=
+    all_proxy=
+    no_proxy=
+
+.. note::
+
+    Proxy settings must be respected by the applications you're building.
+    When using custom buildpacks, make sure they respect proxy settings.
+
+
+Configuring before server launch
+--------------------------------
+
+Before provisioning the servers using the provision scripts in the Deis repository, edit
+``contrib/coreos/user-data.example`` and replace the contents of the file to suit your environment.
+
+For example:
+
+.. code-block:: console
+
+  - path: /etc/environment_proxy
+    owner: core
+    content: |
+      HTTP_PROXY=http://proxy.example.com:3128
+      HTTPS_PROXY=http://proxy.example.com:3128
+      ALL_PROXY=http://proxy.example.com:3128
+      NO_PROXY="127.0.0.1,localhost,.example.com"
+      http_proxy=http://proxy.example.com:3128
+      https_proxy=http://proxy.example.com:3128
+      all_proxy=http://proxy.example.com:3128
+      no_proxy="127.0.0.1,localhost,.example.com"
+
+After running ``make discovery-url`` and provisioning your servers, the platform will come up with
+your proxy settings.
+
+Configuring after server launch
+-------------------------------
+
+It's also possible to configure these settings after the server has been provisioned, but this will
+result in downtime of the Deis platform as components are restarted.
+
+You'll need to edit ``/etc/environment_proxy`` on all CoreOS hosts (as the builder component can
+be relocated to any host in the cluster). Then, restart Docker with ``sudo systemctl restart docker``
+and monitor Deis components with ``deisctl list``. It may be necessary to restart components
+if they do not recover automatically from the Docker restart.


### PR DESCRIPTION
Proxy settings for coreos, builder, slugrunner, slugbuilder and docker

originally using /etc/environment, changed to /etc/environment_proxy to avoid current automations failures

closes #1734 -- edited by @bacongobbler