### PR TITLE
ref(tests): remove unnecessary time.Sleep()

### DIFF
--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
-	"time"
 )
 
 // BuildTag returns the $BUILD_TAG environment variable or `git rev-parse` output.
@@ -155,7 +154,6 @@ func RunCommandWithStdoutStderr(cmd *exec.Cmd) (bytes.Buffer, bytes.Buffer, erro
 	go func() {
 		streamOutput(stderrPipe, &stderr, os.Stderr)
 	}()
-	time.Sleep(2000 * time.Millisecond)
 	err = cmd.Wait()
 	if err != nil {
 		fmt.Println("error at command wait")


### PR DESCRIPTION
The artificial delay in `RunCommandWithStdoutStderr` has always been there, without explanation. I couldn't discern why, so I removed it and ran test-integration.sh three times without any errors. Hopefully Jenkins agrees, as this shaves a couple minutes off the overall test time.