### PR TITLE
feat(contrib/ec2): Set ELB timeout to 1200s

### DIFF
--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -293,7 +293,10 @@
           {
             "Fn::GetAtt": ["DeisWebELBSecurityGroup", "GroupId"]
           }
-        ]
+        ],
+        "ConnectionSettings": {
+          "IdleTimeout": 1200
+        }
       }
     },
     "DeisWebELBSecurityGroup": {

--- a/docs/managing_deis/configure-load-balancers.rst
+++ b/docs/managing_deis/configure-load-balancers.rst
@@ -30,9 +30,7 @@ EC2
 ===
 
 The Deis provisioning scripts for EC2 automatically create an Elastic Load Balancer for your Deis
-cluster. However, ELBs on EC2 have a default timeout of 60 seconds, which will disrupt a ``git push``
-when using Deis. You should manually `increase this timeout`_ to 1200 seconds to match the timeout
-on the router and application unit files.
+cluster.
 
 Rackspace
 =========
@@ -52,8 +50,6 @@ You'll need to create two load balancers on Rackspace, as follows:
       Virtual IP Shared VIP on Another Load Balancer (select Load Balancer 1)
       Port 2222
       Protocol TCP
-
-.. _`increase this timeout`: http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/config-idle-timeout.html
 
 Google Compute Engine
 =====================


### PR DESCRIPTION
Amazon added support for setting the ELB timeout directly from
CloudFormation on the 24th of December.

This commit removes the documentation which tells the user to change it
manually, as that is no longer needed, and sets it to 1200s.

See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-connectionsettings.html