### PR TITLE
chore(*): bump CoreOS to 522.5.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
 
   config.vm.box = "coreos-%s" % $update_channel
-  config.vm.box_version = ">= 494.5.0"
+  config.vm.box_version = ">= 522.5.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
 
   config.vm.provider :virtualbox do |vb, override|

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -89,15 +89,15 @@
 
   "Mappings" : {
     "CoreOSAMIs" : {
-      "eu-central-1"   : { "PV" : "ami-4e7d4d53", "HVM" : "ami-487d4d55" },
-      "ap-northeast-1" : { "PV" : "ami-dccfc0dd", "HVM" : "ami-decfc0df" },
-      "sa-east-1"      : { "PV" : "ami-c904b4d4", "HVM" : "ami-cb04b4d6" },
-      "ap-southeast-2" : { "PV" : "ami-d7e981ed", "HVM" : "ami-d1e981eb" },
-      "ap-southeast-1" : { "PV" : "ami-81406fd3", "HVM" : "ami-83406fd1" },
-      "us-east-1"      : { "PV" : "ami-7e5d3d16", "HVM" : "ami-705d3d18" },
-      "us-west-2"      : { "PV" : "ami-4fd4857f", "HVM" : "ami-4dd4857d" },
-      "us-west-1"      : { "PV" : "ami-15fae850", "HVM" : "ami-17fae852" },
-      "eu-west-1"      : { "PV" : "ami-7a3a840d", "HVM" : "ami-783a840f" }
+      "eu-central-1"   : { "PV" : "ami-448dbd59", "HVM" : "ami-468dbd5b" },
+      "ap-northeast-1" : { "PV" : "ami-0a05160b", "HVM" : "ami-0c05160d" },
+      "sa-east-1"      : { "PV" : "ami-27b00d3a", "HVM" : "ami-23b00d3e" },
+      "ap-southeast-2" : { "PV" : "ami-b5295c8f", "HVM" : "ami-b7295c8d" },
+      "ap-southeast-1" : { "PV" : "ami-ba0f27e8", "HVM" : "ami-b40f27e6" },
+      "us-east-1"      : { "PV" : "ami-3e750856", "HVM" : "ami-3c750854" },
+      "us-west-2"      : { "PV" : "ami-bf2d728f", "HVM" : "ami-bd2d728d" },
+      "us-west-1"      : { "PV" : "ami-8f534dca", "HVM" : "ami-8d534dc8" },
+      "eu-west-1"      : { "PV" : "ami-e76dec90", "HVM" : "ami-f96dec8e" }
 
     },
     "RootDevices" : {

--- a/contrib/rackspace/provision-rackspace-cluster.sh
+++ b/contrib/rackspace/provision-rackspace-cluster.sh
@@ -48,8 +48,9 @@ $CONTRIB_DIR/util/check-user-data.sh
 
 i=1 ; while [[ $i -le $DEIS_NUM_INSTANCES ]] ; do \
     echo_yellow "Provisioning deis-$i..."
-    # This image is CoreOS 494.5.0 in the stable channel
-    supernova $ENV boot --image 6ad64ee8-6726-4077-b051-dbaed2d47e88 --flavor $FLAVOR --key-name $1 --user-data $CONTRIB_DIR/coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
+    # This image is CoreOS 522.4.0 in the stable channel
+    # TODO Update to 522.5.0 when it's available
+    supernova $ENV boot --image 6a0489c2-1768-4883-8d75-1f2f2af58e3c --flavor $FLAVOR --key-name $1 --user-data $CONTRIB_DIR/coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
     ((i = i + 1)) ; \
 done
 

--- a/docs/installing_deis/baremetal.rst
+++ b/docs/installing_deis/baremetal.rst
@@ -99,8 +99,8 @@ Start the installation
 
 
 This will install the latest `CoreOS`_ stable release to disk. The Deis provision scripts for other
-platforms typically specify a CoreOS version - currently, ``494.5.0``. To specify a CoreOS
-version, append the ``-V`` parameter to the install command, e.g. ``-V 494.5.0``.
+platforms typically specify a CoreOS version - currently, ``522.5.0``. To specify a CoreOS
+version, append the ``-V`` parameter to the install command, e.g. ``-V 522.5.0``.
 
 After the installation has finished, reboot your server. Once your machine is back up, you should
 be able to log in as the `core` user using the `deis` ssh key.

--- a/docs/installing_deis/gce.rst
+++ b/docs/installing_deis/gce.rst
@@ -119,7 +119,7 @@ Launch 3 instances. You can choose another starting CoreOS image from the listin
 
 .. code-block:: console
 
-    $ for num in 1 2 3; do gcutil addinstance --image projects/coreos-cloud/global/images/coreos-stable-494-5-0-v20141215 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
+    $ for num in 1 2 3; do gcutil addinstance --image projects/coreos-cloud/global/images/coreos-stable-522-5-0-v20150114 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
 
     Table of resources:
 


### PR DESCRIPTION
Note that I didn't bump the minimum required CoreOS version in the
docs (as nothing in this release is mandatory), but I did bump
the Vagrantfile version so Jenkins tests the latest stable release.