### PR TITLE
ref(Vagrantfile): remove redundant virtio NIC section

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,12 +42,6 @@ Vagrant.configure("2") do |config|
   config.vm.box_version = ">= 522.5.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
 
-  config.vm.provider :virtualbox do |vb, override|
-    # Use paravirtualized network adapters
-    vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
-    vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
-  end
-
   config.vm.provider :vmware_fusion do |vb, override|
     override.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json" % $update_channel
   end


### PR DESCRIPTION
The paravirtualized "virtio" adapter is the default when creating a CoreOS 522.5.0 vagrant / VirtualBox instance, so this stanza is no longer needed.