### PR TITLE
feat(builder): Try shallow cloning buildpack repos

### DIFF
--- a/builder/image/slugbuilder/builder/install-buildpacks
+++ b/builder/image/slugbuilder/builder/install-buildpacks
@@ -8,10 +8,18 @@ download_buildpack() {
     buildpack_name=$(basename $buildpack_url)
     buildpack_commit="$2"
 
-    git clone $buildpack_url $BUILDPACK_INSTALL_PATH/$buildpack_name
-    pushd $BUILDPACK_INSTALL_PATH/$buildpack_name &>/dev/null
-        git checkout --quiet $buildpack_commit
-    popd &>/dev/null
+    set +e
+    git clone --branch $buildpack_commit --depth 1 $buildpack_url $BUILDPACK_INSTALL_PATH/$buildpack_name
+    SHALLOW_CLONED=$?
+    set -e
+    if [ $SHALLOW_CLONED -ne 0 ]; then
+        # if the shallow clone failed partway through, clean up and try a full clone
+        rm -rf $BUILDPACK_INSTALL_PATH/$buildpack_name
+        git clone $buildpack_url $BUILDPACK_INSTALL_PATH/$buildpack_name
+        pushd $BUILDPACK_INSTALL_PATH/$buildpack_name &>/dev/null
+            git checkout --quiet $buildpack_commit
+        popd &>/dev/null
+    fi
 
 }
 

--- a/builder/image/slugbuilder/builder/install-buildpacks
+++ b/builder/image/slugbuilder/builder/install-buildpacks
@@ -9,9 +9,10 @@ download_buildpack() {
     buildpack_commit="$2"
 
     git clone $buildpack_url $BUILDPACK_INSTALL_PATH/$buildpack_name
-    pushd $BUILDPACK_INSTALL_PATH/$buildpack_name 2>&1 >/dev/null
+    pushd $BUILDPACK_INSTALL_PATH/$buildpack_name &>/dev/null
         git checkout --quiet $buildpack_commit
-    popd 2>&1 >/dev/null
+    popd &>/dev/null
+
 }
 
 mkdir -p $BUILDPACK_INSTALL_PATH


### PR DESCRIPTION
Try to shallow clone buildpack repositories before falling back to deep cloning. This improves clone times significantly.

Shallow cloning only works for tags and branches, but not for a specific commit.

Benchmark:
```
localhost:deis johannes$ time git clone https://github.com/heroku/heroku-buildpack-ruby.git
Cloning into 'heroku-buildpack-ruby'...
...

real	0m12.764s
user	0m0.610s
sys	0m0.565s
localhost:deis johannes$ rm -rf heroku-buildpack-ruby/
localhost:deis johannes$ time git clone --branch v129 --depth 1 https://github.com/heroku/heroku-buildpack-ruby.git
Cloning into 'heroku-buildpack-ruby'...
...

real	0m1.657s
user	0m0.078s
sys	0m0.092s
```

This saves around 10 seconds per buildpack and we are cloning 7 buildpacks using a tag currently.