### PR TITLE
fix(logger): create logRoot on startup

### DIFF
--- a/logger/syslogd/syslogd.go
+++ b/logger/syslogd/syslogd.go
@@ -93,6 +93,13 @@ func (h *handler) mainLoop() {
 // Listen starts a new syslog server which runs until it receives a signal.
 func Listen(signalChan chan os.Signal, cleanupDone chan bool) {
 	fmt.Println("Starting syslog...")
+	// If logRoot doesn't exist, create it
+	// equivalent to Python's `if not os.path.exists(filename)`
+	if _, err := os.Stat(logRoot); os.IsNotExist(err) {
+		if err = os.MkdirAll(logRoot, 0777); err != nil {
+			log.Fatalf("unable to create logRoot at %s", logRoot)
+		}
+	}
 	// Create a server with one handler and run one listen gorutine
 	s := syslog.NewServer()
 	s.AddHandler(newHandler())


### PR DESCRIPTION
Currently, logger expects logRoot to exist. If it doesn't,
logger will throw errors hundreds of times per second as it tries
to write a logfile.

This commit makes logger create logRoot on startup.

Note that this doesn't necessarily close #2398, as it's conceivable that permissions could change (or directories removed) while logger is already running, so a single log file write could still fail.

refs #2398