### PR TITLE
chore(controller): bump django-rest-framework to 3.0.3

### DIFF
--- a/controller/api/authentication.py
+++ b/controller/api/authentication.py
@@ -1,0 +1,11 @@
+from django.contrib.auth.models import AnonymousUser
+from rest_framework import authentication
+
+
+class AnonymousAuthentication(authentication.BaseAuthentication):
+
+    def authenticate(self, request):
+        """
+        Authenticate the request for anyone!
+        """
+        return AnonymousUser(), None

--- a/controller/api/tests/test_app.py
+++ b/controller/api/tests/test_app.py
@@ -51,8 +51,6 @@ class AppTest(TestCase):
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']  # noqa
         self.assertIn('id', response.data)
-        self.assertIn('url', response.data)
-        self.assertEqual(response.data['url'], '{app_id}.deisapp.local'.format(**locals()))
         response = self.client.get('/v1/apps',
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
@@ -69,6 +67,22 @@ class AppTest(TestCase):
                                       HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 204)
 
+    def test_response_data(self):
+        """Test that the serialized response contains only relevant data."""
+        body = {'id': 'test'}
+        response = self.client.post('/v1/apps', json.dumps(body),
+                                    content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        for key in response.data.keys():
+            self.assertIn(key, ['uuid', 'created', 'updated', 'id', 'owner', 'url', 'structure'])
+        expected = {
+            'id': 'test',
+            'owner': self.user.username,
+            'url': 'test.deisapp.local',
+            'structure': {}
+        }
+        self.assertDictContainsSubset(expected, response.data)
+
     def test_app_override_id(self):
         body = {'id': 'myid'}
         response = self.client.post('/v1/apps', json.dumps(body),
@@ -79,7 +93,7 @@ class AppTest(TestCase):
         response = self.client.post('/v1/apps', json.dumps(body),
                                     content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
-        self.assertContains(response, 'App with this Id already exists.', status_code=400)
+        self.assertContains(response, 'This field must be unique.', status_code=400)
         return response
 
     def test_app_actions(self):
@@ -139,7 +153,7 @@ class AppTest(TestCase):
         body = {'id': 'deis'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
-        self.assertContains(response, "App IDs cannot be 'deis'", status_code=400)
+        self.assertContains(response, 'deis is a reserved name.', status_code=400)
         body = {'id': app_id}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))

--- a/controller/api/tests/test_auth.py
+++ b/controller/api/tests/test_auth.py
@@ -42,14 +42,20 @@ class AuthTest(TestCase):
         url = '/v1/auth/register'
         response = self.client.post(url, json.dumps(submit), content_type='application/json')
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data['username'], username)
-        self.assertNotIn('password', response.data)
-        self.assertEqual(response.data['email'], email)
-        self.assertEqual(response.data['first_name'], first_name)
-        self.assertEqual(response.data['last_name'], last_name)
-        self.assertTrue(response.data['is_active'])
-        self.assertFalse(response.data['is_superuser'])
-        self.assertFalse(response.data['is_staff'])
+        for key in response.data.keys():
+            self.assertIn(key, ['id', 'last_login', 'is_superuser', 'username', 'first_name',
+                                'last_name', 'email', 'is_active', 'is_superuser', 'is_staff',
+                                'date_joined', 'groups', 'user_permissions'])
+        expected = {
+            'username': username,
+            'email': email,
+            'first_name': first_name,
+            'last_name': last_name,
+            'is_active': True,
+            'is_superuser': False,
+            'is_staff': False
+        }
+        self.assertDictContainsSubset(expected, response.data)
         # test login
         url = '/v1/auth/login/'
         payload = urllib.urlencode({'username': username, 'password': password})

--- a/controller/api/tests/test_domain.py
+++ b/controller/api/tests/test_domain.py
@@ -27,6 +27,25 @@ class DomainTest(TestCase):
         self.assertEqual(response.status_code, 201)
         self.app_id = response.data['id']  # noqa
 
+    def test_response_data(self):
+        """Test that the serialized response contains only relevant data."""
+        body = {'id': 'test'}
+        response = self.client.post('/v1/apps', json.dumps(body),
+                                    content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        body = {'domain': 'test-domain.example.com'}
+        response = self.client.post('/v1/apps/test/domains', json.dumps(body),
+                                    content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        for key in response.data.keys():
+            self.assertIn(key, ['uuid', 'owner', 'created', 'updated', 'app', 'domain'])
+        expected = {
+            'owner': self.user.username,
+            'app': 'test',
+            'domain': 'test-domain.example.com'
+        }
+        self.assertDictContainsSubset(expected, response.data)
+
     def test_manage_domain(self):
         url = '/v1/apps/{app_id}/domains'.format(app_id=self.app_id)
         body = {'domain': 'test-domain.example.com'}

--- a/controller/api/urls.py
+++ b/controller/api/urls.py
@@ -1,12 +1,9 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.conf.urls import include
-from django.conf.urls import patterns
-from django.conf.urls import url
+from django.conf.urls import include, patterns, url
 
-from api import routers
-from api import views
+from api import routers, views
 
 
 router = routers.ApiRouter()
@@ -17,25 +14,25 @@ urlpatterns = patterns(
     url(r'^', include(router.urls)),
     # application release components
     url(r'^apps/(?P<id>{})/config/?'.format(settings.APP_URL_REGEX),
-        views.AppConfigViewSet.as_view({'get': 'retrieve', 'post': 'create'})),
+        views.ConfigViewSet.as_view({'get': 'retrieve', 'post': 'create'})),
     url(r'^apps/(?P<id>{})/builds/(?P<uuid>[-_\w]+)/?'.format(settings.APP_URL_REGEX),
-        views.AppBuildViewSet.as_view({'get': 'retrieve'})),
+        views.BuildViewSet.as_view({'get': 'retrieve'})),
     url(r'^apps/(?P<id>{})/builds/?'.format(settings.APP_URL_REGEX),
-        views.AppBuildViewSet.as_view({'get': 'list', 'post': 'create'})),
+        views.BuildViewSet.as_view({'get': 'list', 'post': 'create'})),
     url(r'^apps/(?P<id>{})/releases/v(?P<version>[0-9]+)/?'.format(settings.APP_URL_REGEX),
-        views.AppReleaseViewSet.as_view({'get': 'retrieve'})),
+        views.ReleaseViewSet.as_view({'get': 'retrieve'})),
     url(r'^apps/(?P<id>{})/releases/rollback/?'.format(settings.APP_URL_REGEX),
-        views.AppReleaseViewSet.as_view({'post': 'rollback'})),
+        views.ReleaseViewSet.as_view({'post': 'rollback'})),
     url(r'^apps/(?P<id>{})/releases/?'.format(settings.APP_URL_REGEX),
-        views.AppReleaseViewSet.as_view({'get': 'list'})),
+        views.ReleaseViewSet.as_view({'get': 'list'})),
     # application infrastructure
     url(r'^apps/(?P<id>{})/containers/(?P<type>[-_\w]+)/(?P<num>[-_\w]+)/?'.format(
         settings.APP_URL_REGEX),
-        views.AppContainerViewSet.as_view({'get': 'retrieve'})),
+        views.ContainerViewSet.as_view({'get': 'retrieve'})),
     url(r'^apps/(?P<id>{})/containers/(?P<type>[-_\w.]+)/?'.format(settings.APP_URL_REGEX),
-        views.AppContainerViewSet.as_view({'get': 'list'})),
+        views.ContainerViewSet.as_view({'get': 'list'})),
     url(r'^apps/(?P<id>{})/containers/?'.format(settings.APP_URL_REGEX),
-        views.AppContainerViewSet.as_view({'get': 'list'})),
+        views.ContainerViewSet.as_view({'get': 'list'})),
     # application domains
     url(r'^apps/(?P<id>{})/domains/(?P<domain>[-\._\w]+)/?'.format(settings.APP_URL_REGEX),
         views.DomainViewSet.as_view({'delete': 'destroy'})),
