### PR TITLE
feat(router): add optional ip_hash affinity support

### DIFF
--- a/docs/customizing_deis/router_settings.rst
+++ b/docs/customizing_deis/router_settings.rst
@@ -57,6 +57,7 @@ setting                                      description
 /deis/router/gzipVary                        nginx gzipVary setting (default: on)
 /deis/router/gzipDisable                     nginx gzipDisable setting (default: "msie6")
 /deis/router/gzipTypes                       nginx gzipTypes setting (default: "application/x-javascript application/xhtml+xml application/xml application/xml+rss application/json text/css text/javascript text/plain text/xml")
+/deis/router/ipHash                          nginx ip_hash setting (default: false)
 /deis/router/serverNameHashMaxSize           nginx server_names_hash_max_size setting (default: 512)
 /deis/router/serverNameHashBucketSize        nginx server_names_hash_bucket_size (default: 64)
 /deis/router/sslCert                         cluster-wide SSL certificate

--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -129,6 +129,8 @@ http {
     {{ $useSSL := or .deis_router_sslCert "false" }}
     {{ $domains := .deis_domains }}{{ range $service := .deis_services }}{{ if $service.Nodes }}
     upstream {{ Base $service.Key }} {
+        {{ $ipHash := or .deis_router_ipHash "false" }}{{ if eq $ipHash "true" }}ip_hash;
+        {{ end }}
         {{ range $upstream := $service.Nodes }}server {{ $upstream.Value }};
         {{ end }}
     }


### PR DESCRIPTION
When enabled, this makes all requests to all apps sticky. I'd much
prefer #3088 but it looks like that means an upgrade to mainline
since the hash directive appeared in nginx-1.7.2