### PR TITLE
Add enforceHttps support

### DIFF
--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -127,6 +127,7 @@ http {
 
     ## start service definitions for each application
     {{ $useSSL := or .deis_router_sslCert "false" }}
+    {{ $enforceHttps := or .deis_router_enforceHttps "false" }}
     {{ $domains := .deis_domains }}{{ range $service := .deis_services }}{{ if $service.Nodes }}
     upstream {{ Base $service.Key }} {
         {{ range $upstream := $service.Nodes }}server {{ $upstream.Value }};
@@ -156,6 +157,12 @@ http {
             proxy_set_header            Connection        $connection_upgrade;
 
             proxy_next_upstream         error timeout http_502 http_503 http_504;
+
+            {{ if ne $enforceHttps "false" }}
+            if ($http_x_forwarded_proto != "https") {
+              rewrite ^(.*)$ https://$host$1 permanent;
+            }
+            {{ end }}
 
             add_header                  X-Deis-Upstream   $upstream_addr;
 


### PR DESCRIPTION
feat(router/enforceHttps): Allow https enforcement

Setting /deis/router/enforceHttps to anything other than "false" will result in any requests to http being redirected to https

closes #2838