### PR TITLE
fix(security): increase max conntrack connections

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -65,6 +65,15 @@ coreos:
       ExecStartPre=/usr/bin/curl -sSL -o /opt/bin/jq http://stedolan.github.io/jq/download/linux64/jq
       ExecStartPre=/usr/bin/chmod +x /opt/bin/jq
       ExecStart=/usr/bin/bash -c "while true; do curl -sL http://127.0.0.1:4001/v2/stats/leader | /opt/bin/jq . ; sleep 1 ; done"
+  - name: increase-nf_conntrack-connections.service
+    command: start
+    content: |
+      [Unit]
+      Description=Increase the number of connections in nf_conntrack. default is 65536
+
+      [Service]
+      Type=oneshot
+      ExecStart=/bin/sh -c "sysctl -w net.netfilter.nf_conntrack_max=262144"
 write_files:
   - path: /etc/deis-release
     content: |


### PR DESCRIPTION
In the logs I saw this:
`Jan 21 18:06:05 nodo-3 sh[27968]: Error:  501: All the given peers are not reachable (Tried to connect to each peer twice and failed) [0]`

Usually this means that something is wrong in the cluster but everything was working just fine (I even checked the etcd leader stats :) )
The problem is the default for `nf_conntrack_max`: 65536 [docs](https://www.kernel.org/doc/Documentation/networking/nf_conntrack-sysctl.txt)

This number sound high but every docker container uses iptables with connection tracking so 200 containers using mongodb with replication (1 connection per mongodb node per application) and that number is a joke.

To check if there is a problem with  nf_conntrack run: `dmesg | grep conntrack`
If it shows something like `nf_conntrack: table full, dropping packet` the connection table is too low for the number of connections.

To check the connection in one node:
```
core@nodo-3 ~ $ toolbox
Spawning container core-ubuntu-debootstrap-14.04 on /var/lib/toolbox/core-ubuntu-debootstrap-14.04.
Press ^] three times within 1s to kill container.
root@nodo-3:~# apt-get update && apt-get install conntrack
....
root@nodo-3:~# conntrack -L
....
conntrack v1.4.1 (conntrack-tools): 71310 flow entries have been shown.
```

I removed the output from `conntrack` to keep this readable :)

This PR increases the number to 2000000. Each connection requires 100 bytes so this number of connections will consume 200MB of ram.