### PR TITLE
fix(client): display default answer for auth:cancel prompt

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -753,7 +753,7 @@ class DeisClient(object):
         self._logger.info('Please log in again in order to cancel this account')
         username = self.auth_login({'<controller>': controller})
         if username:
-            confirm = raw_input("Cancel account \"{}\" at {}? (y/n) ".format(username, controller))
+            confirm = raw_input("Cancel account \"{}\" at {}? (y/N) ".format(username, controller))
             if confirm == 'y':
                 self._dispatch('delete', '/v1/auth/cancel')
                 self._settings['controller'] = None


### PR DESCRIPTION
Just making it clear that if an answer is not supplied, the default answer is no.