### PR TITLE
chore(*): bump CoreOS to 557.2.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,7 +54,7 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
 
   config.vm.box = "coreos-%s" % $update_channel
-  config.vm.box_version = ">= 522.6.0"
+  config.vm.box_version = ">= 557.2.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
 
   ["vmware_fusion", "vmware_workstation"].each do |vmware|

--- a/contrib/azure/azure-coreos-cluster
+++ b/contrib/azure/azure-coreos-cluster
@@ -33,8 +33,8 @@ parser.add_argument('--location', default='West US',
                    help='optional, [West US]')
 parser.add_argument('--ssh', default=22001, type=int,
                    help='optional, starts with 22001 and +1 for each machine in cluster')
-parser.add_argument('--coreos-image', default='2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-522.6.0',
-                   help='optional, [2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-522.6.0]')
+parser.add_argument('--coreos-image', default='2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-557.2.0',
+                   help='optional, [2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-557.2.0]')
 parser.add_argument('--num-nodes', default=3, type=int,
                    help='optional, number of nodes to create (or add), defaults to 3')
 parser.add_argument('--virtual-network-name',

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -103,15 +103,15 @@
 
   "Mappings" : {
     "CoreOSAMIs" : {
-      "eu-central-1"   : { "PV" : "ami-38093a25", "HVM" : "ami-3a093a27" },
-      "ap-northeast-1" : { "PV" : "ami-e2465fe3", "HVM" : "ami-e4465fe5" },
-      "sa-east-1"      : { "PV" : "ami-7f863a62", "HVM" : "ami-7d863a60" },
-      "ap-southeast-2" : { "PV" : "ami-db7d09e1", "HVM" : "ami-d97d09e3" },
-      "ap-southeast-1" : { "PV" : "ami-3e8da66c", "HVM" : "ami-3c8da66e" },
-      "us-east-1"      : { "PV" : "ami-3615525e", "HVM" : "ami-3415525c" },
-      "us-west-2"      : { "PV" : "ami-51134b61", "HVM" : "ami-6f134b5f" },
-      "us-west-1"      : { "PV" : "ami-bebfa6fb", "HVM" : "ami-bcbfa6f9" },
-      "eu-west-1"      : { "PV" : "ami-7bf27e0c", "HVM" : "ami-79f27e0e" }
+      "eu-central-1"   : { "PV" : "ami-88c1f295", "HVM" : "ami-8ec1f293" },
+      "ap-northeast-1" : { "PV" : "ami-ea5c46eb", "HVM" : "ami-e85c46e9" },
+      "sa-east-1"      : { "PV" : "ami-2fe95632", "HVM" : "ami-2de95630" },
+      "ap-southeast-2" : { "PV" : "ami-4fd3a775", "HVM" : "ami-4dd3a777" },
+      "ap-southeast-1" : { "PV" : "ami-70dcf622", "HVM" : "ami-72dcf620" },
+      "us-east-1"      : { "PV" : "ami-8097d4e8", "HVM" : "ami-8297d4ea" },
+      "us-west-2"      : { "PV" : "ami-f3702bc3", "HVM" : "ami-f1702bc1" },
+      "us-west-1"      : { "PV" : "ami-26b5ad63", "HVM" : "ami-24b5ad61" },
+      "eu-west-1"      : { "PV" : "ami-5b911f2c", "HVM" : "ami-5d911f2a" }
 
     },
     "RootDevices" : {

--- a/contrib/rackspace/provision-rackspace-cluster.sh
+++ b/contrib/rackspace/provision-rackspace-cluster.sh
@@ -48,8 +48,8 @@ $CONTRIB_DIR/util/check-user-data.sh
 
 i=1 ; while [[ $i -le $DEIS_NUM_INSTANCES ]] ; do \
     echo_yellow "Provisioning deis-$i..."
-    # This image is CoreOS 522.6.0 in the stable channel
-    supernova $ENV boot --image fc299ac5-433d-4b80-98ae-e097464a7758 --flavor $FLAVOR --key-name $1 --user-data $CONTRIB_DIR/coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
+    # This image is CoreOS 557.2.0 in the stable channel
+    supernova $ENV boot --image 05438eb5-af42-4bdd-bd32-309c2154927d --flavor $FLAVOR --key-name $1 --user-data $CONTRIB_DIR/coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
     ((i = i + 1)) ; \
 done
 

--- a/docs/installing_deis/baremetal.rst
+++ b/docs/installing_deis/baremetal.rst
@@ -104,8 +104,8 @@ Start the installation
 
 
 This will install the latest `CoreOS`_ stable release to disk. The Deis provision scripts for other
-platforms typically specify a CoreOS version - currently, ``522.6.0``. To specify a CoreOS
-version, append the ``-V`` parameter to the install command, e.g. ``-V 522.6.0``.
+platforms typically specify a CoreOS version - currently, ``557.2.0``. To specify a CoreOS
+version, append the ``-V`` parameter to the install command, e.g. ``-V 557.2.0``.
 
 After the installation has finished, reboot your server. Once your machine is back up, you should
 be able to log in as the `core` user using the `deis` ssh key.

--- a/docs/installing_deis/gce.rst
+++ b/docs/installing_deis/gce.rst
@@ -119,7 +119,7 @@ Launch 3 instances. You can choose another starting CoreOS image from the listin
 
 .. code-block:: console
 
-    $ for num in 1 2 3; do gcutil addinstance --use_compute_key --image projects/coreos-cloud/global/images/coreos-stable-522-6-0-v20150128 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
+    $ for num in 1 2 3; do gcutil addinstance --use_compute_key --image projects/coreos-cloud/global/images/coreos-stable-557-2-0-v20150210 --persistent_boot_disk --zone us-central1-a --machine_type n1-standard-2 --tags deis --metadata_from_file user-data:gce-user-data --disk cored${num},deviceName=coredocker --authorized_ssh_keys=core:~/.ssh/deis.pub,core:~/.ssh/google_compute_engine.pub core${num}; done
 
     Table of resources:
 


### PR DESCRIPTION
Notable changes in this version bump:

* Linux 3.18.2 (from 3.17.8)
* Docker 1.4.1 (from 1.3.3)
* fleet 0.9.0 (from 0.8.3)

closes #2745
refs #3046
