### PR TITLE
feat(builder): Adding support to lock BUILDPACK_URL to a git revision 

### DIFF
--- a/builder/image/slugbuilder/builder/build.sh
+++ b/builder/image/slugbuilder/builder/build.sh
@@ -79,7 +79,16 @@ if [[ -n "$BUILDPACK_URL" ]]; then
 
     buildpack="$buildpack_root/custom"
     rm -fr "$buildpack"
-    git clone --quiet --depth=1 "$BUILDPACK_URL" "$buildpack"
+
+    url=${BUILDPACK_URL%#*}
+    branch=${BUILDPACK_URL#*#}
+
+    if [ "$branch" == "$url" ]; then
+        branch="master"
+    fi
+
+    git clone --quiet --branch "$branch" --depth=1 "$url" "$buildpack"
+
     selected_buildpack="$buildpack"
     buildpack_name=$($buildpack/bin/detect "$build_root") && selected_buildpack=$buildpack
 else

--- a/docs/using_deis/using-buildpacks.rst
+++ b/docs/using_deis/using-buildpacks.rst
@@ -135,6 +135,14 @@ To use a custom buildpack, set the ``BUILDPACK_URL`` environment variable.
     === humble-autoharp
     BUILDPACK_URL: https://github.com/dpiddy/heroku-buildpack-ruby-minimal
 
+.. note::
+
+    If, however, you're unable to deploy using the latest version of the buildpack,
+    You can set
+    an exact version of a buildpack by using a git revision in your
+    ``BUILDPACK_URL``.
+    For example: ``BUILDPACK_URL=https://github.com/dpiddy/heroku-buildpack-ruby-minimal#v13``
+
 On your next ``git push``, the custom buildpack will be used.
 
 


### PR DESCRIPTION
You can set an exact version of a buildpack by using a git revision in your BUILDPACK_URL.
`git://repo.git#master` `git://repo.git#v1.2.0`