### PR TITLE
docs(faq): added a link to unofficial Chinese documentation

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -15,3 +15,9 @@ FAQ
     DAY-iss
 
 .. _dais: https://en.wiktionary.org/wiki/dais
+
+- Is there documentation for Deis in languages other than English?
+
+    Unofficial `documentation in Chinese`_ for Deis has been created by the DockerOne community.
+
+.. _`documentation in Chinese`: http://dockerone.com/article/124


### PR DESCRIPTION
Thanks again to the Chinese DockerOne community for this great work! See #2852 for the details.

I used Google translate to spot-check several sections, and the content seems good. It would be nice to include multiple translations at http://docs.deis.io/ directly, but for now providing a link is better than nothing.

Closes #2852.