@@ -73,11 +70,11 @@ urlpatterns = patterns(
         views.ConfigHookViewSet.as_view({'post': 'create'})),
     # authn / authz
     url(r'^auth/register/?',
-        views.UserRegistrationView.as_view({'post': 'create'})),
+        views.UserRegistrationViewSet.as_view({'post': 'create'})),
     url(r'^auth/cancel/?',
-        views.UserManagementView.as_view({'delete': 'destroy'})),
+        views.UserManagementViewSet.as_view({'delete': 'destroy'})),
     url(r'^auth/passwd/?',
-        views.UserManagementView.as_view({'post': 'passwd'})),
+        views.UserManagementViewSet.as_view({'post': 'passwd'})),
     url(r'^auth/login/',
         'rest_framework.authtoken.views.obtain_auth_token'),
     # admin sharing

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -2,176 +2,117 @@
 RESTful view classes for presenting Deis API objects.
 """
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ValidationError
-from django.utils import timezone
-from guardian.shortcuts import assign_perm
-from guardian.shortcuts import get_objects_for_user
-from guardian.shortcuts import get_users_with_perms
-from guardian.shortcuts import remove_perm
-from rest_framework import permissions
-from rest_framework import status
-from rest_framework import viewsets
-from rest_framework.authentication import BaseAuthentication
+from django.contrib.auth.models import User
+from django.shortcuts import get_object_or_404
+from guardian.shortcuts import assign_perm, get_objects_for_user, \
+    get_users_with_perms, remove_perm
+from rest_framework import mixins, renderers, status
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
 
-from api import models, serializers
-from api.permissions import IsAnonymous, IsOwner, IsAppUser, \
-    IsAdmin, HasRegistrationAuth, HasBuilderAuth
-
-
-class AnonymousAuthentication(BaseAuthentication):
-
-    def authenticate(self, request):
-        """
-        Authenticate the request and return a two-tuple of (user, token).
-        """
-        user = AnonymousUser()
-        return user, None
+from api import authentication, models, permissions, serializers, viewsets
 
 
-class UserRegistrationView(viewsets.GenericViewSet,
-                           viewsets.mixins.CreateModelMixin):
-    model = User
-
-    authentication_classes = (AnonymousAuthentication,)
-    permission_classes = (IsAnonymous, HasRegistrationAuth)
+class UserRegistrationViewSet(GenericViewSet,
+                              mixins.CreateModelMixin):
+    """ViewSet to handle registering new users. The logic is in the serializer."""
+    authentication_classes = [authentication.AnonymousAuthentication]
+    permission_classes = [permissions.IsAnonymous, permissions.HasRegistrationAuth]
     serializer_class = serializers.UserSerializer
 
-    def pre_save(self, obj):
-        """Replicate UserManager.create_user functionality."""
-        now = timezone.now()
-        obj.last_login = now
-        obj.date_joined = now
-        obj.is_active = True
-        obj.email = User.objects.normalize_email(obj.email)
-        obj.set_password(obj.password)
-        # Make this first signup an admin / superuser
-        if not User.objects.filter(is_superuser=True).exists():
-            obj.is_superuser = obj.is_staff = True
 
+class UserManagementViewSet(GenericViewSet,
+                            mixins.DestroyModelMixin):
+    serializer_class = serializers.UserSerializer
 
-class UserManagementView(viewsets.GenericViewSet,
-                         viewsets.mixins.CreateModelMixin,
-                         viewsets.mixins.DestroyModelMixin):
-    model = User
-    permission_classes = (permissions.IsAuthenticated,)
+    def get_queryset(self):
+        return User.objects.filter(pk=self.request.user.pk)
 
-    def passwd(self, request, *args, **kwargs):
-        obj = self.request.user
+    def get_object(self):
+        return self.get_queryset()[0]
+
+    def passwd(self, request, **kwargs):
+        obj = self.get_object()
         if not obj.check_password(request.DATA['password']):
             return Response("Current password did not match", status=status.HTTP_400_BAD_REQUEST)
         obj.set_password(request.DATA['new_password'])
         obj.save()
         return Response({'status': 'password set'})
 
-    def destroy(self, request, *args, **kwargs):
-        obj = self.request.user
-        obj.delete()
-        return Response(status=status.HTTP_204_NO_CONTENT)
+
+class BaseDeisViewSet(viewsets.OwnerViewSet):
+    """
+    A generic ViewSet for objects related to Deis.
+
+    To use it, at minimum you'll need to provide the `serializer_class` attribute and
+    the `model` attribute shortcut.
+    """
+    lookup_field = 'id'
+    permission_classes = [IsAuthenticated, permissions.IsAppUser]
+    renderer_classes = [renderers.JSONRenderer]
+
+    def create(self, request, *args, **kwargs):
+        try:
+            return super(BaseDeisViewSet, self).create(request, *args, **kwargs)
+        # If the scheduler oopsie'd
+        except RuntimeError as e:
+            return Response(str(e), status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
 
-class OwnerViewSet(viewsets.ModelViewSet):
-    """Scope views to an `owner` attribute."""
+class AppResourceViewSet(BaseDeisViewSet):
+    """A viewset for objects which are attached to an application."""
 
-    permission_classes = (permissions.IsAuthenticated, IsOwner)
-
-    def pre_save(self, obj):
-        obj.owner = self.request.user
-
-    def get_queryset(self, **kwargs):
-        """Filter all querysets by an `owner` attribute.
-        """
-        return self.model.objects.filter(owner=self.request.user)
-
-
-class AppPermsViewSet(viewsets.ViewSet):
-    """RESTful views for sharing apps with collaborators."""
-
-    model = models.App  # models class
-    perm = 'use_app'    # short name for permission
-
-    def list(self, request, **kwargs):
-        app = get_object_or_404(self.model, id=kwargs['id'])
-        perm_name = "api.{}".format(self.perm)
-        if request.user != app.owner and \
-                not request.user.has_perm(perm_name, app) and \
-                not request.user.is_superuser:
-            return Response(status=status.HTTP_403_FORBIDDEN)
-        usernames = [u.username for u in get_users_with_perms(app)
-                     if u.has_perm(perm_name, app)]
-        return Response({'users': usernames})
-
-    def create(self, request, **kwargs):
-        app = get_object_or_404(self.model, id=kwargs['id'])
-        if request.user != app.owner and not request.user.is_superuser:
-            return Response(status=status.HTTP_403_FORBIDDEN)
-        user = get_object_or_404(User, username=request.DATA['username'])
-        assign_perm(self.perm, user, app)
-        models.log_event(app, "User {} was granted access to {}".format(user, app))
-        return Response(status=status.HTTP_201_CREATED)
-
-    def destroy(self, request, **kwargs):
-        app = get_object_or_404(self.model, id=kwargs['id'])
-        if request.user != app.owner and not request.user.is_superuser:
-            return Response(status=status.HTTP_403_FORBIDDEN)
-        user = get_object_or_404(User, username=kwargs['username'])
-        if user.has_perm(self.perm, app):
-            remove_perm(self.perm, user, app)
-            models.log_event(app, "User {} was revoked access to {}".format(user, app))
-            return Response(status=status.HTTP_204_NO_CONTENT)
-        else:
-            return Response(status=status.HTTP_403_FORBIDDEN)
-
-
-class AdminPermsViewSet(viewsets.ModelViewSet):
-    """RESTful views for sharing admin permissions with other users."""
-
-    model = User
-    serializer_class = serializers.AdminUserSerializer
-    permission_classes = (IsAdmin,)
+    def get_app(self):
+        app = get_object_or_404(models.App, id=self.kwargs['id'])
+        self.check_object_permissions(self.request, app)
+        return app
 
     def get_queryset(self, **kwargs):
-        self.check_object_permissions(self.request, self.request.user)
-        return self.model.objects.filter(is_active=True, is_superuser=True)
+        app = self.get_app()
+        return self.model.objects.filter(app=app)
+
+    def get_object(self, **kwargs):
+        return self.get_queryset(**kwargs).latest('created')
 
     def create(self, request, **kwargs):
-        user = get_object_or_404(User, username=request.DATA['username'])
-        user.is_superuser = user.is_staff = True
-        user.save(update_fields=['is_superuser', 'is_staff'])
-        return Response(status=status.HTTP_201_CREATED)
-
-    def destroy(self, request, **kwargs):
-        user = get_object_or_404(User, username=kwargs['username'])
-        user.is_superuser = user.is_staff = False
-        user.save(update_fields=['is_superuser', 'is_staff'])
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        request.DATA['app'] = self.get_app()
+        return super(AppResourceViewSet, self).create(request, **kwargs)
 
 
-class AppViewSet(OwnerViewSet):
-    """RESTful views for :class:`~api.models.App`."""
+class ReleasableViewSet(AppResourceViewSet):
+    """A viewset for application resources which affect the release cycle.
 
