### PR TITLE
feat(router): add optional query string affinity support

### DIFF
--- a/docs/customizing_deis/router_settings.rst
+++ b/docs/customizing_deis/router_settings.rst
@@ -37,6 +37,7 @@ setting                                      description
 /deis/controller/host                        host of the controller component (set by controller)
 /deis/controller/port                        port of the controller component (set by controller)
 /deis/domains/*                              domain configuration for applications (set by controller)
+/deis/router/affinityArg                     for requests with the indicated query string variable, hash its contents to perform session affinity (default: undefined)
 /deis/router/bodySize                        nginx body size setting (default: 1m)
 /deis/router/builder/timeout/connect         proxy_connect_timeout for deis-builder (default: 10000). Unit in miliseconds
 /deis/router/builder/timeout/read            proxy_read_timeout for deis-builder (default: 1200000). Unit in miliseconds

--- a/router/build.sh
+++ b/router/build.sh
@@ -10,8 +10,8 @@ if [[ -z $DOCKER_BUILD ]]; then
   exit 1
 fi
 
-export VERSION_NGINX=nginx-1.6.2
-export VERSION_TCP_PROXY=0.4.5
+export VERSION_NGINX=nginx-1.7.10
+export VERSION_TCP_PROXY=f2156eff9f6621aaf601eaa8dee40c6820dea0b0
 export VERSION_NAXSI=0d53a64ed856e694fcb4038748c8cf6d5551a603
 
 export BUILD_PATH=/tmp/build
@@ -32,7 +32,7 @@ apt-get update \
 
 # grab the source files
 curl -sSL http://nginx.org/download/$VERSION_NGINX.tar.gz -o $BUILD_PATH/$VERSION_NGINX.tar.gz
-curl -sSL https://github.com/yaoweibin/nginx_tcp_proxy_module/archive/v$VERSION_TCP_PROXY.tar.gz -o $BUILD_PATH/$VERSION_TCP_PROXY.tar.gz
+curl -sSL https://github.com/yaoweibin/nginx_tcp_proxy_module/archive/$VERSION_TCP_PROXY.tar.gz -o $BUILD_PATH/$VERSION_TCP_PROXY.tar.gz
 curl -sSL https://github.com/nbs-system/naxsi/archive/$VERSION_NAXSI.tar.gz -o $BUILD_PATH/$VERSION_NAXSI.tar.gz
 
 # expand the source files

--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -140,8 +140,11 @@ http {
 
     ## start service definitions for each application
     {{ $useSSL := or .deis_router_sslCert "false" }}
+    {{ $affinityArg := .deis_router_affinityArg }}
     {{ $domains := .deis_domains }}{{ range $service := .deis_services }}{{ if $service.Nodes }}
     upstream {{ Base $service.Key }} {
+        {{ if $affinityArg }}hash $arg_{{ $affinityArg }} consistent;
+        {{ end }}
         {{ range $upstream := $service.Nodes }}server {{ $upstream.Value }};
         {{ end }}
     }


### PR DESCRIPTION
To be enabled with extreme prejudice. Twelve-factor processes should be
stateless and share-nothing. Sticky sessions should not be used to cache
user data in memory. Use a backing store to persist session state.

Valid uses, however, do exist and are widespread: eg. see primus/primus#147

> HTTP implementations are expected to engage in connection management,
> which includes maintaining the state of current connections,
> establishing a new connection or reusing an existing connection,
> processing messages received on a connection, detecting connection
> failures, and closing each connection.
> <cite>[RFC 7230]</cite>

Many real time systems rely on detection of connection failures at the
application level. Without session affinity, detection of connection
failures stops at the load balancer and causes undesirable side-effects
for many implementations. For instance, the Google BrowserChannel implementation
that may have led @zag2art to #2060 relies on detection of connection
failures, as does socket.io

Care should be taken when using this setting in conjunction with a 3rd party
Layer-7 load balancer. At this time, Amazon's ELB and Rackspace's Cloud Load
Balancer, for instance, only support cookie-based affinity which must be
manually enabled. Many OSI Layer-4 load balancers, such as the Azure Load
Balancer and GCE Network Load Balancing, currently perform [RFC 2474] 5-tuple
"microflow" hashing by default.

[RFC 2474]: https://tools.ietf.org/html/rfc2474
[RFC 7230]: https://tools.ietf.org/html/rfc7230