### PR TITLE
Let docker-in-docker choose its storage driver

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -22,7 +22,6 @@ install, and start **deis/builder**.
   its configuration (default: */deis/builder*)
 * **ETCD_TTL** sets the time-to-live before etcd purges a configuration
   value, in seconds (default: *10*)
-* **STORAGE_DRIVER** sets the Docker-in-Docker storage driver (default: btrfs)
 * **PORT** sets the TCP port on which the builder listens (default: *2222*)
 
 ## License

--- a/builder/image/bin/boot
+++ b/builder/image/bin/boot
@@ -14,7 +14,6 @@ export ETCD_PORT=${ETCD_PORT:-4001}
 export ETCD="$HOST:$ETCD_PORT"
 export ETCD_PATH=${ETCD_PATH:-/deis/builder}
 export ETCD_TTL=${ETCD_TTL:-10}
-export STORAGE_DRIVER=${STORAGE_DRIVER:-btrfs}
 
 # wait for etcd to be available
 until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do
@@ -51,7 +50,7 @@ CONFD_PID=$!
 test -e /var/run/docker.sock && rm -f /var/run/docker.sock
 
 # spawn a docker daemon to run builds
-docker -d --storage-driver=$STORAGE_DRIVER --bip=172.19.42.1/16 --insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 --insecure-registry 100.64.0.0/10 &
+docker -d --bip=172.19.42.1/16 --insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 --insecure-registry 100.64.0.0/10 &
 DOCKER_PID=$!
 
 # wait for docker to start

--- a/builder/tests/builder_test.go
+++ b/builder/tests/builder_test.go
@@ -49,7 +49,6 @@ func TestBuilder(t *testing.T) {
 			"--rm",
 			"-p", port+":22",
 			"-e", "PORT=22",
-			"-e", "STORAGE_DRIVER=aufs",
 			"-e", "HOST="+host,
 			"-e", "ETCD_PORT="+etcdPort,
 			"-e", "EXTERNAL_PORT="+port,

--- a/deisctl/units/deis-builder.service
+++ b/deisctl/units/deis-builder.service
@@ -7,6 +7,7 @@ TimeoutStartSec=30m
 ExecStartPre=/bin/sh -c "docker inspect deis-builder-data >/dev/null 2>&1 || docker run --name deis-builder-data -v /var/lib/docker ubuntu-debootstrap:14.04 /bin/true"
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker history $IMAGE >/dev/null || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-builder >/dev/null && docker rm -f deis-builder || true"
+ExecStartPre=-/bin/sh -c "/sbin/losetup -f"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker run --name deis-builder --rm -p 2223:22 --volumes-from=deis-builder-data -c 800 -e EXTERNAL_PORT=2223 -e HOST=$COREOS_PRIVATE_IPV4 --privileged $IMAGE"
 ExecStartPost=/bin/sh -c "echo 'Waiting for builder on 2223/tcp...' && until echo 'dummy-value' | ncat $COREOS_PRIVATE_IPV4 2223 >/dev/null 2>&1; do sleep 1; done"
 ExecStartPost=/usr/bin/docker exec deis-builder /usr/local/bin/push-images


### PR DESCRIPTION
Docker at one point had to be coerced into using `btrfs` on CoreOS--which had to be overridden with `aufs` for functional testing on non-`btrfs` hosts. In testing with CoreOS alpha, our choice of `btrfs` fails, since it won't work on a host filesystem formatted with `ext4`.

This change removes the `--storage-driver` override code and allows Docker(-in-Docker) to choose the best driver. This is still `btrfs` when the host filesystem matches--I verified several times inside the container. On CoreOS alpha, Docker chooses `devicemapper` (both `aufs` and `overlay` fail with "not supported"). This would be fine except there are no `/dev/loopN` devices yet, only the master `/dev/loop-control` device, and Docker will fail with "no loopback devices available." Calling `losetup -f` once before starting deis-builder ensures that the standard set of loopback devices is present and that the `devicemapper` backend will work.

(For reasons I couldn't discern, `losetup -f` from within the builder boot script fails, but works fine as a separate `ExecStartPre` task.)

I've tested this multiple times with `test-integration.sh` against all CoreOS channels.

Closes #2975.