+    When a resource is created, a new release is created for the application
+    and it returns some success headers regarding the new release.
+
+    To use it, at minimum you'll need to provide a `release` attribute tied to your class before
+    calling post_save().
+    """
+    def get_object(self):
+        """Retrieve the object based on the latest release's value"""
+        return getattr(self.get_app().release_set.latest(), self.model.__name__.lower())
+
+    def get_success_headers(self, data, **kwargs):
+        headers = super(ReleasableViewSet, self).get_success_headers(data)
+        headers.update({'X-Deis-Release': self.release.version})
+        return headers
+
+
+class AppViewSet(BaseDeisViewSet):
+    """A viewset for interacting with App objects."""
     model = models.App
     serializer_class = serializers.AppSerializer
-    lookup_field = 'id'
-    permission_classes = (permissions.IsAuthenticated, IsAppUser)
 
     def get_queryset(self, **kwargs):
-        """
-        Filter Apps by `owner` attribute or the `api.use_app` permission.
-        """
         return super(AppViewSet, self).get_queryset(**kwargs) | \
             get_objects_for_user(self.request.user, 'api.use_app')
 
-    def post_save(self, app, created=False, **kwargs):
-        if created:
-            app.create()
+    def post_save(self, app):
+        app.create()
 
     def scale(self, request, **kwargs):
         new_structure = {}
