### PR TITLE
fix(builder): ignore header when removing dangling docker images

### DIFF
--- a/builder/image/templates/check-repos
+++ b/builder/image/templates/check-repos
@@ -18,6 +18,6 @@ do
         rm -rf "$repo"
         docker images | grep $appname | awk '{ print $3 }' | xargs docker rmi -f
         # remove any dangling images left over from the cleanup
-        docker images --filter "dangling=true" | awk '{ print $3 }' | xargs docker rmi -f
+        docker images --filter "dangling=true" | awk '{ print $3 }' | grep -v IMAGE | xargs docker rmi -f
     fi
 done


### PR DESCRIPTION
After `deis apps:destroy`, deis-builder will run the [`check-repos`](https://github.com/deis/deis/blob/master/builder/image/templates/check-repos#L21) script, which does `docker rmi` on dangling images. But it includes the header line:
```console
$ docker images --filter "dangling=true" | awk '{ print $3 }'
IMAGE
ea77b2e915c0
71a345926906
77c93f4b07c3
```
causing useless Docker API output in deis-builder:
```log
Feb 06 23:48:37 deis-01 sh[4015]: [info] DELETE /v1.15/images/IMAGE?force=1
Feb 06 23:48:37 deis-01 sh[4015]: [ad780995] +job image_delete(IMAGE)
Feb 06 23:48:37 deis-01 sh[4015]: No such image: IMAGE
Feb 06 23:48:37 deis-01 sh[4015]: [ad780995] -job image_delete(IMAGE) = ERR (1)
Feb 06 23:48:37 deis-01 sh[4015]: [error] server.go:1207 Handler for DELETE /images/{name:.*} returned error: No such image: IMAGE
Feb 06 23:48:37 deis-01 sh[4015]: [error] server.go:110 HTTP Error: statusCode=404 No such image: IMAGE
Feb 06 23:48:37 deis-01 sh[4015]: 2015-02-06T23:48:37Z bd2a5eb21729 confd[155]: ERROR exit status 123
```

This change filters out the header column `IMAGE`.
```console
$ docker images --filter "dangling=true" | awk '{ print $3 }' | grep -v IMAGE
ea77b2e915c0
71a345926906
77c93f4b07c3
```

Closes #3040.