### PR TITLE
feat(store): Scalable store-gateway

### DIFF
--- a/deisctl/README.md
+++ b/deisctl/README.md
@@ -39,7 +39,7 @@ $ deisctl install platform
 Logging subsystem...
 deis-logger.service: loaded
 Storage subsystem...
-deis-store-gateway.service: loaded
+deis-store-gateway@1.service: loaded
 Control plane...
 deis-cache.service: loaded
 deis-database.service: loaded
@@ -66,7 +66,7 @@ deis-logspout.service: running
 Storage subsystem...
 deis-store-daemon.service: running
 deis-store-monitor.service: running
-deis-store-gateway.service: running
+deis-store-gateway@1.service: running
 Control plane...
 deis-cache.service: running
 deis-database.service: running
@@ -84,7 +84,7 @@ Done.
 
 Note that the default start command activates 1 of each component.
 You can scale components with `deisctl scale router=3`, for example.
-The router and the registry are the only component that _currently_ scales beyond 1 unit.
+The router, the registry and the store gateway are the only component that _currently_ scales beyond 1 unit.
 
 You can also use the `deisctl uninstall` command to destroy platform units:
 
@@ -105,7 +105,7 @@ deis-cache.service: inactive
 deis-database.service: inactive
 deis-registry@1.service: inactive
 Storage subsystem...
-deis-store-gateway.service: inactive
+deis-store-gateway@1.service: inactive
 Logging subsystem...
 deis-logger.service: inactive
 Done.

--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -46,11 +46,11 @@ func ListUnitFiles(argv []string, b backend.Backend) error {
 }
 
 // Scale grows or shrinks the number of running components.
