### PR TITLE
fix(contrib/coreos) etdcd_request_timeout value type

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -16,7 +16,7 @@ coreos:
     # will all publish the same private IP. This is harmless for cloud providers.
     public-ip: $private_ipv4
     # allow etcd to slow down at times
-    etcd_request_timeout: 3
+    etcd_request_timeout: 3.0
   units:
   - name: etcd.service
     command: start


### PR DESCRIPTION
When validating the ``user-data.example`` in https://coreos.com/validate/ it warns (or errors?) about 'Line 19:incorrect type for "etcd_request_timeout" (want float64).'

Also using the ``user-data.example`` (with token added to ``coreos.fleet.discovery``) it failed to discover the cluster nodes (but worked after lunch when I changed the ``3`` to ``3.0`` and reinited the cluster) haven't reproduced it, could just be coincidence. Used ``CoreOS 522.5.0`` on digitalocean.

Solution: Use ``float64`` as the value type for ``etcd_request_timeout``