### PR TITLE
chore(registry): bump registry to fix pull timeout

### DIFF
--- a/registry/build.sh
+++ b/registry/build.sh
@@ -28,7 +28,7 @@ useradd -s /bin/bash registry
 # add the docker registry source from github
 git clone https://github.com/deis/docker-registry /docker-registry && \
     cd /docker-registry && \
-    git checkout eb62607 && \
+    git checkout 8ad7142 && \
     chown -R registry:registry /docker-registry
 
 # install boto configuration


### PR DESCRIPTION
I'm not yet letting Jenkins test this as the commit still has to be finalized, but this is here as a placeholder so we don't forget about https://github.com/deis/docker-registry/pull/9

refs https://github.com/deis/docker-registry/pull/9
closes #2916