### PR TITLE
fix(contrib/coreos): fix debug-etcd service

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -57,7 +57,6 @@ coreos:
       RemainAfterExit=yes
       Type=oneshot
   - name: debug-etcd.service
-    command: enable
     content: |
       [Unit]
       Description=etcd debugging service


### PR DESCRIPTION
The debug-etcd service added in #2779 has an issue - the `command: start`
is invalid.

This doesn't *appear* to break things, but the service that handles
cloud-config parsing will error out, which can result in services not starting.