@@ -215,131 +156,79 @@ class AppViewSet(OwnerViewSet):
         return Response(output_and_rc, status=status.HTTP_200_OK,
                         content_type='text/plain')
 
-    def destroy(self, request, **kwargs):
-        obj = self.get_object()
-        obj.delete()
-        return Response(status=status.HTTP_204_NO_CONTENT)
 
-
-class BaseAppViewSet(viewsets.ModelViewSet):
-
-    permission_classes = (permissions.IsAuthenticated, IsAppUser)
-
-    def pre_save(self, obj):
-        obj.owner = self.request.user
-
-    def get_queryset(self, **kwargs):
-        app = get_object_or_404(models.App, id=self.kwargs['id'])
-        self.check_object_permissions(self.request, app)
-        return self.model.objects.filter(app=app)
-
-    def get_object(self, *args, **kwargs):
-        obj = self.get_queryset().latest('created')
-        self.check_object_permissions(self.request, obj)
-        return obj
-
-
-class AppBuildViewSet(BaseAppViewSet):
-    """RESTful views for :class:`~api.models.Build`."""
-
+class BuildViewSet(ReleasableViewSet):
+    """A viewset for interacting with Build objects."""
     model = models.Build
     serializer_class = serializers.BuildSerializer
 
-    def post_save(self, build, created=False):
-        if created:
-            self.release = build.create(self.request.user)
-
-    def get_success_headers(self, data):
-        headers = super(AppBuildViewSet, self).get_success_headers(data)
-        headers.update({'X-Deis-Release': self.release.version})
-        return headers
-
-    def create(self, request, *args, **kwargs):
-        app = get_object_or_404(models.App, id=self.kwargs['id'])
-        self.check_object_permissions(self.request, app)
-        request._data = request.DATA.copy()
-        request.DATA['app'] = app
-        try:
-            return super(AppBuildViewSet, self).create(request, *args, **kwargs)
-        except RuntimeError as e:
-            return Response(str(e), status=status.HTTP_503_SERVICE_UNAVAILABLE)
+    def post_save(self, build):
+        self.release = build.create(self.request.user)
+        super(BuildViewSet, self).post_save(build)
 
 
-class AppConfigViewSet(BaseAppViewSet):
-    """RESTful views for :class:`~api.models.Config`."""
-
+class ConfigViewSet(ReleasableViewSet):
+    """A viewset for interacting with Config objects."""
     model = models.Config
     serializer_class = serializers.ConfigSerializer
 
