### PR TITLE
chore(*): update to go 1.4.1

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/deis/deis",
-	"GoVersion": "go1.3.3",
+	"GoVersion": "go1.4.1",
 	"Packages": [
 		"./..."
 	],

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.3
+FROM golang:1.4
 
 ADD firewall /tmp/firewall
 

--- a/tests/bin/setup-node.sh
+++ b/tests/bin/setup-node.sh
@@ -23,7 +23,7 @@ wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.1_x86_64.deb
 dpkg -i vagrant_1.7.1_x86_64.deb && rm vagrant_1.7.1_x86_64.deb
 
 # install go
-wget -qO- https://storage.googleapis.com/golang/go1.3.3.linux-amd64.tar.gz | tar -C /usr/local -xz
+wget -qO- https://storage.googleapis.com/golang/go1.4.1.linux-amd64.tar.gz | tar -C /usr/local -xz
 echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile
 echo "You must reboot for the global $PATH changes to take effect."
 

--- a/tests/etcdutils/Dockerfile
+++ b/tests/etcdutils/Dockerfile
@@ -14,7 +14,7 @@ RUN buildDeps='curl git-core'; \
     set -x; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get update && apt-get install -y $buildDeps --no-install-recommends \
-    && curl -sSL https://storage.googleapis.com/golang/go1.3.1.linux-amd64.tar.gz | tar -C /usr/local -xz \
+    && curl -sSL https://storage.googleapis.com/golang/go1.4.1.linux-amd64.tar.gz | tar -C /usr/local -xz \
     && git clone -q https://github.com/coreos/etcd.git /opt/etcd \
     && cd /opt/etcd && git checkout -q v0.4.6 && PATH=/usr/local/go/bin:$PATH ./build \
     && cp /opt/etcd/bin/etcd /usr/local/bin \


### PR DESCRIPTION
Besides keeping things up-to-date, I'm working on a test refactoring that will require go 1.4 or later.