### PR TITLE
fix(builder): allow procfile to override default process types

### DIFF
--- a/builder/image/templates/builder
+++ b/builder/image/templates/builder
@@ -75,10 +75,6 @@ if [ -f Dockerfile ]; then
     USING_DOCKERFILE=true
 fi
 
-if [ -f Procfile ]; then
-    PROCFILE=$(cat Procfile)
-fi
-
 # pull config from controller to be used during build
 URL="{{ .deis_controller_protocol }}://{{ .deis_controller_host }}:{{ .deis_controller_port }}/v1/hooks/config"
 RESPONSE=$(/app/bin/get-app-config -url="$URL" -key="{{ .deis_controller_builderKey }}" -user=$USER -app=$APP_NAME)
@@ -139,23 +135,18 @@ puts-step "Pushing image to private registry"
 docker push $TMP_IMAGE  &>/dev/null
 echo
 
-if [ -f $TMP_DIR/slug.tgz ]; then
-    RELEASE_INFO=$(tar --to-stdout -xf $TMP_DIR/slug.tgz ./.release | /app/bin/extract-types)
+# use Procfile if provided, otherwise try default process types from ./release
+if [ -f Procfile ]; then
+    PROCFILE=$(cat Procfile | /app/bin/yaml2json-procfile)
+elif [ -f $TMP_DIR/slug.tgz ]; then
+    PROCFILE=$(tar --to-stdout -xf $TMP_DIR/slug.tgz ./.release | /app/bin/extract-types)
 else
-    RELEASE_INFO="{}"
-fi
-
-if [ "$RELEASE_INFO" == "{}" ]; then
-    if [ -f $TMP_DIR/Procfile ]; then
-        # fall back to Procfile if there's no default process types
-        # FIXME: refactor into slugbuilder
-        RELEASE_INFO=$(cat $TMP_DIR/Procfile | /app/bin/yaml2json-procfile)
-    fi
+    PROCFILE="{}"
 fi
 
 puts-step "Launching... "
 URL="{{ .deis_controller_protocol }}://{{ .deis_controller_host }}:{{ .deis_controller_port }}/v1/hooks/build"
-DATA=$(/app/bin/generate-buildhook "$SHORT_SHA" "$USER" "$APP_NAME" "$APP_NAME" "$RELEASE_INFO" "$USING_DOCKERFILE")
+DATA=$(/app/bin/generate-buildhook "$SHORT_SHA" "$USER" "$APP_NAME" "$APP_NAME" "$PROCFILE" "$USING_DOCKERFILE")
 PUBLISH_RELEASE=$(echo "$DATA" | /app/bin/publish-release-controller -url=$URL -key={{ .deis_controller_builderKey }})
 
 CODE=$?


### PR DESCRIPTION
This PR reworks the process type resolution logic in the builder.  As of @53204c1ec, it appears we stopped respecting `Procfile` as an override for default process types.  Is that right @bacongobbler?

Fixes #2874 and #2637.

```console
$ cat > Procfile <<EOF
web: bundle exec ruby web.rb -p ${PORT:-5000}
worker: bash -c "while true; do echo hi; sleep 5; done"
EOF
$ git add Procfile 
$ git commit -m 'add worker to Procfile'
[master 2a9ef52] add worker to Procfile
 1 file changed, 1 insertion(+)

$ git push deis master
...
-----> Discovering process types
       Procfile declares types -> web, worker
       Default process types for Ruby -> rake, console, web
-----> Compiled slug size is 15M
...

$ deis scale worker=1
Scaling processes... but first, coffee!
done in 31s
=== ruby Processes

--- web: 
web.1 up (v9)

--- worker: 
worker.1 up (v9)

$ deis logs | tail -n 10
2015-01-16T21:28:49UTC deis[api]: ruby: build ruby-88190dc created
2015-01-16T21:28:49UTC deis[api]: ruby: release ruby-v9 created
2015-01-16T21:28:49UTC deis[api]: gabrtv deployed 2a9ef52
2015-01-16T21:29:13UTC ruby[web.1]: [2015-01-16 21:29:13] INFO  WEBrick 1.3.1
2015-01-16T21:29:13UTC ruby[web.1]: [2015-01-16 21:29:13] INFO  ruby 1.9.3 (2014-11-13) [x86_64-linux]
2015-01-16T21:29:13UTC ruby[web.1]: == Sinatra/1.4.2 has taken the stage on 5000 for production with backup from WEBrick
2015-01-16T21:29:13UTC ruby[web.1]: [2015-01-16 21:29:13] INFO  WEBrick::HTTPServer#start: pid=1 port=5000
2015-01-16T21:29:26UTC deis[api]: ruby: gabrtv scaled containers worker=1
2015-01-16T21:29:57UTC ruby[worker.1]: hi
2015-01-16T21:30:02UTC ruby[worker.1]: hi
```