### PR TITLE
feat(store): add store-admin container

### DIFF
--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -653,6 +653,7 @@ Options:
 		"deis-publisher.service",
 		"deis-registry.service",
 		"deis-router.service",
+		"deis-store-admin.service",
 		"deis-store-daemon.service",
 		"deis-store-gateway.service",
 		"deis-store-metadata.service",

--- a/deisctl/units/deis-store-admin.service
+++ b/deisctl/units/deis-store-admin.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=deis-store-admin
+
+[Service]
+EnvironmentFile=/etc/environment
+TimeoutStartSec=20m
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-admin` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-store-admin >/dev/null 2>&1 && docker rm -f deis-store-admin >/dev/null 2>&1 || true"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-admin` && docker run --name deis-store-admin --rm --volumes-from=deis-store-daemon-data --volumes-from=deis-store-monitor-data -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
+ExecStopPost=-/usr/bin/docker rm -f deis-store-admin
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+
+[X-Fleet]
+Global=true

--- a/store/Makefile
+++ b/store/Makefile
@@ -1,8 +1,10 @@
 include ../includes.mk
 
-TEMPLATE_IMAGES=daemon gateway metadata monitor
+TEMPLATE_IMAGES=admin daemon gateway metadata monitor
 BUILT_IMAGES=base $(TEMPLATE_IMAGES)
 
+ADMIN_IMAGE = $(IMAGE_PREFIX)store-admin:$(BUILD_TAG)
+ADMIN_DEV_IMAGE = $(DEV_REGISTRY)/$(ADMIN_IMAGE)
 DAEMON_IMAGE = $(IMAGE_PREFIX)store-daemon:$(BUILD_TAG)
 DAEMON_DEV_IMAGE = $(DEV_REGISTRY)/$(DAEMON_IMAGE)
 GATEWAY_IMAGE = $(IMAGE_PREFIX)store-gateway:$(BUILD_TAG)
@@ -68,6 +70,8 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
+	docker tag $(ADMIN_IMAGE) $(ADMIN_DEV_IMAGE)
+	docker push $(ADMIN_DEV_IMAGE)
 	docker tag $(DAEMON_IMAGE) $(DAEMON_DEV_IMAGE)
 	docker push $(DAEMON_DEV_IMAGE)
 	docker tag $(GATEWAY_IMAGE) $(GATEWAY_DEV_IMAGE)
@@ -78,12 +82,14 @@ push: check-registry
 	docker push $(MONITOR_DEV_IMAGE)
 
 set-image: check-deisctl
+	deisctl config store-admin set image=$(ADMIN_DEV_IMAGE)
 	deisctl config store-daemon set image=$(DAEMON_DEV_IMAGE)
 	deisctl config store-gateway set image=$(GATEWAY_DEV_IMAGE)
 	deisctl config store-metadata set image=$(METADATA_DEV_IMAGE)
 	deisctl config store-monitor set image=$(MONITOR_DEV_IMAGE)
 
 release:
+	docker push $(ADMIN_IMAGE)
 	docker push $(DAEMON_IMAGE)
 	docker push $(GATEWAY_IMAGE)
 	docker push $(METADATA_IMAGE)

--- a/store/admin/Dockerfile.template
+++ b/store/admin/Dockerfile.template
@@ -1,0 +1,5 @@
+#FROM is generated dynamically by the Makefile
+
+WORKDIR /app
+CMD ["/app/bin/boot"]
+ADD bin/boot /app/bin/boot

--- a/store/admin/bin/boot
+++ b/store/admin/bin/boot
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# This script is designed to be run inside the container
+#
+
+ETCD_PORT=${ETCD_PORT:-4001}
+ETCD="$HOST:$ETCD_PORT"
+
+confd -node $ETCD -config-file /app/confd.toml &
+
+# loop forever until the container is stopped
+while true; do
+  sleep 5
+done

--- a/store/admin/bin/boot
+++ b/store/admin/bin/boot
@@ -10,5 +10,5 @@ confd -node $ETCD -config-file /app/confd.toml &
 
 # loop forever until the container is stopped
 while true; do
-  sleep 5
+  sleep 1
 done


### PR DESCRIPTION
Adds a new optional component, `deis-store-admin`, to aid in diagnosing and recovering from issues with store.

Most of the store containers only write the Ceph config file once before the /bin/boot script execs the Ceph daemon, so when a user comes along and tries to query cluster state, it's likely that he's using a very old config file and will see a bunch of monitor faults. This admin container uses confd to rewrite the config file constantly, ensuring that the latest cluster state is reflected in the config.

This change also moves the Troubleshooting Store docs into its own page, since they were overwhelming the Troubleshooting Deis docs. I had to include a toctree in the main Troubleshooting docs to satisfy Sphinx.

closes #2925