-    def get_object(self, *args, **kwargs):
-        """Return the Config associated with the App's latest Release."""
-        app = get_object_or_404(models.App, id=self.kwargs['id'])
-        self.check_object_permissions(self.request, app)
-        return app.release_set.latest().config
-
-    def pre_save(self, config):
-        """merge the old config with the new"""
-        previous_config = config.app.config_set.latest()
-        config.owner = self.request.user
-        if previous_config:
-            for attr in ['cpu', 'memory', 'tags', 'values']:
-                # Guard against migrations from older apps without fixes to
-                # JSONField encoding.
-                try:
-                    data = getattr(previous_config, attr).copy()
-                except AttributeError:
-                    data = {}
-                try:
-                    new_data = getattr(config, attr).copy()
-                except AttributeError:
-                    new_data = {}
-                data.update(new_data)
-                # remove config keys if we provided a null value
-                [data.pop(k) for k, v in new_data.items() if v is None]
-                setattr(config, attr, data)
-
-    def post_save(self, config, created=False):
-        if created:
-            release = config.app.release_set.latest()
-            self.release = release.new(self.request.user, config=config, build=release.build)
-            try:
-                config.app.deploy(self.request.user, self.release)
-            except RuntimeError:
-                self.release.delete()
-                raise
-
-    def get_success_headers(self, data):
-        headers = super(AppConfigViewSet, self).get_success_headers(data)
-        headers.update({'X-Deis-Release': self.release.version})
-        return headers
-
-    def create(self, request, *args, **kwargs):
-        obj = self.get_object()
-        request.DATA['app'] = obj.app
+    def post_save(self, config):
+        release = config.app.release_set.latest()
+        self.release = release.new(self.request.user, config=config, build=release.build)
         try:
-            return super(AppConfigViewSet, self).create(request, *args, **kwargs)
-        except RuntimeError as e:
-            return Response(str(e), status=status.HTTP_503_SERVICE_UNAVAILABLE)
+            config.app.deploy(self.request.user, self.release)
+        except RuntimeError:
+            self.release.delete()
+            raise
 
 
-class AppReleaseViewSet(BaseAppViewSet):
-    """RESTful views for :class:`~api.models.Release`."""
+class ContainerViewSet(AppResourceViewSet):
+    """A viewset for interacting with Container objects."""
+    model = models.Container
+    serializer_class = serializers.ContainerSerializer
 
+    def get_queryset(self, **kwargs):
+        qs = super(ContainerViewSet, self).get_queryset(**kwargs)
+        container_type = self.kwargs.get('type')
+        if container_type:
+            qs = qs.filter(type=container_type)
+        else:
+            qs = qs.exclude(type='run')
+        return qs
+
+    def get_object(self, **kwargs):
+        qs = self.get_queryset(**kwargs)
+        return qs.get(num=self.kwargs['num'])
+
+
+class DomainViewSet(AppResourceViewSet):
+    """A viewset for interacting with Domain objects."""
+    model = models.Domain
+    serializer_class = serializers.DomainSerializer
+
+
+class KeyViewSet(BaseDeisViewSet):
+    """A viewset for interacting with Key objects."""
+    model = models.Key
+    serializer_class = serializers.KeySerializer
+
+
+class ReleaseViewSet(AppResourceViewSet):
+    """A viewset for interacting with Release objects."""
     model = models.Release
     serializer_class = serializers.ReleaseSerializer
 
