### PR TITLE
ref(controller): query fleet state

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -181,8 +181,11 @@ class App(UuidAuditedModel):
 
     def delete(self, *args, **kwargs):
         """Delete this application including all containers"""
-        for c in self.container_set.exclude(type='run'):
-            c.destroy()
+        try:
+            # attempt to remove containers from the scheduler
+            self._destroy_containers([c for c in self.container_set.exclude(type='run')])
+        except RuntimeError:
+            pass
         self._clean_app_logs()
         return super(App, self).delete(*args, **kwargs)
 

--- a/controller/api/serializers.py
+++ b/controller/api/serializers.py
@@ -205,6 +205,7 @@ class ContainerSerializer(ModelSerializer):
     class Meta:
         """Metadata options for a :class:`ContainerSerializer`."""
         model = models.Container
+        fields = ['owner', 'app', 'release', 'type', 'num', 'state', 'created', 'updated', 'uuid']
 
     def get_release(self, obj):
         return "v{}".format(obj.release.version)

--- a/controller/api/south_migrations/0020_auto__del_field_container_state.py
+++ b/controller/api/south_migrations/0020_auto__del_field_container_state.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Container.state'
+        db.delete_column(u'api_container', 'state')
+
+
+    def backwards(self, orm):
+        # Adding field 'Container.state'
+        db.add_column(u'api_container', 'state',
+                      self.gf('django_fsm.FSMField')(default=u'initialized', max_length=50),
+                      keep_default=False)
+
+
+    models = {
+        u'api.app': {
+            'Meta': {'object_name': 'App'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.SlugField', [], {'default': "'verbal-autoharp'", 'unique': 'True', 'max_length': '64'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'structure': ('json_field.fields.JSONField', [], {'default': '{}', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('api.fields.UuidField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'})
+        },
+        u'api.build': {
+            'Meta': {'ordering': "[u'-created']", 'unique_together': "((u'app', u'uuid'),)", 'object_name': 'Build'},
+            'app': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.App']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'dockerfile': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'image': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'procfile': ('json_field.fields.JSONField', [], {'default': '{}', 'blank': 'True'}),
+            'sha': ('django.db.models.fields.CharField', [], {'max_length': '40', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('api.fields.UuidField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'})
+        },
+        u'api.config': {
+            'Meta': {'ordering': "[u'-created']", 'unique_together': "((u'app', u'uuid'),)", 'object_name': 'Config'},
+            'app': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.App']"}),
+            'cpu': ('json_field.fields.JSONField', [], {'default': '{}', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'memory': ('json_field.fields.JSONField', [], {'default': '{}', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'tags': ('json_field.fields.JSONField', [], {'default': '{}', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('api.fields.UuidField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'values': ('json_field.fields.JSONField', [], {'default': '{}', 'blank': 'True'})
+        },
+        u'api.container': {
+            'Meta': {'ordering': "[u'created']", 'object_name': 'Container'},
+            'app': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.App']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'num': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'release': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.Release']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('api.fields.UuidField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'})
+        },
+        u'api.domain': {
+            'Meta': {'object_name': 'Domain'},
+            'app': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.App']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'domain': ('django.db.models.fields.TextField', [], {'unique': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'api.key': {
+            'Meta': {'unique_together': "((u'owner', u'id'),)", 'object_name': 'Key'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'public': ('django.db.models.fields.TextField', [], {'unique': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('api.fields.UuidField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'})
+        },
+        u'api.push': {
+            'Meta': {'ordering': "[u'-created']", 'unique_together': "((u'app', u'uuid'),)", 'object_name': 'Push'},
+            'app': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.App']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'fingerprint': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'receive_repo': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'receive_user': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sha': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'ssh_connection': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'ssh_original_command': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('api.fields.UuidField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'})
+        },
+        u'api.release': {
+            'Meta': {'ordering': "[u'-created']", 'unique_together': "((u'app', u'version'),)", 'object_name': 'Release'},
+            'app': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.App']"}),
+            'build': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.Build']", 'null': 'True'}),
+            'config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['api.Config']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'summary': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('api.fields.UuidField', [], {'unique': 'True', 'max_length': '32', 'primary_key': 'True'}),
+            'version': ('django.db.models.fields.PositiveIntegerField', [], {})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['api']

--- a/controller/api/tests/test_container.py
+++ b/controller/api/tests/test_container.py
@@ -12,7 +12,7 @@ import requests
 
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
-from django_fsm import TransitionNotAllowed
+from scheduler.states import TransitionNotAllowed
 from rest_framework.authtoken.models import Token
 
 from api.models import App, Build, Container, Release

--- a/controller/api/tests/test_scheduler.py
+++ b/controller/api/tests/test_scheduler.py
@@ -30,13 +30,13 @@ class SchedulerTest(TransactionTestCase):
         chaos.START_ERROR_RATE = 0
         chaos.STOP_ERROR_RATE = 0
         # use chaos scheduler
-        settings.SCHEDULER_MODULE = 'chaos'
+        settings.SCHEDULER_MODULE = 'scheduler.chaos'
         # provide mock authentication used for run commands
         settings.SSH_PRIVATE_KEY = '<some-ssh-private-key>'
 
     def tearDown(self):
         # reset for subsequent tests
-        settings.SCHEDULER_MODULE = 'mock'
+        settings.SCHEDULER_MODULE = 'scheduler.mock'
         settings.SSH_PRIVATE_KEY = ''
 
     def test_create_chaos(self):

--- a/controller/deis/settings.py
+++ b/controller/deis/settings.py
@@ -136,7 +136,6 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.staticfiles',
     # Third-party apps
-    'django_fsm',
     'guardian',
     'json_field',
     'gunicorn',
@@ -276,7 +275,7 @@ DEIS_DOMAIN = 'deisapp.local'
 DEIS_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S%Z'
 
 # default scheduler settings
-SCHEDULER_MODULE = 'mock'
+SCHEDULER_MODULE = 'scheduler.mock'
 SCHEDULER_TARGET = ''  # path to scheduler endpoint (e.g. /var/run/fleet.sock)
 SCHEDULER_AUTH = ''
 SCHEDULER_OPTIONS = {}

--- a/controller/registry/private.py
+++ b/controller/registry/private.py
@@ -147,7 +147,6 @@ def _put_checksum(image, layer, cookies):
     r = _api_call(url, headers=headers, cookies=cookies, request_type='PUT')
     if not r.status_code == 200:
         raise RuntimeError("PUT Checksum Error ({}: {})".format(r.status_code, r.text))
-    print r.json()
 
 
 def _put_tag(image_id, repository_path, tag):
@@ -156,7 +155,6 @@ def _put_tag(image_id, repository_path, tag):
     r = _api_call(url, data=json.dumps(image_id), request_type='PUT')
     if not r.status_code == 200:
         raise RuntimeError("PUT Tag Error ({}: {})".format(r.status_code, r.text))
-    print r.json()
 
 
 # utility functions

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -4,9 +4,9 @@
 # ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future pip install [args]
 #
 Django==1.6.10
-# FIXME: switch to upstream pending merge of https://github.com/kmmbvnr/django-fsm/pull/59
-git+https://github.com/deis/django-fsm@propagate-false
 django-cors-headers==1.0.0
+# required for south migrations
+django-fsm==2.2.0
 django-guardian==1.2.5
 django-json-field==0.5.7
 djangorestframework==3.0.5

--- a/controller/scheduler/chaos.py
+++ b/controller/scheduler/chaos.py
@@ -1,4 +1,7 @@
 import random
+from .mock import MockSchedulerClient, jobs
+from .states import JobState
+
 
 CREATE_ERROR_RATE = 0
 DESTROY_ERROR_RATE = 0
@@ -6,44 +9,26 @@ START_ERROR_RATE = 0
 STOP_ERROR_RATE = 0
 
 
-class ChaosSchedulerClient(object):
-
-    def __init__(self, target, auth, options, pkey):
-        self.target = target
-        self.auth = auth
-        self.options = options
-        self.pkey = pkey
-
-    # job api
+class ChaosSchedulerClient(MockSchedulerClient):
 
     def create(self, name, image, command, **kwargs):
         if random.random() < CREATE_ERROR_RATE:
-            raise RuntimeError
-        return True
-
-    def start(self, name):
-        """
-        Start an idle job
-        """
-        if random.random() < START_ERROR_RATE:
-            raise RuntimeError
-        return True
-
-    def stop(self, name):
-        """
-        Stop a running job
-        """
-        if random.random() < STOP_ERROR_RATE:
-            raise RuntimeError
-        return True
+            job = jobs.get(name, {})
+            job.update({'state': JobState.error})
+            jobs[name] = job
+            return
+        return super(ChaosSchedulerClient, self).create(name, image, command, **kwargs)
 
     def destroy(self, name):
         """
         Destroy an existing job
         """
         if random.random() < DESTROY_ERROR_RATE:
-            raise RuntimeError
-        return True
+            job = jobs.get(name, {})
+            job.update({'state': JobState.error})
+            jobs[name] = job
+            return
+        return super(ChaosSchedulerClient, self).destroy(name)
 
     def run(self, name, image, entrypoint, command):
         """
@@ -51,6 +36,28 @@ class ChaosSchedulerClient(object):
         """
         if random.random() < CREATE_ERROR_RATE:
             raise RuntimeError('exit code 1')
-        return 0, ''
+        return super(ChaosSchedulerClient, self).run(name, image, entrypoint, command)
+
+    def start(self, name):
+        """
+        Start an idle job
+        """
+        if random.random() < START_ERROR_RATE:
+            job = jobs.get(name, {})
+            job.update({'state': JobState.crashed})
+            jobs[name] = job
+            return
+        return super(ChaosSchedulerClient, self).start(name)
+
+    def stop(self, name):
+        """
+        Stop a running job
+        """
+        if random.random() < STOP_ERROR_RATE:
+            job = jobs.get(name, {})
+            job.update({'state': JobState.error})
+            jobs[name] = job
+            return
+        return super(ChaosSchedulerClient, self).stop(name)
 
 SchedulerClient = ChaosSchedulerClient

--- a/controller/scheduler/states.py
+++ b/controller/scheduler/states.py
@@ -1,0 +1,15 @@
+import enum
+
+
+class TransitionNotAllowed(Exception):
+    """Raised when a transition from one state to another is illegal"""
+
+
+class JobState(enum.Enum):
+    initialized = 1
+    created = 2
+    up = 3
+    down = 4
+    destroyed = 5
+    crashed = 6
+    error = 7

--- a/controller/templates/confd_settings.py
+++ b/controller/templates/confd_settings.py
@@ -3,7 +3,7 @@ SECRET_KEY = '{{ .deis_controller_secretKey }}'
 BUILDER_KEY = '{{ .deis_controller_builderKey }}'
 
 # scheduler settings
-SCHEDULER_MODULE = '{{ or (.deis_controller_schedulerModule) "fleet" }}'
+SCHEDULER_MODULE = 'scheduler.{{ or (.deis_controller_schedulerModule) "fleet" }}'
 SCHEDULER_TARGET = '{{ or (.deis_controller_schedulerTarget) "/var/run/fleet.sock" }}'
 try:
     SCHEDULER_OPTIONS = dict('{{ or (.deis_controller_schedulerOptions) "{}" }}')

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -8,9 +8,9 @@
 # ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future pip install [args]
 #
 Django==1.6.10
-# FIXME: switch to upstream pending merge of https://github.com/kmmbvnr/django-fsm/pull/59
-git+https://github.com/deis/django-fsm@propagate-false
 django-cors-headers==1.0.0
+# required for south migrations
+django-fsm==2.2.0
 django-guardian==1.2.5
 django-json-field==0.5.7
 djangorestframework==3.0.5


### PR DESCRIPTION
Before, we relied on django-fsm to give us a general idea of what state
the container object in the model is at. This did not give users an
accurate idea of the state of their containers. Introducing a new
.state() method to the scheduler as well as changing Container.state to
call it's own scheduler's .state() method allows users to directly
understand what state their containers are in.

closes #2766 
closes #2987

This was thoroughly tested by hand since the controller does not wrap unit tests around fleet.py, but this should cover it :)

Points: PTAL at the systemdActiveStateMap in fleet.py and let me know if the mappings between the [dbus API's ActiveState](http://www.freedesktop.org/wiki/Software/systemd/dbus/) and what used to be DjangoFSM's JobState is correct.