### PR TITLE
docs(using_deis): add disabling registration docs to user creation

### DIFF
--- a/docs/managing_deis/operational_tasks.rst
+++ b/docs/managing_deis/operational_tasks.rst
@@ -29,6 +29,8 @@ You can use the ``deis perms`` command to promote a user to an administrator:
 
     $ deis perms:create john --admin
 
+.. _disable_user_registration:
+
 Disabling user registration
 ---------------------------
 

--- a/docs/using_deis/register-user.rst
+++ b/docs/using_deis/register-user.rst
@@ -30,7 +30,9 @@ Note that you always use ``deis.<domain>`` to communicate with the controller.
 
 .. important::
 
-    The first user to register with Deis receives "superuser" privileges.
+    The first user to register with Deis receives "superuser" privileges. Additional users who
+    register will be ordinary users. It's also possible to disable user registration after creating
+    the superuser account. For details, see :ref:`disable_user_registration`.
 
 Upload Your SSH Public Key
 --------------------------


### PR DESCRIPTION
@brynary suggested that it'd be helpful to note how to disable user registration after instructing users to create their superuser account.