-    def get_object(self, *args, **kwargs):
-        """Get Release by version always."""
+    def get_object(self, **kwargs):
+        """Get release by version always"""
         return self.get_queryset(**kwargs).get(version=self.kwargs['version'])
 
-    def rollback(self, request, *args, **kwargs):
+    def rollback(self, request, **kwargs):
         """
-        Create a new release as a copy of the state of the compiled slug and
-        config vars of a previous release.
+        Create a new release as a copy of the state of the compiled slug and config vars of a
+        previous release.
         """
         try:
-            app = get_object_or_404(models.App, id=self.kwargs['id'])
-            self.check_object_permissions(self.request, app)
+            app = self.get_app()
             release = app.release_set.latest()
             version_to_rollback_to = release.version - 1
             if request.DATA.get('version'):
@@ -349,136 +238,74 @@ class AppReleaseViewSet(BaseAppViewSet):
             return Response(response, status=status.HTTP_201_CREATED)
         except EnvironmentError as e:
             return Response(str(e), status=status.HTTP_400_BAD_REQUEST)
-        except RuntimeError as e:
+        except RuntimeError:
             new_release.delete()
-            return Response(str(e), status=status.HTTP_503_SERVICE_UNAVAILABLE)
+            raise
 
 
-class AppContainerViewSet(BaseAppViewSet):
-    """RESTful views for :class:`~api.models.Container`."""
-
-    model = models.Container
-    serializer_class = serializers.ContainerSerializer
-
-    def get_queryset(self, **kwargs):
-        qs = super(AppContainerViewSet, self).get_queryset(**kwargs)
-        container_type = self.kwargs.get('type')
-        if container_type:
-            qs = qs.filter(type=container_type)
-        else:
-            qs = qs.exclude(type='run')
-        return qs
-
-    def get_object(self, *args, **kwargs):
-        qs = self.get_queryset(**kwargs)
-        obj = qs.get(num=self.kwargs['num'])
-        return obj
-
-
-class KeyViewSet(OwnerViewSet):
-    """RESTful views for :class:`~api.models.Key`."""
-
-    model = models.Key
-    serializer_class = serializers.KeySerializer
-    lookup_field = 'id'
-
-
-class DomainViewSet(OwnerViewSet):
-    """RESTful views for :class:`~api.models.Domain`."""
-
-    model = models.Domain
-    serializer_class = serializers.DomainSerializer
-
-    def create(self, request, *args, **kwargs):
-        app = get_object_or_404(models.App, id=self.kwargs['id'])
-        self.check_object_permissions(self.request, app)
-        request._data = request.DATA.copy()
-        request.DATA['app'] = app
-        return super(DomainViewSet, self).create(request, *args, **kwargs)
-
-    def get_queryset(self, **kwargs):
-        app = get_object_or_404(models.App, id=self.kwargs['id'])
-        self.check_object_permissions(self.request, app)
-        return self.model.objects.filter(app=app)
-
-    def get_object(self, *args, **kwargs):
-        qs = self.get_queryset(**kwargs)
-        obj = qs.get(domain=self.kwargs['domain'])
-        return obj
-
-
-class BaseHookViewSet(viewsets.ModelViewSet):
-
-    permission_classes = (HasBuilderAuth,)
-
-    def pre_save(self, obj):
-        # SECURITY: we trust the username field to map to the owner
-        obj.owner = self.request.DATA['owner']
+class BaseHookViewSet(BaseDeisViewSet):
+    permission_classes = [permissions.HasBuilderAuth]
 
 
 class PushHookViewSet(BaseHookViewSet):
     """API hook to create new :class:`~api.models.Push`"""
-
     model = models.Push
     serializer_class = serializers.PushSerializer
 
     def create(self, request, *args, **kwargs):
-        app = get_object_or_404(models.App, id=request.DATA['receive_repo'])
-        user = get_object_or_404(
-            User, username=request.DATA['receive_user'])
-        # check the user is authorized for this app
-        if user == app.owner or \
-           user in get_users_with_perms(app) or \
-           user.is_superuser:
-            request._data = request.DATA.copy()
-            request.DATA['app'] = app
-            request.DATA['owner'] = user
-            return super(PushHookViewSet, self).create(request, *args, **kwargs)
-        raise PermissionDenied()
-
-
-class BuildHookViewSet(BaseHookViewSet):
-    """API hook to create new :class:`~api.models.Build`"""
-
-    model = models.Build
-    serializer_class = serializers.BuildSerializer
-
-    def create(self, request, *args, **kwargs):
-        app = get_object_or_404(models.App, id=request.DATA['receive_repo'])
-        self.user = get_object_or_404(
-            User, username=request.DATA['receive_user'])
+        app = get_object_or_404(models.App, id=request.data['receive_repo'])
+        self.user = get_object_or_404(User, username=request.data['receive_user'])
         # check the user is authorized for this app
         if self.user == app.owner or \
            self.user in get_users_with_perms(app) or \
            self.user.is_superuser:
