### PR TITLE
fix(controller): ignore run procs when updating structure field

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -228,7 +228,8 @@ class App(UuidAuditedModel):
             if to_remove:
                 self._destroy_containers(to_remove)
         # save new structure to the database
-        vals = self.container_set.values('type').annotate(Count('pk')).order_by()
+        vals = self.container_set.exclude(type='run').values(
+            'type').annotate(Count('pk')).order_by()
         self.structure = {v['type']: v['pk__count'] for v in vals}
         self.save()
         return changed


### PR DESCRIPTION
Refs #3022, which still needs a cleanup fix for the fleet unit files that can be orphaned in that situation if a worker actually times out. ~~It wasn't reasonable to write a unit or integration test for this case unfortunately, IMHO, but I await the judgment of other maintainers.~~ Implemented a controller unit test that fails before this fix, passes afterward. :green_heart: