### PR TITLE
fix(logger): use godep for dependencies

### DIFF
--- a/logger/Dockerfile
+++ b/logger/Dockerfile
@@ -1,7 +1,0 @@
-FROM golang:1.3
-
-WORKDIR /go/src/github.com/deis/deis/logger
-CMD /go/bin/logger
-
-ADD . /go/src/github.com/deis/deis/logger
-RUN CGO_ENABLED=0 go get -a -ldflags '-s' github.com/deis/deis/logger

--- a/logger/Makefile
+++ b/logger/Makefile
@@ -4,15 +4,14 @@ COMPONENT = logger
 IMAGE = $(IMAGE_PREFIX)$(COMPONENT):$(BUILD_TAG)
 BUILD_IMAGE := $(COMPONENT)-build
 DEV_IMAGE = $(DEV_REGISTRY)/$(IMAGE)
+BINARY_DEST_DIR = image/bin
 
 build: check-docker
-	docker build -t $(BUILD_IMAGE) .
-	docker cp `docker run -d $(BUILD_IMAGE)`:/go/bin/logger image/bin/
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -v -ldflags '-s' -o $(BINARY_DEST_DIR)/logger github.com/deis/deis/logger || exit 1
 	docker build -t $(IMAGE) image
-	rm -rf image/bin/logger
-	-docker rm -f `docker ps | grep logger-build | awk '{print $$1}'`
 
 clean: check-docker check-registry
+	rm -f image/bin/logger
 	docker rmi $(IMAGE)
 
 full-clean: check-docker check-registry


### PR DESCRIPTION
This issue was brought up when building a new release of images for
deployment. The logger relied on `go get` to fetch dependencies. Because
there was a breaking change in the etcd client[1], the logger failed to
connect to the cluster. We have moved over to a global Godeps for
managing dependencies, so this changes the compilation on the host to
follow the other components' build process.

[1]: https://github.com/coreos/go-etcd/commit/5348c80bde6223fa53c48ef546b4802db69b1d70#diff-33c1223aac4ef741731cc8c73b4d7777L295