-            request._data = request.DATA.copy()
-            request.DATA['app'] = app
-            request.DATA['owner'] = self.user
-            try:
-                super(BuildHookViewSet, self).create(request, *args, **kwargs)
-                # return the application databag
-                response = {'release': {'version': app.release_set.latest().version},
-                            'domains': ['.'.join([app.id, settings.DEIS_DOMAIN])]}
-                return Response(response, status=status.HTTP_200_OK)
-            except RuntimeError as e:
-                return Response(str(e), status=status.HTTP_503_SERVICE_UNAVAILABLE)
+                request.data['app'] = app
+                request.data['owner'] = self.user
+                return super(PushHookViewSet, self).create(request, *args, **kwargs)
         raise PermissionDenied()
 
-    def post_save(self, build, created=False):
-        if created:
-            build.create(self.user)
+    def perform_create(self, serializer, **kwargs):
+        serializer.save(owner=self.user)
+
+
+class BuildHookViewSet(BaseHookViewSet):
+    """API hook to create new :class:`~api.models.Build`"""
+    model = models.Build
+    serializer_class = serializers.BuildSerializer
+
+    def create(self, request, *args, **kwargs):
+        app = get_object_or_404(models.App, id=request.data['receive_repo'])
+        self.user = get_object_or_404(User, username=request.data['receive_user'])
+        # check the user is authorized for this app
+        if self.user == app.owner or \
+           self.user in get_users_with_perms(app) or \
+           self.user.is_superuser:
+            request._data = request.data.copy()
+            request.data['app'] = app
+            request.data['owner'] = self.user
+            super(BuildHookViewSet, self).create(request, *args, **kwargs)
+            # return the application databag
+            response = {'release': {'version': app.release_set.latest().version},
+                        'domains': ['.'.join([app.id, settings.DEIS_DOMAIN])]}
+            return Response(response, status=status.HTTP_200_OK)
+        raise PermissionDenied()
+
+    def perform_create(self, serializer, **kwargs):
+        build = serializer.save(owner=self.user)
+        self.post_save(build)
+
+    def post_save(self, build):
+        build.create(self.user)
 
 
 class ConfigHookViewSet(BaseHookViewSet):
     """API hook to grab latest :class:`~api.models.Config`"""
-
     model = models.Config
     serializer_class = serializers.ConfigSerializer
 
     def create(self, request, *args, **kwargs):
         app = get_object_or_404(models.App, id=request.DATA['receive_repo'])
-        user = get_object_or_404(
-            User, username=request.DATA['receive_user'])
+        user = get_object_or_404(User, username=request.DATA['receive_user'])
         # check the user is authorized for this app
         if user == app.owner or \
            user in get_users_with_perms(app) or \
@@ -487,3 +314,66 @@ class ConfigHookViewSet(BaseHookViewSet):
             serializer = self.get_serializer(config)
             return Response(serializer.data, status=status.HTTP_200_OK)
         raise PermissionDenied()
