### PR TITLE
fix(builder): exit if an error occur compiling go

### DIFF
--- a/builder/Makefile
+++ b/builder/Makefile
@@ -9,7 +9,7 @@ BINARY_DEST_DIR := image/bin
 
 build: check-docker
 	for i in $(BINARIES); do \
-		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -v -ldflags '-s' -o $(BINARY_DEST_DIR)/$$i bin/$$i.go ; \
+		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -v -ldflags '-s' -o $(BINARY_DEST_DIR)/$$i bin/$$i.go || exit 1; \
 	done
 	docker build -t $(IMAGE) image
 


### PR DESCRIPTION
Without this any error is omitted by the for loop.
To test this change any .go to contain an error and compile the builder `make -C builder/ build`.