### PR TITLE
feat(contrib/ec2): use ephemeral drive for etcd journal

### DIFF
--- a/contrib/ec2/gen-json.py
+++ b/contrib/ec2/gen-json.py
@@ -6,9 +6,42 @@ import yaml
 CURR_DIR = os.path.dirname(os.path.realpath(__file__))
 
 # Add EC2-specific units to the shared user-data
-FORMAT_EPHEMERAL = '''
+FORMAT_EPHEMERAL_VOLUME = '''
   [Unit]
-  Description=Formats the ephemeral drive
+  Description=Formats the ephemeral volume
+  ConditionPathExists=!/etc/ephemeral-volume-formatted
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  ExecStart=/usr/sbin/wipefs -f /dev/xvdb
+  ExecStart=/usr/sbin/mkfs.ext4 /dev/xvdb
+  ExecStart=/bin/touch /etc/ephemeral-volume-formatted
+'''
+MOUNT_EPHEMERAL_VOLUME = '''
+  [Unit]
+  Description=Formats and mounts the ephemeral drive
+  Requires=format-ephemeral-volume.service
+  After=format-ephemeral-volume.service
+  [Mount]
+  What=/dev/xvdb
+  Where=/media/ephemeral
+  Type=ext4
+'''
+PREPARE_ETCD_DATA_DIRECTORY = '''
+  [Unit]
+  Description=Prepares the etcd data directory
+  Requires=media-ephemeral.mount
+  After=media-ephemeral.mount
+  Before=etcd.service
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  ExecStart=/usr/bin/mkdir -p /media/ephemeral/etcd
+  ExecStart=/usr/bin/chown -R etcd /media/ephemeral/etcd
+'''
+FORMAT_DOCKER_VOLUME = '''
+  [Unit]
+  Description=Formats the added EBS volume for Docker
   ConditionPathExists=!/etc/docker-volume-formatted
   [Service]
   Type=oneshot
@@ -17,11 +50,11 @@ FORMAT_EPHEMERAL = '''
   ExecStart=/usr/sbin/mkfs.btrfs -f /dev/xvdf
   ExecStart=/bin/touch /etc/docker-volume-formatted
 '''
-DOCKER_MOUNT = '''
+MOUNT_DOCKER_VOLUME = '''
   [Unit]
-  Description=Mount ephemeral to /var/lib/docker
-  Requires=format-ephemeral.service
-  After=format-ephemeral.service
+  Description=Mount Docker volume to /var/lib/docker
+  Requires=format-docker-volume.service
+  After=format-docker-volume.service
   Before=docker.service
   [Mount]
   What=/dev/xvdf
@@ -30,8 +63,14 @@ DOCKER_MOUNT = '''
 '''
 
 data = yaml.load(file(os.path.join(CURR_DIR, '..', 'coreos', 'user-data'), 'r'))
-data['coreos']['units'].append(dict({'name': 'format-ephemeral.service', 'command': 'start', 'content': FORMAT_EPHEMERAL}))
-data['coreos']['units'].append(dict({'name': 'var-lib-docker.mount', 'command': 'start', 'content': DOCKER_MOUNT}))
+data['coreos']['units'].append(dict({'name': 'format-ephemeral-volume.service', 'command': 'start', 'content': FORMAT_EPHEMERAL_VOLUME}))
+data['coreos']['units'].append(dict({'name': 'media-ephemeral.mount', 'command': 'start', 'content': MOUNT_EPHEMERAL_VOLUME}))
+data['coreos']['units'].append(dict({'name': 'prepare-etcd-data-directory.service', 'command': 'start', 'content': PREPARE_ETCD_DATA_DIRECTORY}))
+data['coreos']['units'].append(dict({'name': 'format-docker-volume.service', 'command': 'start', 'content': FORMAT_DOCKER_VOLUME}))
+data['coreos']['units'].append(dict({'name': 'var-lib-docker.mount', 'command': 'start', 'content': MOUNT_DOCKER_VOLUME}))
+
+# configure etcd to use the ephemeral drive
+data['coreos']['etcd']['data-dir'] = '/media/ephemeral/etcd'
 
 header = ["#cloud-config", "---"]
 dump = yaml.dump(data, default_flow_style=False)


### PR DESCRIPTION
The changes in #2803 unfortunately don't address all of the etcd-related
performance issues. Provisioning Deis can still cause etcd timeouts.
Moving the etcd journal to the unused ephemeral disk allows etcd to
write to a very fast disk, resulting in fewer etcd/fleet issues.

refs #2793
refs #2506