### PR TITLE
feat(controller): add hostname exposing to units

### DIFF
--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -49,6 +49,7 @@ etcd_set_default secretKey ${DEIS_SECRET_KEY:-`openssl rand -base64 64 | tr -d '
 etcd_set_default builderKey ${DEIS_BUILDER_KEY:-`openssl rand -base64 64 | tr -d '\n'`}
 etcd_set_default registrationEnabled 1
 etcd_set_default webEnabled 0
+etcd_set_default unitHostname default
 
 # safely create required keyspaces
 etcd_safe_mkdir /deis/services

--- a/controller/deis/settings.py
+++ b/controller/deis/settings.py
@@ -308,6 +308,13 @@ APP_URL_REGEX = '[a-z0-9-]+'
 # see https://docs.djangoproject.com/en/1.6/ref/settings/#secure-proxy-ssl-header
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
+# Unit Hostname handling.
+# Supports:
+#  default      - Docker generated hostname
+#  application  - Hostname based on application unit name (i.e. my-application.v2.web.1)
+#  server       - Hostname based on CoreOS server hostname
+UNIT_HOSTNAME = 'default'
+
 # Create a file named "local_settings.py" to contain sensitive settings data
 # such as database configuration, admin email, or passwords and keys. It
 # should also be used for any settings which differ between development

--- a/controller/templates/confd_settings.py
+++ b/controller/templates/confd_settings.py
@@ -44,3 +44,5 @@ REGISTRATION_ENABLED = bool({{ .deis_controller_registrationEnabled }})
 {{ if .deis_controller_webEnabled }}
 WEB_ENABLED = bool({{ .deis_controller_webEnabled }})
 {{ end }}
+
+UNIT_HOSTNAME = '{{ or (.deis_controller_unitHostname) "default" }}'

--- a/docs/customizing_deis/controller_settings.rst
+++ b/docs/customizing_deis/controller_settings.rst
@@ -19,17 +19,18 @@ Settings set by controller
 --------------------------
 The following etcd keys are set by the controller component, typically in its /bin/boot script.
 
-===========================              =================================================================================
+=============================            =================================================================================
 setting                                  description
-===========================              =================================================================================
+=============================            =================================================================================
 /deis/controller/host                    IP address of the host running controller
 /deis/controller/port                    port used by the controller service (default: 8000)
 /deis/controller/protocol                protocol for controller (default: http)
 /deis/controller/secretKey               used for secrets (default: randomly generated)
 /deis/controller/builderKey              used by builder to authenticate with the controller (default: randomly generated)
+/deis/controller/unitHostname            See `Unit hostname`_. (default: "default")
 /deis/builder/users/*                    stores user SSH keys (used by builder)
 /deis/domains/*                          domain configuration for applications (used by router)
-===========================              =================================================================================
+=============================            =================================================================================
 
 Settings used by controller
 ---------------------------
@@ -73,3 +74,35 @@ Be sure that your custom image functions in the same way as the `stock controlle
 Deis. Specifically, ensure that it sets and reads appropriate etcd keys.
 
 .. _`stock controller image`: https://github.com/deis/deis/tree/master/controller
+
+Unit hostname
+-------------
+Per default, Docker automatically generates a hostname for your application unit, such as: 
+``5c149b397cd6``. Auto generated hostnames is not always preferred. For instance, 
+New Relic would classify each Docker container as an unique server since they use hostname 
+for grouping applications running on the same server together.
+
+Deis supports configuring hostname assignment through the ``unitHostname`` setting.
+You can change the assignment solution using the following command:
+
+.. code-block:: console
+
+    $ deisctl config controller set unitHostname=application
+
+The valid ``unitHostname`` values are:
+
+default
+    Docker will generate the hostname. Example: ``5c149b397cd6``
+
+application
+    The hostname is assigned based on the unit name. Example: ``dancing-cat.v2.web.1``
+
+server
+    The hostname is assigned based on the CoreOS hostname. Example: 
+    ``ip-10-21-2-168.eu-west-1.compute.internal``
+
+.. note::
+
+    Changes to ``/deis/controller/unitHostname`` requires either pushing a new build to 
+    every application or scaling them down and up.
+    The change is only detected when a container unit is deployed.


### PR DESCRIPTION
This exposes a configurable hostname type to Docker container through
fleet unit files.

Three hostname types are supported:
- default     : standard Docker hostname
- application : application hostname (e.g. my-app.v54.web.1)
- server      : Core OS hostname

This fixes #2835 and is an alternative to #2428, which got rejected.

It is necessary when using a monitoring solution like New Relic.