### PR TITLE
ref(store): rewrite store-volume to use ceph-fuse

### DIFF
--- a/deisctl/units/deis-store-volume.service
+++ b/deisctl/units/deis-store-volume.service
@@ -5,10 +5,10 @@ Description=deis-store-volume
 EnvironmentFile=/etc/environment
 ExecStartPre=/usr/bin/mkdir -p /var/lib/deis/store
 ExecStartPre=/bin/sh -c "echo waiting for store-monitor... && until etcdctl get /deis/store/monSetupComplete >/dev/null 2>&1; do sleep 2; done"
-ExecStartPre=/bin/bash -c "HOSTS=`etcdctl ls /deis/store/hosts | cut -d/ -f5 | awk '{if(NR == 1) {printf $0} else {printf \",\"$0}}'` && cat /proc/mounts |grep '/var/lib/deis/store' || mount -t ceph $HOSTS:/ /var/lib/deis/store -o name=admin,secret=`etcdctl get /deis/store/adminKeyring | grep 'key =' | cut -d' ' -f3`"
-ExecStart=/usr/bin/tail -f /dev/null
-ExecStartPost=/bin/sh -c "test -d /var/lib/deis/store/logs || mkdir -p /var/lib/deis/store/logs"
-ExecStopPost=-/usr/bin/umount /var/lib/deis/store
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-volume` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-store-volume >/dev/null 2>&1 && docker rm -f deis-store-volume >/dev/null 2>&1 || true"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-volume` && docker run --name deis-store-volume --rm -e HOST=$COREOS_PRIVATE_IPV4 -v /var/lib/deis/store:/data --cap-add SYS_ADMIN --device /dev/fuse $IMAGE"
+ExecStopPost=-/usr/bin/docker rm -f deis-store-volume
 Restart=on-failure
 RestartSec=5
 

--- a/store/Makefile
+++ b/store/Makefile
@@ -1,6 +1,6 @@
 include ../includes.mk
 
-TEMPLATE_IMAGES=admin daemon gateway metadata monitor
+TEMPLATE_IMAGES=admin daemon gateway metadata monitor volume
 BUILT_IMAGES=base $(TEMPLATE_IMAGES)
 
 ADMIN_IMAGE = $(IMAGE_PREFIX)store-admin:$(BUILD_TAG)
@@ -13,6 +13,8 @@ METADATA_IMAGE = $(IMAGE_PREFIX)store-metadata:$(BUILD_TAG)
 METADATA_DEV_IMAGE = $(DEV_REGISTRY)/$(METADATA_IMAGE)
 MONITOR_IMAGE = $(IMAGE_PREFIX)store-monitor:$(BUILD_TAG)
 MONITOR_DEV_IMAGE = $(DEV_REGISTRY)/$(MONITOR_IMAGE)
+VOLUME_IMAGE = $(IMAGE_PREFIX)store-volume:$(BUILD_TAG)
+VOLUME_DEV_IMAGE = $(DEV_REGISTRY)/$(VOLUME_IMAGE)
 
 build: check-docker
 	@# Build base as normal
@@ -80,6 +82,8 @@ push: check-registry
 	docker push $(METADATA_DEV_IMAGE)
 	docker tag -f $(MONITOR_IMAGE) $(MONITOR_DEV_IMAGE)
 	docker push $(MONITOR_DEV_IMAGE)
+	docker tag -f $(VOLUME_IMAGE) $(VOLUME_DEV_IMAGE)
+	docker push $(VOLUME_DEV_IMAGE)
 
 set-image: check-deisctl
 	deisctl config store-admin set image=$(ADMIN_DEV_IMAGE)
@@ -87,6 +91,7 @@ set-image: check-deisctl
 	deisctl config store-gateway set image=$(GATEWAY_DEV_IMAGE)
 	deisctl config store-metadata set image=$(METADATA_DEV_IMAGE)
 	deisctl config store-monitor set image=$(MONITOR_DEV_IMAGE)
+	deisctl config store-volume set image=$(VOLUME_DEV_IMAGE)
 
 release:
 	docker push $(ADMIN_IMAGE)
@@ -94,6 +99,7 @@ release:
 	docker push $(GATEWAY_IMAGE)
 	docker push $(METADATA_IMAGE)
 	docker push $(MONITOR_IMAGE)
+	docker push $(VOLUME_IMAGE)
 
 deploy: build dev-release restart
 

--- a/store/README.md
+++ b/store/README.md
@@ -14,8 +14,10 @@ Please add any issues you find with this software to the
 
 ## Containers
 
-The store component is comprised of four containers:
+The store component is comprised of six containers:
 
+* [store-admin](https://index.docker.io/u/deis/store-daemon/) - an optional administrative container
+to aid in diagnosing and resolving issues with the storage cluster
 * [store-daemon](https://index.docker.io/u/deis/store-daemon/) - the daemon which serves data
 (in Ceph, this is an object store daemon, or OSD)
 * [store-gateway](https://index.docker.io/u/deis/store-gateway/) - the blob store gateway,
@@ -24,6 +26,8 @@ offering Swift and S3-compatible bucket APIs
 to use the CephFS shared filesystem (in Ceph, this is a metadata server daemon, or MDS)
 * [store-monitor](https://index.docker.io/u/deis/store-monitor/) - the service responsible for
 keeping track of the cluster state (this is also called a monitor in Ceph)
+* [store-volume](https://index.docker.io/u/deis/store-volume/) - a container which mounts a CephFS
+FUSE filesystem to be used by other containers
 
 These are all based upon the [store-base](https://github.com/deis/deis/tree/master/store/base) image,
 which is a Docker container that preinstalls Ceph.

--- a/store/volume/Dockerfile.template
+++ b/store/volume/Dockerfile.template
@@ -1,0 +1,5 @@
+#FROM is generated dynamically by the Makefile
+
+WORKDIR /app
+CMD ["/app/bin/boot"]
+ADD bin/boot /app/bin/boot

--- a/store/volume/bin/boot
+++ b/store/volume/bin/boot
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# This script is designed to be run inside the container
+#
+
+ETCD_PORT=${ETCD_PORT:-4001}
+ETCD="$HOST:$ETCD_PORT"
+
+# write the Ceph configuration file before trying to mount the volume
+until confd -onetime -node $ETCD -config-file /app/confd.toml >/dev/null 2>&1 ; do
+  echo "store-volume: waiting for confd to write initial templates..."
+  sleep 5
+done
+
+# update the configuration file periodically because we can
+confd -node $ETCD -config-file /app/confd.toml &
+
+# mount the data directory
+ceph-fuse -d /data
+
+# prepare for application logs
+test -d /data/logs || mkdir -p /data/logs
+
+# unmount on exit
+function on_exit() {
+  fusermount -u /data
+  exit 0
+}
+trap on_exit INT TERM EXIT
+
+# loop forever until the container is stopped
+while true; do
+  sleep 1
+done
+


### PR DESCRIPTION
Several users have reported host crashes, presumably due to Ceph
kernel driver issues. This commit refactors the store-volume component
into a Docker container that uses ceph-fuse to mount the CephFS volume
instead of the kernel driver, so bugs will hopefully at most crash the
volume container and not the host.

**TODO:**
- [ ] Benchmark performance compared to the kernel driver 
- [ ] Test upgrades / switching from kernel-driven `deis-store-volume`

closes #2970
