### PR TITLE
chore(controller): update Django to 1.6.9 bugfix release

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -3,7 +3,7 @@
 # NOTE: For testing on Mac OS X Mavericks, use the following to work around a clang issue:
 # ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future pip install [args]
 #
-Django==1.6.8
+Django==1.6.9
 # FIXME: switch to upstream pending merge of https://github.com/kmmbvnr/django-fsm/pull/59
 git+https://github.com/deis/django-fsm@propagate-false
 django-cors-headers==1.0.0

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -7,7 +7,7 @@
 # NOTE: For testing on Mac OS X Mavericks, use the following to work around a clang issue:
 # ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future pip install [args]
 #
-Django==1.6.8
+Django==1.6.9
 # FIXME: switch to upstream pending merge of https://github.com/kmmbvnr/django-fsm/pull/59
 git+https://github.com/deis/django-fsm@propagate-false
 django-cors-headers==1.0.0


### PR DESCRIPTION
See https://docs.djangoproject.com/en/dev/releases/1.6.9/ for details.