### PR TITLE
Proposal: Platform-wide log drain

### DIFF
--- a/docs/managing_deis/platform_logging.rst
+++ b/docs/managing_deis/platform_logging.rst
@@ -16,8 +16,19 @@ and sends their logs to ``/deis/logs/host`` and ``/deis/logs/port``.
 when a client runs ``deis logs``. This component publishes its host and port to ``/deis/logs/host``
 and ``/deis/logs/port``, and is typically the service which consumes logs from ``deis-logspout``.
 
-Routing logs to a custom location
----------------------------------
+Application log drain
+---------------------
+
+Application logs can be drained to an external syslog server (or compatible service such as Logstash, Papertrail, Splunk etc).
+
+.. code-block:: console
+
+    $ deisctl config logs set drain=syslog://logs2.papertrailapp.com:23654
+
+This will send all application logs - there is currently no way to drain logs per application.
+
+Routing host logs to a custom location
+--------------------------------------
 
 Logging to an external location can be achieved without modifying the log flow within Deis -
 we can simply send the master journal on a CoreOS host using ``ncat``. For example, if I'm using the

--- a/logger/drain/drain.go
+++ b/logger/drain/drain.go
@@ -1,0 +1,60 @@
+package drain
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/url"
+	"os"
+
+	"github.com/coreos/go-etcd/etcd"
+)
+
+func GetDrain() string {
+	host := getopt("HOST", "127.0.0.1")
+
+	etcdPort := getopt("ETCD_PORT", "4001")
+	etcdPath := getopt("ETCD_PATH", "/deis/logs")
+
+	client := etcd.NewClient([]string{"http://" + host + ":" + etcdPort})
+
+	s, err := client.Get(etcdPath+"/drain", true, false)
+	if err != nil {
+		return ""
+	}
+
+	return s.Node.Value
+}
+
+func SendToDrain(m string, drain string) error {
+	u, err := url.Parse(drain)
+	if err != nil {
+		log.Fatal(err)
+	}
+	uri := u.Host + u.Path
+	switch u.Scheme {
+	case "syslog":
+		sendToSyslogDrain(m, uri)
+	default:
+		log.Println(u.Scheme + " drain type is not implemented.")
+	}
+	return nil
+}
+
+func sendToSyslogDrain(m string, drain string) error {
+	conn, err := net.Dial("udp", drain)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+	fmt.Fprintf(conn, m)
+	return nil
+}
+
+func getopt(name, dfault string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		value = dfault
+	}
+	return value
+}

--- a/logger/syslogd/syslogd.go
+++ b/logger/syslogd/syslogd.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 
 	"github.com/deis/deis/logger/syslog"
+
+	"github.com/deis/deis/logger/drain"
 )
 
 const logRoot = "/data/logs"
@@ -81,6 +83,10 @@ func (h *handler) mainLoop() {
 		m := h.Get()
 		if m == nil {
 			break
+		}
+		d := drain.GetDrain()
+		if d != "" {
+			drain.SendToDrain(m.String(), d)
 		}
 		err := writeToDisk(m)
 		if err != nil {


### PR DESCRIPTION
Currently [platform logging](http://docs.deis.io/en/latest/managing_deis/platform_logging/) is done via `journalctl -o short -f | ncat --ssl logs2.papertrailapp.com 23654`

There are a couple of disadvantages to this:
1. A unit needs to be created (and customised) by end users.
2. Container logs aren't prefixed with application name.

I propose adding an external drain to `logger` that would send to external syslog servers in addition to the current write to disk process.

Interface would be:

```
$ deisctl config logs set drain/host logs2.papertrailapp.com
$ deisctl config logs set drain/port 23654
```

Logger pulls this configuration out of etcd and sends the messages on.

related #980  