### PR TITLE
feat(controller): worker processes named as "deis-controller"

### DIFF
--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -71,9 +71,7 @@ chmod 777 /data/logs
 sudo -E -u deis ./manage.py syncdb --migrate --noinput
 
 # spawn a gunicorn server in the background
-sudo -E -u deis gunicorn deis.wsgi -b 0.0.0.0 -w 8 -n deis --timeout=1200 --pid=/tmp/gunicorn.pid \
-                         --log-level info --error-logfile - --access-logfile - \
-                         --access-logformat '%(h)s "%(r)s" %(s)s %(b)s "%(a)s"' &
+sudo -E -u deis gunicorn -c deis/gconf.py deis.wsgi &
 
 # smart shutdown on SIGINT and SIGTERM
 function on_exit() {

--- a/controller/deis/gconf.py
+++ b/controller/deis/gconf.py
@@ -1,0 +1,9 @@
+bind = '0.0.0.0'
+workers = 8
+proc_name = 'deis-controller'
+timeout = 1200
+pidfile = '/tmp/gunicorn.pid'
+loglevel = 'info'
+errorlog = '-'
+accesslog = '-'
+access_log_format = '%(h)s "%(r)s" %(s)s %(b)s "%(a)s"'

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -16,5 +16,6 @@ paramiko==1.15.2
 psycopg2==2.6
 python-etcd==0.3.2
 PyYAML==3.11
+setproctitle==1.1.8
 static==1.1.1
 South==1.0.2


### PR DESCRIPTION
[The `-n` gunicorn option](http://docs.gunicorn.org/en/latest/settings.html#proc-name) wasn't working because the python [setproctitle](https://pypi.python.org/pypi/setproctitle/) library wasn't installed. This change also moves config options into a separate file (which facilitates signal handlers, which I've been [~~fighting~~ working with](https://github.com/deis/deis/issues/3035#issuecomment-74346603)), and renames the processes from "deis" to "deis-controller" so they're easier to identify on the host.

Before (cropped, but you get the idea):
```console
root@71881ad2ee93:/app# ps faux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root       662  0.0  0.1  18148  3180 ?        S    20:04   0:00 bash
root       680  0.0  0.1  15572  2132 ?        R+   20:04   0:00  \_ ps faux
root         1  0.0  0.1  18008  3016 ?        Ss   20:01   0:00 /bin/bash /app/bin/boot
root       122  0.0  0.1  43000  2260 ?        S    20:01   0:00 sudo -E -u deis gunicorn deis.wsgi -b 0.0.0.0 -w 8 -n deis --t
deis       129  0.0  0.5  48604 11124 ?        S    20:01   0:00  \_ /usr/bin/python /usr/local/bin/gunicorn deis.wsgi -b 0.0.0
deis       134  0.0  0.8  56308 16456 ?        S    20:01   0:00      \_ /usr/bin/python /usr/local/bin/gunicorn deis.wsgi -b 0
deis       135  0.0  0.7  56316 16408 ?        S    20:01   0:00      \_ /usr/bin/python /usr/local/bin/gunicorn deis.wsgi -b 0
deis       136  0.0  0.7  56328 16416 ?        S    20:01   0:00      \_ /usr/bin/python /usr/local/bin/gunicorn deis.wsgi -b 0
deis       137  0.0  0.7  56324 16420 ?        S    20:01   0:00      \_ /usr/bin/python /usr/local/bin/gunicorn deis.wsgi -b 0
deis       138  0.0  0.7  56344 16428 ?        S    20:01   0:00      \_ /usr/bin/python /usr/local/bin/gunicorn deis.wsgi -b 0
deis       139  0.0  0.8  56352 16436 ?        S    20:01   0:00      \_ /usr/bin/python /usr/local/bin/gunicorn deis.wsgi -b 0
deis       140  0.0  0.8  56364 16444 ?        S    20:01   0:00      \_ /usr/bin/python /usr/local/bin/gunicorn deis.wsgi -b 0
deis       141  0.0  0.8  56376 16452 ?        S    20:01   0:00      \_ /usr/bin/python /usr/local/bin/gunicorn deis.wsgi -b 0
root       123  0.0  0.1 254792  3636 ?        Sl   20:01   0:00 confd -node 172.17.8.100:4001 -config-file /app/confd.toml
root       661  0.0  0.0   4352   692 ?        S    20:04   0:00 sleep 5
```

After:
```console
root@53b96dfac6b3:/app# ps faux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root        12  0.0  0.1  18148  3112 ?        S    20:12   0:00 bash
root       147  0.0  0.1  15572  2232 ?        R+   20:12   0:00  \_ ps faux
root         1  0.0  0.1  18008  3048 ?        Ss   20:12   0:00 /bin/bash /app/bin/boot
root       108  0.0  0.1  43000  3096 ?        S    20:12   0:00 sudo -E -u deis gunicorn -c deis/gconf.py deis.wsgi
deis       113  1.1  0.7  51128 15760 ?        S    20:12   0:00  \_ gunicorn: master [deis-controller]                        
deis       120  0.5  0.9  58420 19248 ?        S    20:12   0:00      \_ gunicorn: worker [deis-controller]                    
deis       121  0.5  0.9  58432 19136 ?        S    20:12   0:00      \_ gunicorn: worker [deis-controller]                    
deis       122  0.5  0.9  58440 19148 ?        S    20:12   0:00      \_ gunicorn: worker [deis-controller]                    
deis       123  0.6  0.9  58448 19152 ?        S    20:12   0:00      \_ gunicorn: worker [deis-controller]                    
deis       124  0.5  0.9  58456 19160 ?        S    20:12   0:00      \_ gunicorn: worker [deis-controller]                    
deis       125  0.3  0.9  58464 19160 ?        S    20:12   0:00      \_ gunicorn: worker [deis-controller]                    
deis       126  0.3  0.9  58560 19164 ?        S    20:12   0:00      \_ gunicorn: worker [deis-controller]                    
deis       127  0.3  0.9  58488 19176 ?        S    20:12   0:00      \_ gunicorn: worker [deis-controller]                    
root       109  0.0  0.2 179972  6072 ?        Sl   20:12   0:00 confd -node 172.17.8.100:4001 -config-file /app/confd.toml
root       146  0.0  0.0   4352   660 ?        S    20:12   0:00 sleep 5
```