### PR TITLE
feat(*): add pre-commit hook to run flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,4 @@
+- repo: git://github.com/pre-commit/pre-commit-hooks
+  sha: c4c3c735fd99be1f70b89c816739c0cb0f1e9b53
+  hooks:
+    - id: flake8


### PR DESCRIPTION
I angered flake8 in #3091. Why not use standardized pre-commit hooks to run linters?

This enables the hook for `flake8`.

Considering I wrote my first line of golang yesterday, perhaps someone with a few more hours in can patch [hooks.yaml] to run `go vet` or `golint` or `whatever-it-actually-is`?

[hooks.yaml]: https://github.com/pre-commit/pre-commit-hooks/blob/master/hooks.yaml