### PR TITLE
chore(*): bump CoreOS to 522.6.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
 
   config.vm.box = "coreos-%s" % $update_channel
-  config.vm.box_version = ">= 522.5.0"
+  config.vm.box_version = ">= 522.6.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
 
   config.vm.provider :vmware_fusion do |vb, override|

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -89,15 +89,15 @@
 
   "Mappings" : {
     "CoreOSAMIs" : {
-      "eu-central-1"   : { "PV" : "ami-448dbd59", "HVM" : "ami-468dbd5b" },
-      "ap-northeast-1" : { "PV" : "ami-0a05160b", "HVM" : "ami-0c05160d" },
-      "sa-east-1"      : { "PV" : "ami-27b00d3a", "HVM" : "ami-23b00d3e" },
-      "ap-southeast-2" : { "PV" : "ami-b5295c8f", "HVM" : "ami-b7295c8d" },
-      "ap-southeast-1" : { "PV" : "ami-ba0f27e8", "HVM" : "ami-b40f27e6" },
-      "us-east-1"      : { "PV" : "ami-3e750856", "HVM" : "ami-3c750854" },
-      "us-west-2"      : { "PV" : "ami-bf2d728f", "HVM" : "ami-bd2d728d" },
-      "us-west-1"      : { "PV" : "ami-8f534dca", "HVM" : "ami-8d534dc8" },
-      "eu-west-1"      : { "PV" : "ami-e76dec90", "HVM" : "ami-f96dec8e" }
+      "eu-central-1"   : { "PV" : "ami-38093a25", "HVM" : "ami-3a093a27" },
+      "ap-northeast-1" : { "PV" : "ami-e2465fe3", "HVM" : "ami-e4465fe5" },
+      "sa-east-1"      : { "PV" : "ami-7f863a62", "HVM" : "ami-7d863a60" },
+      "ap-southeast-2" : { "PV" : "ami-db7d09e1", "HVM" : "ami-d97d09e3" },
+      "ap-southeast-1" : { "PV" : "ami-3e8da66c", "HVM" : "ami-3c8da66e" },
+      "us-east-1"      : { "PV" : "ami-3615525e", "HVM" : "ami-3415525c" },
+      "us-west-2"      : { "PV" : "ami-51134b61", "HVM" : "ami-6f134b5f" },
+      "us-west-1"      : { "PV" : "ami-bebfa6fb", "HVM" : "ami-bcbfa6f9" },
+      "eu-west-1"      : { "PV" : "ami-7bf27e0c", "HVM" : "ami-79f27e0e" }
 
     },
     "RootDevices" : {

--- a/contrib/rackspace/provision-rackspace-cluster.sh
+++ b/contrib/rackspace/provision-rackspace-cluster.sh
@@ -49,6 +49,7 @@ $CONTRIB_DIR/util/check-user-data.sh
 i=1 ; while [[ $i -le $DEIS_NUM_INSTANCES ]] ; do \
     echo_yellow "Provisioning deis-$i..."
     # This image is CoreOS 522.5.0 in the stable channel
+    # TODO update to 522.6.0 once it's available in the stable channel
     supernova $ENV boot --image 4261011b-d98b-418b-80a1-9d2e687c9108 --flavor $FLAVOR --key-name $1 --user-data $CONTRIB_DIR/coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
     ((i = i + 1)) ; \
 done

--- a/docs/installing_deis/baremetal.rst
+++ b/docs/installing_deis/baremetal.rst
@@ -99,8 +99,8 @@ Start the installation
 
 
 This will install the latest `CoreOS`_ stable release to disk. The Deis provision scripts for other
-platforms typically specify a CoreOS version - currently, ``522.5.0``. To specify a CoreOS
-version, append the ``-V`` parameter to the install command, e.g. ``-V 522.5.0``.
+platforms typically specify a CoreOS version - currently, ``522.6.0``. To specify a CoreOS
+version, append the ``-V`` parameter to the install command, e.g. ``-V 522.6.0``.
 
 After the installation has finished, reboot your server. Once your machine is back up, you should
 be able to log in as the `core` user using the `deis` ssh key.

--- a/docs/installing_deis/gce.rst
+++ b/docs/installing_deis/gce.rst
@@ -119,7 +119,7 @@ Launch 3 instances. You can choose another starting CoreOS image from the listin
 
 .. code-block:: console
 
-    $ for num in 1 2 3; do gcutil addinstance --use_compute_key --image projects/coreos-cloud/global/images/coreos-stable-522-5-0-v20150114 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
+    $ for num in 1 2 3; do gcutil addinstance --use_compute_key --image projects/coreos-cloud/global/images/coreos-stable-522-6-0-v20150128 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
 
     Table of resources:
 


### PR DESCRIPTION
This release includes a glibc fix for CVE-2015-0235.