### PR TITLE
docs(logspout): Fix remote syslog example

### DIFF
--- a/logspout/README.md
+++ b/logspout/README.md
@@ -18,7 +18,7 @@ Logspout is a very small Docker container, so you can just pull it from the inde
 
 The simplest way to use logspout is to just take all logs and ship to a remote syslog. Just pass a default syslog target URI as the command. Also, we always mount the Docker Unix socket with `-v` to `/tmp/docker.sock`:
 
-	$ docker run -v=/var/run/docker.sock:/tmp/docker.sock deis/logspout syslog://logs.papertrailapp.com:55555
+	$ docker run -v=/var/run/docker.sock:/tmp/docker.sock deis/logspout /bin/logspout syslog://logs.papertrailapp.com:55555
 
 If deis/logspout is deployed on Deis, it will connect automatically to deis-logger via service discovery.
 


### PR DESCRIPTION
A tiny tweak to the logspout readme to include the correct Docker incantation to route logs to a syslog endpoint.