### PR TITLE
feat(slugbuilder): update nodejs buildpack to v64 (yoga release)

### DIFF
--- a/builder/image/slugbuilder/builder/install-buildpacks
+++ b/builder/image/slugbuilder/builder/install-buildpacks
@@ -18,7 +18,7 @@ mkdir -p $BUILDPACK_INSTALL_PATH
 
 download_buildpack https://github.com/ddollar/heroku-buildpack-multi.git         6e79094
 download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v129
-download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v62
+download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v64
 download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v32
 download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         24a8ebe
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         1ef927d


### PR DESCRIPTION
This release provides 2 very importan updates: 

1. the option to specify the [npm version](https://github.com/heroku/heroku-buildpack-nodejs/tree/yoga#specify-an-npm-version) to use
2. support for [scoped packages](https://docs.npmjs.com/misc/scope) (using npm 2.1.x)
3. correct support for chaining buildpacks
