### PR TITLE
fix (contrib/gce/create-gce-user-data): replace discovery_url with discovery

### DIFF
--- a/contrib/gce/create-gce-user-data
+++ b/contrib/gce/create-gce-user-data
@@ -62,7 +62,7 @@ def main():
     configuration = combine_dicts(configuration_coreos_template,
                                   configuration_gce_template)
 
-    configuration["coreos"]["etcd"]["discovery_url"] = url
+    configuration["coreos"]["etcd"]["discovery"] = url
 
     with gce_user_data as outfile:
         try:


### PR DESCRIPTION
fix (contrib/gce/create-gce-user-data): replace discovery_url with discovery

This simply changes the discovery_url to discovery to allow the nodes in gce set their ETCD_DISCOVERY