### PR TITLE
fix(store): use hostnames for mon host

### DIFF
--- a/store/base/templates/ceph.conf
+++ b/store/base/templates/ceph.conf
@@ -1,7 +1,7 @@
 [global]
 fsid = {{ .deis_store_fsid }}
 mon initial members = {{ .deis_store_monSetupLock }}
-mon host = {{ range $index, $mon := .deis_store_hosts }}{{ if $index }}, {{ end }}{{ Base $mon.Key }}{{ end }}
+mon host = {{ range $index, $mon := .deis_store_hosts }}{{ if $index }}, {{ end }}{{ $mon.Value }}{{ end }}
 mon addr = {{ range $index, $mon := .deis_store_hosts }}{{ if $index }}, {{ end }}{{ Base $mon.Key }}:6789{{ end }}
 auth cluster required = cephx
 auth service required = cephx


### PR DESCRIPTION
Commit 690b380 had a typo which made the `mon host` config entry for
Ceph contain IP addresses, not hostnames. This doesn't seem to
be an issue for day-to-day operations, but could have unforeseen
consequences. It's best to fix this up.