### PR TITLE
ref(docs): remove local_settings.py hack for secret key

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,12 +22,6 @@ import sys
 open(os.path.join('..', '__init__.py'), 'a')
 sys.path.insert(0, os.path.abspath(os.path.join('..')))
 sys.path.insert(0, os.path.abspath(os.path.join('..', 'controller')))
-# create local_settings.py for SECRET_KEY if necessary
-local_settings_path = os.path.abspath(
-    os.path.join('..', 'controller', 'deis', 'local_settings.py'))
-if not os.path.exists(local_settings_path):
-    with open(local_settings_path, 'w') as local_settings:
-        local_settings.write("SECRET_KEY = 'DummySecretKey'\n")
 # set up Django
 os.environ['DJANGO_SETTINGS_MODULE'] = 'deis.settings'
 from django.conf import settings  # noqa


### PR DESCRIPTION
Doc generation creates a local_settings.py file, because at one time having `SECRET_KEY` unset caused an error when importing Django code. That was essentially a temp file that was never cleaned up, and it no longer seems to be necessary.