+
+
+class AppPermsViewSet(BaseDeisViewSet):
+    """RESTful views for sharing apps with collaborators."""
+
+    model = models.App  # models class
+    perm = 'use_app'    # short name for permission
+
+    def list(self, request, **kwargs):
+        app = get_object_or_404(self.model, id=kwargs['id'])
+        perm_name = "api.{}".format(self.perm)
+        if request.user != app.owner and \
+                not request.user.has_perm(perm_name, app) and \
+                not request.user.is_superuser:
+            return Response(status=status.HTTP_403_FORBIDDEN)
+        usernames = [u.username for u in get_users_with_perms(app)
+                     if u.has_perm(perm_name, app)]
+        return Response({'users': usernames})
+
+    def create(self, request, **kwargs):
+        app = get_object_or_404(self.model, id=kwargs['id'])
+        if request.user != app.owner and not request.user.is_superuser:
+            return Response(status=status.HTTP_403_FORBIDDEN)
+        user = get_object_or_404(User, username=request.DATA['username'])
+        assign_perm(self.perm, user, app)
+        models.log_event(app, "User {} was granted access to {}".format(user, app))
+        return Response(status=status.HTTP_201_CREATED)
+
+    def destroy(self, request, **kwargs):
+        app = get_object_or_404(self.model, id=kwargs['id'])
+        if request.user != app.owner and not request.user.is_superuser:
+            return Response(status=status.HTTP_403_FORBIDDEN)
+        user = get_object_or_404(User, username=kwargs['username'])
+        if user.has_perm(self.perm, app):
+            remove_perm(self.perm, user, app)
+            models.log_event(app, "User {} was revoked access to {}".format(user, app))
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        else:
+            return Response(status=status.HTTP_403_FORBIDDEN)
+
+
+class AdminPermsViewSet(BaseDeisViewSet):
+    """RESTful views for sharing admin permissions with other users."""
+
+    model = User
+    serializer_class = serializers.AdminUserSerializer
+    permission_classes = (permissions.IsAdmin,)
+
+    def get_queryset(self, **kwargs):
+        self.check_object_permissions(self.request, self.request.user)
+        return self.model.objects.filter(is_active=True, is_superuser=True)
+
+    def create(self, request, **kwargs):
+        user = get_object_or_404(User, username=request.DATA['username'])
+        user.is_superuser = user.is_staff = True
+        user.save(update_fields=['is_superuser', 'is_staff'])
+        return Response(status=status.HTTP_201_CREATED)
+
+    def destroy(self, request, **kwargs):
+        user = get_object_or_404(User, username=kwargs['username'])
+        user.is_superuser = user.is_staff = False
+        user.save(update_fields=['is_superuser', 'is_staff'])
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/controller/api/viewsets.py
+++ b/controller/api/viewsets.py
@@ -1,0 +1,28 @@
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
+
+from api import permissions
+
+
+class OwnerViewSet(viewsets.ModelViewSet):
+    """
+    A simple ViewSet for objects filtered by their 'owner' attribute.
+
+    To use it, at minimum you'll need to provide the `serializer_class` attribute and
+    the `model` attribute shortcut.
+    """
+    permission_classes = [IsAuthenticated, permissions.IsOwner]
+
+    def get_queryset(self):
+        return self.model.objects.filter(owner=self.request.user)
+
+    def perform_create(self, serializer):
+        obj = serializer.save(owner=self.request.user)
+        self.post_save(obj)
+
+    def post_save(self, obj):
+        """A post_save hook for performing actions after the object has been pushed to the
+        database.
+
+        Leave it up to child classes to implement."""
+        pass

--- a/controller/deis/settings.py
+++ b/controller/deis/settings.py
@@ -183,7 +183,11 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.TokenAuthentication',
     ),
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+    ),
     'PAGINATE_BY': 100,
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 
 # URLs that end with slashes are ugly

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -9,7 +9,7 @@ git+https://github.com/deis/django-fsm@propagate-false
 django-cors-headers==1.0.0
 django-guardian==1.2.4
 django-json-field==0.5.7
-djangorestframework==2.4.4
+djangorestframework==3.0.3
 docker-py==0.6.0
 gunicorn==19.1.1
 paramiko==1.15.2

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -13,7 +13,7 @@ git+https://github.com/deis/django-fsm@propagate-false
 django-cors-headers==1.0.0
 django-guardian==1.2.4
 django-json-field==0.5.7
-djangorestframework==2.4.4
+djangorestframework==3.0.3
 docker-py==0.6.0
 gunicorn==19.1.1
 paramiko==1.15.2

--- a/tests/apps_test.go
+++ b/tests/apps_test.go
@@ -62,7 +62,7 @@ func appsCreateTest(t *testing.T, params *utils.DeisTestConfig) {
 	utils.Execute(t, appsCreateCmdBuildpack, params, false, "BUILDPACK_URL")
 	utils.Execute(t, appsDestroyCmdNoApp, params, false, "")
 	utils.Execute(t, appsCreateCmd, params, false, "")
-	utils.Execute(t, appsCreateCmd, params, true, "App with this Id already exists")
+	utils.Execute(t, appsCreateCmd, params, true, "This field must be unique.")
 }
 
 func appsDestroyTest(t *testing.T, params *utils.DeisTestConfig) {

--- a/tests/keys_test.go
+++ b/tests/keys_test.go
@@ -34,7 +34,7 @@ func keysAddTest(t *testing.T, params *utils.DeisTestConfig) {
 	params.AuthKey = "deiskey"
 	utils.Execute(t, keysAddCmd, params, false, "")
 	utils.Execute(t, keysAddCmd, params, true,
-		"SSH Key with this Public already exists")
+		"This field must be unique")
 }
 
 func keysListTest(t *testing.T, params *utils.DeisTestConfig, notflag bool) {


### PR DESCRIPTION
this is the beginning of #2854. Considering that bumping to DRF 3.0.3 broke a lot of old functionality, I wanted to mainly focus on bumping DRF before completely refactoring so there's less to review.

TODO:

 - [x] add unit tests to ensure the serialized response for all objects stays the same