### PR TITLE
ref(controller): API view refactor

### DIFF
--- a/controller/api/permissions.py
+++ b/controller/api/permissions.py
@@ -42,6 +42,20 @@ class IsOwner(permissions.BasePermission):
             return False
 
 
+class IsOwnerOrAdmin(permissions.BasePermission):
+    """
+    Object-level permission to allow only owners of an object or administrators to access it.
+    Assumes the model instance has an `owner` attribute.
+    """
+    def has_object_permission(self, request, view, obj):
+        if request.user.is_superuser:
+            return True
+        if hasattr(obj, 'owner'):
+            return obj.owner == request.user
+        else:
+            return False
+
+
 class IsAppUser(permissions.BasePermission):
     """
     Object-level permission to allow owners or collaborators to access

--- a/controller/api/tests/test_perm.py
+++ b/controller/api/tests/test_perm.py
@@ -215,7 +215,6 @@ class TestAppPerms(TestCase):
         response = self.client.delete(url, content_type='application/json',
                                       HTTP_AUTHORIZATION='token {}'.format(self.token2))
         self.assertEqual(response.status_code, 403)
-        self.assertIsNone(response.data)
         # delete permission to user 1's app
         response = self.client.delete(url, content_type='application/json',
                                       HTTP_AUTHORIZATION='token {}'.format(self.token))

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -141,7 +141,7 @@ class AppViewSet(BaseDeisViewSet):
         except (TypeError, ValueError):
             return Response({'detail': 'Invalid scaling format'},
                             status=status.HTTP_400_BAD_REQUEST)
-        except (ValidationError, EnvironmentError) as e:
+        except (EnvironmentError, ValidationError) as e:
             return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
         except RuntimeError as e:
             return Response({'detail': str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -150,13 +150,11 @@ class AppViewSet(BaseDeisViewSet):
     def logs(self, request, **kwargs):
         app = self.get_object()
         try:
-            logs = app.logs()
+            return Response(app.logs(), status=status.HTTP_200_OK, content_type='text/plain')
         except EnvironmentError:
             return Response("No logs for {}".format(app.id),
                             status=status.HTTP_204_NO_CONTENT,
                             content_type='text/plain')
-        return Response(logs, status=status.HTTP_200_OK,
-                        content_type='text/plain')
 
     def run(self, request, **kwargs):
         app = self.get_object()

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -323,8 +323,8 @@ class AppPermsViewSet(BaseDeisViewSet):
         app = get_object_or_404(self.model, id=kwargs['id'])
         perm_name = "api.{}".format(self.perm)
         if request.user != app.owner and \
-                not request.user.has_perm(perm_name, app) and \
-                not request.user.is_superuser:
+           not request.user.has_perm(perm_name, app) and \
+           not request.user.is_superuser:
             return Response(status=status.HTTP_403_FORBIDDEN)
         usernames = [u.username for u in get_users_with_perms(app)
                      if u.has_perm(perm_name, app)]
@@ -344,12 +344,11 @@ class AppPermsViewSet(BaseDeisViewSet):
         if request.user != app.owner and not request.user.is_superuser:
             return Response(status=status.HTTP_403_FORBIDDEN)
         user = get_object_or_404(User, username=kwargs['username'])
-        if user.has_perm(self.perm, app):
-            remove_perm(self.perm, user, app)
-            models.log_event(app, "User {} was revoked access to {}".format(user, app))
-            return Response(status=status.HTTP_204_NO_CONTENT)
-        else:
+        if not user.has_perm(self.perm, app):
             return Response(status=status.HTTP_403_FORBIDDEN)
+        remove_perm(self.perm, user, app)
+        models.log_event(app, "User {} was revoked access to {}".format(user, app))
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class AdminPermsViewSet(BaseDeisViewSet):
@@ -357,7 +356,7 @@ class AdminPermsViewSet(BaseDeisViewSet):
 
     model = User
     serializer_class = serializers.AdminUserSerializer
-    permission_classes = (permissions.IsAdmin,)
+    permission_classes = [permissions.IsAdmin]
 
     def get_queryset(self, **kwargs):
         self.check_object_permissions(self.request, self.request.user)

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -158,9 +158,8 @@ class AppViewSet(BaseDeisViewSet):
 
     def run(self, request, **kwargs):
         app = self.get_object()
-        command = request.data['command']
         try:
-            output_and_rc = app.run(self.request.user, command)
+            output_and_rc = app.run(self.request.user, request.data['command'])
         except EnvironmentError as e:
             return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
         except RuntimeError as e:
@@ -239,8 +238,8 @@ class ReleaseViewSet(AppResourceViewSet):
         Create a new release as a copy of the state of the compiled slug and config vars of a
         previous release.
         """
+        app = self.get_app()
         try:
-            app = self.get_app()
             release = app.release_set.latest()
             version_to_rollback_to = release.version - 1
             if request.data.get('version'):


### PR DESCRIPTION
The majority of code shifting was done earlier in #2898, so this optimizes the rest of the viewsets to use more generic calls, specifically the hooks and app perm viewsets which were basically re-implementing the permission calls.

closes #2854