### PR TITLE
Refactor deisctl config logic and add docs on Router SSL

### DIFF
--- a/deisctl/config/config_test.go
+++ b/deisctl/config/config_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+// TestConfigSSHPrivateKey ensures private keys are base64 encoded from file path
+func TestConfigSSHPrivateKey(t *testing.T) {
+
+	f, err := writeTempFile("private-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := valueForPath("/deis/platform/sshPrivateKey", f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("private-key"))
+
+	if val != encoded {
+		t.Fatalf("expected: %v, got: %v", encoded, val)
+	}
+}
+
+func TestConfigRouterKey(t *testing.T) {
+
+	f, err := writeTempFile("router-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := valueForPath("/deis/router/sslKey", f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != "router-key" {
+		t.Fatalf("expected: router-key, got: %v", val)
+	}
+
+}
+
+func TestConfigRouterCert(t *testing.T) {
+
+	f, err := writeTempFile("router-cert")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := valueForPath("/deis/router/sslCert", f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != "router-cert" {
+		t.Fatalf("expected: router-cert, got: %v", val)
+	}
+
+}
+
+func writeTempFile(data string) (*os.File, error) {
+	f, err := ioutil.TempFile("", "deisctl")
+	if err != nil {
+		return nil, err
+	}
+
+	f.Write([]byte(data))
+	defer f.Close()
+
+	return f, nil
+}

--- a/docs/managing_deis/ssl-endpoints.rst
+++ b/docs/managing_deis/ssl-endpoints.rst
@@ -69,5 +69,23 @@ See your vendor's specific instructions on installing SSL on your load balancer.
 documentation on `installing an SSL cert for load balancing`_. For Rackspace, see their
 `Product FAQ`_.
 
+Installing SSL on the Deis Routers
+----------------------------------
+
+You can also use the Deis routers to terminate SSL connections.
+Use ``deisctl`` to install the certificate and private keys:
+
+.. code-block:: console
+
+    $ deisctl config router set sslKey=<path-to-key> sslCert=<path-to-cert>
+
+If your certificate has intermediate certs that need to be presented as part of a
+certificate chain, append the intermediate certs to the bottom of the sslCert value.
+
+.. note::
+
+    To secure all endpoints on the platform domain, you must use a wildcard certificate.
+
+
 .. _`installing an SSL cert for load balancing`: http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/ssl-server-cert.html
 .. _`Product FAQ`: http://www.rackspace.com/knowledge_center/product-faq/cloud-load-balancers


### PR DESCRIPTION
This PR fixes #2712 and cleans up the config logic in `deisctl`:

 * defines `fileKeys` which are read from local files
 * defines `b64Keys` which are base64-encoded before stored (needed for `sshPrivateKey`)
 * `valueForPath` is factored out with corresponding test coverage

I've also added documentation on how to configure the Deis routers to terminate SSL.
