### PR TITLE
feat(logspout): use custom datetime

### DIFF
--- a/logspout/README.md
+++ b/logspout/README.md
@@ -48,6 +48,10 @@ By default, routes are ephemeral. But if you mount a volume to `/mnt/routes`, th
 
 See [Routes Resource](#routes-resource) for all options.
 
+#### Using a custom timestamp format
+
+By default, logspout will use the timestamp format `2006-01-02T15:04:05MST`. A custom format can be specified by setting the `DATETIME_FORMAT` environment variable.
+
 ## HTTP API
 
 ### Streaming Endpoints

--- a/logspout/logspout.go
+++ b/logspout/logspout.go
@@ -73,7 +73,7 @@ func syslogStreamer(target Target, types []string, logstream chan *Log) {
 		// HACK: Go's syslog package hardcodes the log format, so let's send our own message
 		_, err = fmt.Fprintf(conn,
 			"%s %s[%s]: %s",
-			time.Now().Format(dtime.DEIS_DATETIME_FORMAT),
+			time.Now().Format(getopt("DATETIME_FORMAT", dtime.DEIS_DATETIME_FORMAT)),
 			tag,
 			pid,
 			logline.Data)


### PR DESCRIPTION
This commit enables users to specify their own datetime format
by supplying the `DATETIME_FORMAT` environment variable when
using logspout. If none is supplied, logspout will continue to use
`DEIS_DATETIME_FORMAT`.

closes #3032