### PR TITLE
chore(controller): update docker-py to 0.7.2

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -10,7 +10,7 @@ django-cors-headers==1.0.0
 django-guardian==1.2.5
 django-json-field==0.5.7
 djangorestframework==3.0.5
-docker-py==0.6.0
+docker-py==0.7.2
 gunicorn==19.2.1
 paramiko==1.15.2
 psycopg2==2.6

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -14,7 +14,7 @@ django-cors-headers==1.0.0
 django-guardian==1.2.5
 django-json-field==0.5.7
 djangorestframework==3.0.5
-docker-py==0.6.0
+docker-py==0.7.2
 gunicorn==19.2.1
 paramiko==1.15.2
 python-etcd==0.3.2


### PR DESCRIPTION
See https://github.com/docker/docker-py/compare/0.6.0...0.7.2

Deis still uses only the `utils.parse_repository_tag` function, so this is purely housekeeping for now.