### PR TITLE
fix(client): remove fetch call from apps:create

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -490,7 +490,7 @@ class DeisClient(object):
         else:
             try:
                 subprocess.check_call(
-                    ['git', 'remote', 'add', '-f', 'deis', git_remote],
+                    ['git', 'remote', 'add', 'deis', git_remote],
                     stdout=subprocess.PIPE)
                 self._logger.info('Git remote deis added')
             except subprocess.CalledProcessError:


### PR DESCRIPTION
If you have a violating key in your known_hosts file, it will cause
you to fail adding the git remote, even though the app is already
created on the controller's side. Validating that the server's key
is correct should happen at git push to match Heroku.