### PR TITLE
ref(builder): Remove use of root in gitreceive

### DIFF
--- a/builder/image/Dockerfile
+++ b/builder/image/Dockerfile
@@ -38,9 +38,6 @@ RUN useradd -d $GITHOME $GITUSER
 RUN mkdir -p $GITHOME/.ssh && chown git:git $GITHOME/.ssh
 RUN chown -R $GITUSER:$GITUSER $GITHOME
 
-# let the git user run `sudo /home/git/builder` (not writeable)
-RUN echo "%git    ALL=(ALL:ALL) NOPASSWD:/home/git/builder" >> /etc/sudoers
-
 # HACK: import progrium/cedarish as a tarball
 # see https://github.com/deis/deis/issues/1027
 RUN curl -#SL -o /progrium_cedarish.tar.gz \
@@ -55,6 +52,11 @@ ENTRYPOINT ["/app/bin/entry"]
 CMD ["/app/bin/boot"]
 EXPOSE 22
 RUN addgroup --quiet --gid 2000 slug && useradd slug --uid=2000 --gid=2000
+
+# $GITUSER is added to docker group to use docker without sudo and to slug
+# group in order to share resources with the slug user
+RUN usermod -a -G docker $GITUSER
+RUN usermod -a -G slug $GITUSER
 
 ADD templates/shim.dockerfile /home/git/
 ADD etc /etc

--- a/builder/image/templates/builder
+++ b/builder/image/templates/builder
@@ -102,8 +102,13 @@ if [ ! -f Dockerfile ]; then
     BUILD_OPTS+=' -v '
     BUILD_OPTS+=$(echo $CACHE_DIR)
     BUILD_OPTS+=':/tmp/cache:rw'
-    # give non-root slugbuilder user R/W perms for docker volumes
-    chown -R 2000:2000 $TMP_DIR $CACHE_DIR
+    # give slug group ownership of TMP_DIR and CACHE_DIR.
+    chown -R :2000 $TMP_DIR
+    chown :2000 $CACHE_DIR
+    # TMP_DIR is created using mktemp, which sets permissions to 700. Since
+    # we share this with the slug group, the slug group needs to be able to
+    # work with it.
+    chmod g+rwx $TMP_DIR
 
     BUILD_OPTS+=' deis/slugbuilder'
 

--- a/builder/image/templates/builder
+++ b/builder/image/templates/builder
@@ -94,12 +94,6 @@ BUILD_OPTS+=$(echo $RESPONSE | /app/bin/get-app-values)
 # if no Dockerfile is present, use slugbuilder to compile a heroku slug
 # and write out a Dockerfile to use that slug
 if [ ! -f Dockerfile ]; then
-    if [ -f /buildpacks ]; then
-        BUILD_OPTS+=' -v /buildpacks:/tmp/buildpacks:rw'
-        # give non-root slugbuilder user R/W perms for docker volumes
-        chown -R 2000:2000 /buildpacks
-    fi
-
     # run in the background, we'll attach to it to retrieve logs
     BUILD_OPTS+=' -d'
     BUILD_OPTS+=' -v '

--- a/builder/image/templates/gitreceive
+++ b/builder/image/templates/gitreceive
@@ -57,8 +57,7 @@ EOF
         cd $GITHOME
         # if we're processing a receive-pack on an existing repo, run a build
         if [[ $SSH_ORIGINAL_COMMAND == git-receive-pack* ]]; then
-          # SECURITY: git user runs the builder as root (for docker access)
-          sudo $GITHOME/builder $RECEIVE_USER $RECEIVE_REPO $newrev 2>&1 | strip_remote_prefix
+          $GITHOME/builder $RECEIVE_USER $RECEIVE_REPO $newrev 2>&1 | strip_remote_prefix
         fi
 
         rm -f "$LOCKFILE"


### PR DESCRIPTION
Changed the builder from running an entire script as root through sudo, to just a single command.

This also fixes #1843, which happened since the builder script was ran as root, and we executed "git gc" as root, causing files and folders to "randomly" be owned by root:root instead of git:git