### PR TITLE
test(controller): add expected unit test failures for response codes

### DIFF
--- a/controller/api/tests/test_app.py
+++ b/controller/api/tests/test_app.py
@@ -277,6 +277,12 @@ class AppTest(TestCase):
         url = '{}/{}/logs'.format(base_url, app_id)
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(unauthorized_token))
         self.assertEqual(response.status_code, 403)
+        url = '{}/{}'.format(base_url, app_id)
+        response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(unauthorized_token))
+        self.assertEqual(response.status_code, 403)
+        response = self.client.delete(url,
+                                      HTTP_AUTHORIZATION='token {}'.format(unauthorized_token))
+        self.assertEqual(response.status_code, 403)
 
     def test_app_info_not_showing_wrong_app(self):
         app_id = 'autotest'


### PR DESCRIPTION
When testing the security holes found recently (#2826), we found a few response
codes that were not what was to be expected. Adding test coverage around
this such that we can address these tests in future refactors.