### PR TITLE
ref(docs): remove postgresql from doc generation requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ deisctl/package/
 deisctl/makeself/
 docs/_build/
 docs/docs.zip
+docs/dummy.sqlite3
 logspout/build/
 logspout/image/logspout
 logspout/Godeps/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,8 @@ if not os.path.exists(local_settings_path):
         local_settings.write("SECRET_KEY = 'DummySecretKey'\n")
 # set up Django
 os.environ['DJANGO_SETTINGS_MODULE'] = 'deis.settings'
+os.environ['DATABASE_ENGINE'] = 'sqlite3'
+os.environ['DATABASE_NAME'] = 'dummy.sqlite3'
 from django.conf import settings  # noqa
 
 # -- General configuration -----------------------------------------------------

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -17,7 +17,6 @@ djangorestframework==3.0.3
 docker-py==0.6.0
 gunicorn==19.1.1
 paramiko==1.15.2
-psycopg2==2.5.4
 python-etcd==0.3.2
 PyYAML==3.11
 South==1.0.2


### PR DESCRIPTION
To automatically generate python code documentation, Sphinx needs to import the code, which requires Django, which requires a database driver. This change sets the driver to python's built-in `sqlite3` at runtime to simplify requirements for building the docs.

Refs #2887.