### PR TITLE
fix(database): update wal-e because error in python-daemon

### DIFF
--- a/database/build.sh
+++ b/database/build.sh
@@ -36,7 +36,7 @@ cd /tmp
 git clone https://github.com/wal-e/wal-e.git
 
 cd /tmp/wal-e
-git checkout dbf9783
+git checkout c16e58a
 
 pip install .
 


### PR DESCRIPTION
A new build of the current content of deis-database produces this error:
```
Processing /tmp/wal-e
    /usr/local/lib/python2.7/dist-packages/setuptools/dist.py:283: UserWarning: The version specified requires normalization, consider using '0.8rc1' instead of '0.8c1'.
      self.metadata.version,
Collecting gevent>=0.13.1 (from wal-e==0.8rc1)
  Downloading gevent-1.0.1.tar.gz (1.5MB)
Collecting boto>=2.6.0 (from wal-e==0.8rc1)
  Downloading boto-2.35.1-py2.py3-none-any.whl (1.3MB)
Collecting azure>=0.7.0 (from wal-e==0.8rc1)
  Downloading azure-0.9.0.zip (107kB)
Collecting python-swiftclient>=1.8.0 (from wal-e==0.8rc1)
  Downloading python_swiftclient-2.3.1-py2.py3-none-any.whl (51kB)
Collecting python-keystoneclient>=0.4.2 (from wal-e==0.8rc1)
  Downloading python_keystoneclient-1.0.0-py2.py3-none-any.whl (373kB)
Collecting python-daemon>=1.5.2 (from wal-e==0.8rc1)
  Downloading python-daemon-2.0.2.tar.gz (67kB)
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-73ac8d/python-daemon/setup.py", line 27, in <module>
        import version
      File "version.py", line 51, in <module>
        import docutils.core
    ImportError: No module named docutils.core
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

      File "<string>", line 20, in <module>

      File "/tmp/pip-build-73ac8d/python-daemon/setup.py", line 27, in <module>

        import version

      File "version.py", line 51, in <module>

        import docutils.core

    ImportError: No module named docutils.core

    ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-73ac8d/python-daemon
2015/01/13 11:59:19 The command [/bin/sh -c DOCKER_BUILD=true /tmp/build.sh] returned a non-zero code: 1
```


This is not failing in CI because it's using the docker cache.