### PR TITLE
feat(*): support RFC 6598 for insecure registries

### DIFF
--- a/builder/image/bin/boot
+++ b/builder/image/bin/boot
@@ -51,7 +51,7 @@ CONFD_PID=$!
 test -e /var/run/docker.sock && rm -f /var/run/docker.sock
 
 # spawn a docker daemon to run builds
-docker -d --storage-driver=$STORAGE_DRIVER --bip=172.19.42.1/16 --insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 &
+docker -d --storage-driver=$STORAGE_DRIVER --bip=172.19.42.1/16 --insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 --insecure-registry 100.64.0.0/10 &
 DOCKER_PID=$!
 
 # wait for docker to start

--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -80,7 +80,7 @@ write_files:
   - path: /etc/systemd/system/docker.service.d/50-insecure-registry.conf
     content: |
         [Service]
-        Environment="DOCKER_OPTS=--insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16"
+        Environment="DOCKER_OPTS=--insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 --insecure-registry 100.64.0.0/10"
   - path: /run/deis/bin/get_image
     permissions: '0755'
     content: |


### PR DESCRIPTION
An additional address range, 100.64.0.0/10, is reserved by RFC 6598.
This is also the private address space used by Azure, so this will
also allow us to support Azure without building a custom builder
component just for Azure, which was the previously-planned approach.

refs #2824