### PR TITLE
chore(builder): Updated gradle and play buildpack

### DIFF
--- a/builder/image/slugbuilder/builder/install-buildpacks
+++ b/builder/image/slugbuilder/builder/install-buildpacks
@@ -20,9 +20,9 @@ download_buildpack https://github.com/ddollar/heroku-buildpack-multi.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v129
 download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v64
 download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v32
-download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         24a8ebe
+download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v12
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         1ef927d
-download_buildpack https://github.com/heroku/heroku-buildpack-play.git           9c137b4
+download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v22
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v53
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v57
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v63


### PR DESCRIPTION
Both buildpacks are now also tagged when released.

Changes:
https://github.com/heroku/heroku-buildpack-gradle/compare/24a8ebe...v12
https://github.com/heroku/heroku-buildpack-play/compare/9c137b4...v22

This improves https://github.com/deis/deis/pull/2988 even further. @bacongobbler do you have example apps to tests those buildpacks?  Otherwise I would create them.