### PR TITLE
fix(controller): disallow unauthorized users from modifying apps

### DIFF
--- a/controller/api/__init__.py
+++ b/controller/api/__init__.py
@@ -2,4 +2,4 @@
 The **api** Django app presents a RESTful web API for interacting with the **deis** system.
 """
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'

--- a/controller/api/tests/test_build.py
+++ b/controller/api/tests/test_build.py
@@ -208,16 +208,22 @@ class BuildTest(TransactionTestCase):
                          response.data['app'], response.data['uuid'][:7]))
 
     @mock.patch('requests.post', mock_import_repository_task)
-    def test_unauthorized_user_cannot_create_build(self):
-        """An unauthorized user should not be able to create builds for other apps."""
+    def test_unauthorized_user_cannot_modify_build(self):
+        """
+        An unauthorized user should not be able to modify other builds.
+
+        Since an unauthorized user should not know about the application at all, these
+        requests should return a 404.
+        """
+        app_id = 'autotest'
         url = '/v1/apps'
-        response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
-        app_id = response.data['id']
-        # attempt to create a build as a malicious user
-        evil_user = User.objects.get(username='autotest2')
-        evil_token = Token.objects.get(user=evil_user).key
-        url = "/v1/apps/{app_id}/builds".format(**locals())
-        body = {'image': 'eeeeeevillllll'}
+        body = {'id': app_id}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(evil_token))
-        self.assertEqual(response.status_code, 403)
+                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        unauthorized_user = User.objects.get(username='autotest2')
+        unauthorized_token = Token.objects.get(user=unauthorized_user).key
+        url = '{}/{}/builds'.format(url, app_id)
+        body = {'image': 'foo'}
+        response = self.client.post(url, json.dumps(body), content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(unauthorized_token))
+        self.assertEqual(response.status_code, 404)

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -104,7 +104,7 @@ class AppPermsViewSet(viewsets.ViewSet):
         if request.user != app.owner and \
                 not request.user.has_perm(perm_name, app) and \
                 not request.user.is_superuser:
-            return Response(status=status.HTTP_403_FORBIDDEN)
+            return Response(status=status.HTTP_404_NOT_FOUND)
         usernames = [u.username for u in get_users_with_perms(app)
                      if u.has_perm(perm_name, app)]
         return Response({'users': usernames})
@@ -112,7 +112,7 @@ class AppPermsViewSet(viewsets.ViewSet):
     def create(self, request, **kwargs):
         app = get_object_or_404(self.model, id=kwargs['id'])
         if request.user != app.owner and not request.user.is_superuser:
-            return Response(status=status.HTTP_403_FORBIDDEN)
+            return Response(status=status.HTTP_404_NOT_FOUND)
         user = get_object_or_404(User, username=request.DATA['username'])
         assign_perm(self.perm, user, app)
         models.log_event(app, "User {} was granted access to {}".format(user, app))
@@ -121,7 +121,7 @@ class AppPermsViewSet(viewsets.ViewSet):
     def destroy(self, request, **kwargs):
         app = get_object_or_404(self.model, id=kwargs['id'])
         if request.user != app.owner and not request.user.is_superuser:
-            return Response(status=status.HTTP_403_FORBIDDEN)
+            return Response(status=status.HTTP_404_NOT_FOUND)
         user = get_object_or_404(User, username=kwargs['username'])
         if user.has_perm(self.perm, app):
             remove_perm(self.perm, user, app)
@@ -138,7 +138,22 @@ class AdminPermsViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.AdminUserSerializer
     permission_classes = (IsAdmin,)
 
+    def check_obj_permissions(self, obj):
+        """
+        Small wrapper around check_object_permissions().
+
+        If the user is denied permission to the object, then
+        it should return a 404 so the user is not aware of the
+        application resource.
+        """
+        try:
+            self.check_object_permissions(self.request, obj)
+        except PermissionDenied:
+            raise Http404("No {} matches the given query.".format(
+                self.model._meta.object_name))
+
     def get_queryset(self, **kwargs):
+        self.check_obj_permissions(self.request.user)
         return self.model.objects.filter(is_active=True, is_superuser=True)
 
     def create(self, request, **kwargs):
@@ -225,21 +240,31 @@ class BaseAppViewSet(viewsets.ModelViewSet):
 
     permission_classes = (permissions.IsAuthenticated, IsAppUser)
 
+    def check_obj_permissions(self, obj):
+        """
+        Small wrapper around check_object_permissions().
+
+        If the user is denied permission to the object, then
+        it should return a 404 so the user is not aware of the
+        application resource.
+        """
+        try:
+            self.check_object_permissions(self.request, obj)
+        except PermissionDenied:
+            raise Http404("No {} matches the given query.".format(
+                self.model._meta.object_name))
+
     def pre_save(self, obj):
         obj.owner = self.request.user
 
     def get_queryset(self, **kwargs):
         app = get_object_or_404(models.App, id=self.kwargs['id'])
-        try:
-            self.check_object_permissions(self.request, app)
-        except PermissionDenied:
-            raise Http404("No {} matches the given query.".format(
-                self.model._meta.object_name))
+        self.check_obj_permissions(app)
         return self.model.objects.filter(app=app)
 
     def get_object(self, *args, **kwargs):
         obj = self.get_queryset().latest('created')
-        self.check_object_permissions(self.request, obj)
+        self.check_obj_permissions(obj)
         return obj
 
 
@@ -260,7 +285,7 @@ class AppBuildViewSet(BaseAppViewSet):
 
     def create(self, request, *args, **kwargs):
         app = get_object_or_404(models.App, id=self.kwargs['id'])
-        self.check_object_permissions(self.request, app)
+        self.check_obj_permissions(app)
         request._data = request.DATA.copy()
         request.DATA['app'] = app
         try:
@@ -278,12 +303,8 @@ class AppConfigViewSet(BaseAppViewSet):
     def get_object(self, *args, **kwargs):
         """Return the Config associated with the App's latest Release."""
         app = get_object_or_404(models.App, id=self.kwargs['id'])
