### PR TITLE
fix(controller): disallow unauthorized users from deleting apps

### DIFF
--- a/controller/api/permissions.py
+++ b/controller/api/permissions.py
@@ -36,6 +36,8 @@ class IsAppUser(permissions.BasePermission):
     an app-related model.
     """
     def has_object_permission(self, request, view, obj):
+        if request.user.is_superuser:
+            return True
         if isinstance(obj, models.App) and obj.owner == request.user:
             return True
         elif hasattr(obj, 'app') and obj.app.owner == request.user:

--- a/controller/api/tests/test_app.py
+++ b/controller/api/tests/test_app.py
@@ -275,6 +275,10 @@ class AppTest(TestCase):
         url = '{}/{}/logs'.format(base_url, app_id)
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(unauthorized_token))
         self.assertEqual(response.status_code, 404)
+        url = '{}/{}'.format(base_url, app_id)
+        response = self.client.delete(url,
+                                      HTTP_AUTHORIZATION='token {}'.format(unauthorized_token))
+        self.assertEqual(response.status_code, 404)
 
     def test_app_info_not_showing_wrong_app(self):
         app_id = 'autotest'

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -368,6 +368,7 @@ class AppReleaseViewSet(BaseAppViewSet):
         """
         try:
             app = get_object_or_404(models.App, id=self.kwargs['id'])
+            self.check_object_permissions(self.request, app)
             release = app.release_set.latest()
             version_to_rollback_to = release.version - 1
             if request.DATA.get('version'):

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -231,7 +231,7 @@ class AppViewSet(OwnerViewSet):
                         content_type='text/plain')
 
     def destroy(self, request, **kwargs):
-        obj = get_object_or_404(self.model, id=kwargs['id'])
+        obj = self.get_object()
         obj.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
Authenticated users who were not given explicit permission to view
or modify an application were still allowed to delete other user's
applications, should the unauthorized user know what the ID of the
application would be. This returns a 404 message if the user is
unauthorized to see the application.

Because we were calling get_object_or_404(), we were not performing
any authorization against the API call. Calling self.get_object() is
the preferred method to retrieve an object since it authenticates
against the classes' permissions classes to ensure that the user is
authorized to see the application.

This also fixes up an issue where administrators were not explicitly
given permission to an app. They fell through the same "unauthorized"
issue as above.

closes #2845
closes #2846