### PR TITLE
fix(contrib/azure): bump load balancer timeout to 20 minutes

### DIFF
--- a/contrib/azure/azure-coreos-cluster
+++ b/contrib/azure/azure-coreos-cluster
@@ -151,11 +151,13 @@ def network_config(subnet_name=None, port='59913', public_ip_name=None):
     if subnet_name:
         network.subnet_names.append(subnet_name)
     if public_ip_name:
-        network.public_ips.public_ips.append(PublicIP(name=public_ip_name))
+        ip = PublicIP(name=public_ip_name)
+        ip.idle_timeout_in_minutes = 20
+        network.public_ips.public_ips.append(ip)
     if args.deis:
         # create web endpoint with probe checking /health-check
         network.input_endpoints.input_endpoints.append(endpoint_config('web', '80', load_balancer_probe('/health-check', '80', 'http')))
-        # create builder endpoint with no health check
+        # create builder endpoint TCP probe check
         network.input_endpoints.input_endpoints.append(endpoint_config('builder', '2222', load_balancer_probe(None, '2222', 'tcp')))
     return network
 


### PR DESCRIPTION
The default is only 4 minutes, which frequently is too short to
successfully deploy an application.

closes #3053