### PR TITLE
fix(*): force tags in Makefiles

### DIFF
--- a/builder/Makefile
+++ b/builder/Makefile
@@ -41,7 +41,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag $(IMAGE) $(DEV_IMAGE)
+	docker tag -f $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
 
 set-image: check-deisctl

--- a/cache/Makefile
+++ b/cache/Makefile
@@ -38,7 +38,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag $(IMAGE) $(DEV_IMAGE)
+	docker tag -f $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
 
 set-image: check-deisctl

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -36,7 +36,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag $(IMAGE) $(DEV_IMAGE)
+	docker tag -f $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
 
 set-image: check-deisctl

--- a/database/Makefile
+++ b/database/Makefile
@@ -32,7 +32,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag $(IMAGE) $(DEV_IMAGE)
+	docker tag -f $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
 
 set-image: check-deisctl

--- a/logger/Makefile
+++ b/logger/Makefile
@@ -36,7 +36,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag $(IMAGE) $(DEV_IMAGE)
+	docker tag -f $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
 
 set-image: check-deisctl

--- a/logspout/Makefile
+++ b/logspout/Makefile
@@ -38,7 +38,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag $(RELEASE_IMAGE) $(DEV_DOCKER_IMAGE)
+	docker tag -f $(RELEASE_IMAGE) $(DEV_DOCKER_IMAGE)
 	docker push $(DEV_DOCKER_IMAGE)
 
 set-image: check-deisctl

--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -26,7 +26,7 @@ install: check-deisctl
 dev-release: push set-image
 
 push: check-registry
-	docker tag $(RELEASE_IMAGE) $(REMOTE_IMAGE)
+	docker tag -f $(RELEASE_IMAGE) $(REMOTE_IMAGE)
 	docker push $(REMOTE_IMAGE)
 
 set-image: check-deisctl

--- a/registry/Makefile
+++ b/registry/Makefile
@@ -32,7 +32,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag $(IMAGE) $(DEV_IMAGE)
+	docker tag -f $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
 
 set-image: check-deisctl

--- a/router/Makefile
+++ b/router/Makefile
@@ -44,7 +44,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag $(IMAGE) $(DEV_IMAGE)
+	docker tag -f $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
 
 set-image: check-deisctl

--- a/store/Makefile
+++ b/store/Makefile
@@ -70,15 +70,15 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag $(ADMIN_IMAGE) $(ADMIN_DEV_IMAGE)
+	docker tag -f $(ADMIN_IMAGE) $(ADMIN_DEV_IMAGE)
 	docker push $(ADMIN_DEV_IMAGE)
-	docker tag $(DAEMON_IMAGE) $(DAEMON_DEV_IMAGE)
+	docker tag -f $(DAEMON_IMAGE) $(DAEMON_DEV_IMAGE)
 	docker push $(DAEMON_DEV_IMAGE)
-	docker tag $(GATEWAY_IMAGE) $(GATEWAY_DEV_IMAGE)
+	docker tag -f $(GATEWAY_IMAGE) $(GATEWAY_DEV_IMAGE)
 	docker push $(GATEWAY_DEV_IMAGE)
-	docker tag $(METADATA_IMAGE) $(METADATA_DEV_IMAGE)
+	docker tag -f $(METADATA_IMAGE) $(METADATA_DEV_IMAGE)
 	docker push $(METADATA_DEV_IMAGE)
-	docker tag $(MONITOR_IMAGE) $(MONITOR_DEV_IMAGE)
+	docker tag -f $(MONITOR_IMAGE) $(MONITOR_DEV_IMAGE)
 	docker push $(MONITOR_DEV_IMAGE)
 
 set-image: check-deisctl


### PR DESCRIPTION
When running `make build`, sometimes components fail to build,
aborting the Makefile run. After fixing the issue, building again,
and running `make dev-release`, some components
have already been tagged and emit an error like "Tag asdf already
references image bcde".

This commit makes `docker tag` force the tag, preventing
a semi-successful build from preventing releases.

replaces #2998