### PR TITLE
Revert "fix(contrib): use 1GB per VM"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ $num_instances = 1
 $update_channel = ENV["COREOS_CHANNEL"] || "stable"
 $enable_serial_logging = false
 $vb_gui = false
-$vb_memory = 1024
+$vb_memory = 2048
 $vb_cpus = 1
 
 # Attempt to apply the deprecated environment variable NUM_INSTANCES to


### PR DESCRIPTION
This reverts commit 10f80cf8528cb669780bf686bafdd7108ec5e83a.

Many tears were shed because the testing infrastructure was choking
due to having too little memory. Trying to run Deis with too little
memory invites a slew of issues.

If Deis doesn't work well on 1GB, we shouldn't easily allow people
to run it that way. Our system requirements documentation even
calls out that instances should have at least 2GB minimum. Folks can
always manually edit the file if they want to try 1GB, but in that case
it's clear that it's not recommended.

Deis is a distributed system - 8GB of RAM really isn't a ridiculous requirement.
There's always Digital Ocean test machines, or Dokku for 1-node production workloads.