### PR TITLE
feat(client): Add controller to whoami command.

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -869,7 +869,8 @@ class DeisClient(object):
         """
         user = self._settings.get('username')
         if user:
-            self._logger.info(user)
+            self._logger.info(
+                'You are {} at {}'.format(user, self._settings['controller']))
         else:
             self._logger.info(
                 'Not logged in. Use `deis login` or `deis register` to get started.')


### PR DESCRIPTION
Whoami command needs to display both username and controller. Useful
when using multiple deis clusters.