-// Currently "router" and "registry" are the only types that can be scaled.
+// Currently "router", "registry" and "store-gateway" are the only types that can be scaled.
 func Scale(argv []string, b backend.Backend) error {
 	usage := `Grows or shrinks the number of running components.
 
-Currently "router" and "registry" are the only types that can be scaled.
+Currently "router", "registry" and "store-gateway" are the only types that can be scaled.
 
 Usage:
   deisctl scale [<target>...] [options]
@@ -74,7 +74,7 @@ Usage:
 			return err
 		}
 		// the router is the only component that can scale at the moment
-		if !strings.Contains(component, "router") && !strings.Contains(component, "registry") {
+		if !strings.Contains(component, "router") && !strings.Contains(component, "registry") && !strings.Contains(component, "store-gateway") {
 			return fmt.Errorf("cannot scale %s components", component)
 		}
 		b.Scale(component, num, &wg, outchan, errchan)
@@ -171,7 +171,7 @@ func startDefaultServices(b backend.Backend, wg *sync.WaitGroup, outchan chan st
 	wg.Wait()
 
 	// we start gateway first to give metadata time to come up for volume
-	b.Start([]string{"store-gateway"}, wg, outchan, errchan)
+	b.Start([]string{"store-gateway@1"}, wg, outchan, errchan)
 	wg.Wait()
 	b.Start([]string{"store-volume"}, wg, outchan, errchan)
 	wg.Wait()
@@ -282,7 +282,7 @@ func stopDefaultServices(b backend.Backend, wg *sync.WaitGroup, outchan chan str
 	wg.Wait()
 
 	outchan <- fmt.Sprintf("Storage subsystem...")
-	b.Stop([]string{"store-volume", "store-gateway"}, wg, outchan, errchan)
+	b.Stop([]string{"store-volume", "store-gateway@1"}, wg, outchan, errchan)
 	wg.Wait()
 	b.Stop([]string{"store-metadata"}, wg, outchan, errchan)
 	wg.Wait()
@@ -428,7 +428,7 @@ func InstallPlatform(b backend.Backend) error {
 func installDefaultServices(b backend.Backend, wg *sync.WaitGroup, outchan chan string, errchan chan error) {
 
 	outchan <- fmt.Sprintf("Storage subsystem...")
-	b.Create([]string{"store-daemon", "store-monitor", "store-metadata", "store-volume", "store-gateway"}, wg, outchan, errchan)
+	b.Create([]string{"store-daemon", "store-monitor", "store-metadata", "store-volume", "store-gateway@1"}, wg, outchan, errchan)
 	wg.Wait()
 
 	outchan <- fmt.Sprintf("Logging subsystem...")
@@ -524,7 +524,7 @@ func uninstallAllServices(b backend.Backend, wg *sync.WaitGroup, outchan chan st
 	wg.Wait()
 
 	outchan <- fmt.Sprintf("Storage subsystem...")
-	b.Destroy([]string{"store-volume", "store-gateway"}, wg, outchan, errchan)
+	b.Destroy([]string{"store-volume", "store-gateway@1"}, wg, outchan, errchan)
 	wg.Wait()
 	b.Destroy([]string{"store-metadata"}, wg, outchan, errchan)
 	wg.Wait()

--- a/deisctl/deisctl.go
+++ b/deisctl/deisctl.go
@@ -35,7 +35,7 @@ Commands, use "deisctl help <command>" to learn more:
   start             start compnents
   stop              stop components
   restart           stop, then start components
-  scale             grow or shrink the number of routers or registries
+  scale             grow or shrink the number of routers, registries or store gateways
   journal           print the log output of a component
   config            set platform or component values
   refresh-units     refresh unit files from GitHub

--- a/deisctl/units/deis-store-gateway.service
+++ b/deisctl/units/deis-store-gateway.service
@@ -14,3 +14,6 @@ RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
+
+[X-Fleet]
+Conflicts=deis-store-gateway@*.service

--- a/store/Makefile
+++ b/store/Makefile
@@ -38,10 +38,10 @@ install: check-deisctl
 	deisctl install store-daemon
 	deisctl install store-metadata
 	deisctl install store-volume
-	deisctl install store-gateway
+	deisctl install store-gateway@1
 
 uninstall: check-deisctl
-	deisctl uninstall store-gateway
+	deisctl uninstall store-gateway@1
 	deisctl uninstall store-volume
 	deisctl uninstall store-metadata
 	deisctl uninstall store-daemon
@@ -52,10 +52,10 @@ start: check-deisctl
 	deisctl start store-daemon
 	deisctl start store-metadata
 	deisctl start store-volume
-	deisctl start store-gateway
+	deisctl start store-gateway@1
 
 stop: check-deisctl
-	deisctl stop store-gateway
+	deisctl stop store-gateway@1
 	deisctl stop store-volume
 	deisctl stop store-metadata
 	deisctl stop store-daemon

--- a/store/gateway/bin/boot
+++ b/store/gateway/bin/boot
@@ -13,6 +13,7 @@ set -eo pipefail
 export ETCD_PORT=${ETCD_PORT:-4001}
 export ETCD="$HOST:$ETCD_PORT"
 export ETCD_PATH=${ETCD_PATH:-/deis/store/gateway}
+export HOST_ETCD_PATH=${HOST_ETCD_PATH:-/deis/store/gateway/hosts/$HOST}
 export ETCD_TTL=${ETCD_TTL:-10}
 
 # wait for etcd to be available
@@ -128,8 +129,14 @@ if [[ ! -z $EXTERNAL_PORT ]]; then
 
   # while the port is listening, publish to etcd
   while [[ ! -z $(netstat -lnt | awk "\$6 == \"LISTEN\" && \$4 ~ \".$PUBLISH\" && \$1 ~ \"$PROTO.?\"") ]] ; do
-    etcdctl --no-sync -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
-    etcdctl --no-sync -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
+    if etcdctl --no-sync -C $ETCD mk ${ETCD_PATH}/masterLock $HOST --ttl $ETCD_TTL >/dev/null 2>&1 \
+    || [[ `etcdctl --no-sync -C $ETCD get ${ETCD_PATH}/masterLock` == "$HOST" ]] ; then
+      etcdctl --no-sync -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
+      etcdctl --no-sync -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
+      etcdctl --no-sync -C $ETCD update ${ETCD_PATH}/masterLock $HOST --ttl $ETCD_TTL >/dev/null
+    fi
+    etcdctl --no-sync -C $ETCD set $HOST_ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
+    etcdctl --no-sync -C $ETCD set $HOST_ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
     sleep $(($ETCD_TTL/2)) # sleep for half the TTL
   done
 


### PR DESCRIPTION
Allow the store gateway to be scaled across multiple cluster nodes. This speeds up app rescheduling when the node hosting the gateway died

Helps with cases like https://github.com/deis/deis/issues/2920 
Basis for: https://github.com/deis/deis/issues/2725

An inactive gateway uses ~40mb memory, so it might make sense to schedule two gateways by default. https://www.dropbox.com/s/3uwz2brmn188ouu/Screenshot%202015-01-20%2015.36.00.png?dl=0