-        try:
-            self.check_object_permissions(self.request, app)
-            return app.release_set.latest().config
-        except (PermissionDenied, models.Release.DoesNotExist):
-            raise Http404("No {} matches the given query.".format(
-                self.model._meta.object_name))
+        self.check_obj_permissions(app)
+        return app.release_set.latest().config
 
     def pre_save(self, config):
         """merge the old config with the new"""
@@ -396,20 +417,35 @@ class DomainViewSet(OwnerViewSet):
     model = models.Domain
     serializer_class = serializers.DomainSerializer
 
+    def check_obj_permissions(self, obj):
+        """
+        Small wrapper around check_object_permissions().
+
+        If the user is denied permission to the object, then
+        it should return a 404 so the user is not aware of the
+        application resource.
+        """
+        try:
+            self.check_object_permissions(self.request, obj)
+        except PermissionDenied:
+            raise Http404("No {} matches the given query.".format(
+                self.model._meta.object_name))
+
     def create(self, request, *args, **kwargs):
         app = get_object_or_404(models.App, id=self.kwargs['id'])
+        self.check_obj_permissions(app)
         request._data = request.DATA.copy()
         request.DATA['app'] = app
         return super(DomainViewSet, self).create(request, *args, **kwargs)
 
     def get_queryset(self, **kwargs):
         app = get_object_or_404(models.App, id=self.kwargs['id'])
-        qs = self.model.objects.filter(app=app)
-        return qs
+        self.check_obj_permissions(app)
+        return self.model.objects.filter(app=app)
 
     def get_object(self, *args, **kwargs):
-        qs = self.get_queryset(**kwargs)
-        obj = qs.get(domain=self.kwargs['domain'])
+        obj = self.get_queryset().get(domain=self.kwargs['domain'])
+        self.check_obj_permissions(obj)
         return obj
 
 

--- a/docs/reference/api-v1.1.rst
+++ b/docs/reference/api-v1.1.rst
@@ -6,7 +6,7 @@
 Controller API v1.1
 ===================
 
-This is the v1.0 REST API for the :ref:`Controller`.
+This is the v1.1 REST API for the :ref:`Controller`.
 
 
 What's New
@@ -15,6 +15,8 @@ What's New
 **New!** All controller responses now return the ``X_DEIS_API_VERSION`` header.
 
 **New!** All controller responses now return the ``X_DEIS_PLATFORM_VERSION`` header.
+
+**New!** Users see a 404 response when modifying applications they are unauthorized to see.
 
 
 Authentication

--- a/tests/perms_test.go
+++ b/tests/perms_test.go
@@ -53,7 +53,7 @@ func permsCreateAdminTest(t *testing.T, params *utils.DeisTestConfig) {
 
 func permsCreateAppTest(t *testing.T, params, user *utils.DeisTestConfig) {
 	utils.Execute(t, authLoginCmd, user, false, "")
-	utils.Execute(t, permsCreateAppCmd, user, true, "403 FORBIDDEN")
+	utils.Execute(t, permsCreateAppCmd, user, true, "404 NOT FOUND")
 	utils.Execute(t, authLoginCmd, params, false, "")
 	utils.Execute(t, permsCreateAppCmd, params, false, "")
 	utils.CheckList(t, permsListAppCmd, params, "test1", false)
@@ -66,7 +66,7 @@ func permsDeleteAdminTest(t *testing.T, params *utils.DeisTestConfig) {
 
 func permsDeleteAppTest(t *testing.T, params, user *utils.DeisTestConfig) {
 	utils.Execute(t, authLoginCmd, user, false, "")
-	utils.Execute(t, permsDeleteAppCmd, user, true, "403 FORBIDDEN")
+	utils.Execute(t, permsDeleteAppCmd, user, true, "404 NOT FOUND")
 	utils.Execute(t, authLoginCmd, params, false, "")
 	utils.Execute(t, permsDeleteAppCmd, params, false, "")
 	utils.CheckList(t, permsListAppCmd, params, "test1", true)


### PR DESCRIPTION
Authenticated users who were not given explicit permission
to view or modify an app were still allowed to create new releases,
run commands, retrieve logs etc. This makes those requests return a 404
if the user should not be able to see the application.

Please let me know if I missed any loopholes and I will happily correct them.

closes #2820, refs #2811