### PR TITLE
feat(contrib/ec2): Add optional extra WebSocket/TCP ELB

### DIFF
--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -405,11 +405,15 @@
   },
   "Outputs" : {
     "DNSName" : {
-      "Description" : "DNS Name of the HTTP ELB",
+      "Description" : "(Deprecated) DNS Name of Deis Web ELB",
       "Value" :  { "Fn::GetAtt" : ["DeisWebELB", "DNSName"] }
     },
-    "TCPELBName" : {
-      "Description" : "DNS Name of the TCP ELB",
+    "WebELBDNSName" : {
+        "Description" : "DNS Name of Deis Web ELB",
+        "Value" :  { "Fn::GetAtt" : ["DeisWebELB", "DNSName"] }
+    },
+    "TCPELBELBName" : {
+      "Description" : "DNS Name of Deis TCP ELB",
       "Condition" : "CreateExtraTCPELB",
       "Value" : { "Fn::GetAtt" : ["DeisTCPELB", "DNSName"] }
     }

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -98,6 +98,13 @@
       "Default": "internet-facing",
       "AllowedValues" : [ "internet-facing", "internal" ],
       "ConstraintDescription" : "must be either 'internet-facing' for public use, or 'internal' for private use"
+    },
+    "ExtraTCPELB": {
+        "Description": "Whether to create an extra TCP configured ELB (necessary for websocket support)",
+        "Type": "String",
+        "Default": "false",
+        "AllowedValues" : [ "true", "false" ],
+        "ConstraintDescription" : "must be either true or false"
     }
   },
 
@@ -133,6 +140,12 @@
            ""
         ]
       }]
+    },
+    "CreateExtraTCPELB" : {
+      "Fn::Equals" : [
+        { "Ref" : "ExtraTCPELB" },
+          "true"
+      ]
     }
   },
 
@@ -241,7 +254,8 @@
             {"Key": "Name", "Value": "Deis", "PropagateAtLaunch": true}
         ],
         "LoadBalancerNames": [
-          { "Ref": "DeisWebELB" }
+          { "Ref": "DeisWebELB" },
+          { "Fn::If" : [ "CreateExtraTCPELB", { "Ref": "DeisTCPELB" }, { "Ref": "AWS::NoValue" } ] }
         ]
       }
     },
@@ -314,6 +328,47 @@
         }
       }
     },
+    "DeisTCPELB": {
+        "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+        "Condition": "CreateExtraTCPELB",
+        "DependsOn" : "GatewayToInternet",
+        "Properties": {
+            "Scheme" : {"Ref": "ELBScheme"},
+            "HealthCheck": {
+                "HealthyThreshold": "4",
+                "Interval": "15",
+                "Target": "HTTP:80/health-check",
+                "Timeout": "5",
+                "UnhealthyThreshold": "2"
+            },
+            "Subnets": [
+                { "Ref" : "Subnet1" },
+                { "Ref" : "Subnet2" }
+            ],
+            "Listeners": [
+                {
+                    "InstancePort": "80",
+                    "InstanceProtocol": "TCP",
+                    "LoadBalancerPort": "80",
+                    "Protocol": "TCP"
+                },
+                {
+                    "InstancePort": "2222",
+                    "InstanceProtocol": "TCP",
+                    "LoadBalancerPort": "2222",
+                    "Protocol": "TCP"
+                }
+            ],
+            "SecurityGroups": [
+                {
+                    "Fn::GetAtt": ["DeisWebELBSecurityGroup", "GroupId"]
+                }
+            ],
+            "ConnectionSettings": {
+                "IdleTimeout": 1200
+            }
+        }
+    },
     "DeisWebELBSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
@@ -350,8 +405,13 @@
   },
   "Outputs" : {
     "DNSName" : {
-      "Description" : "DNS Name of the ELB",
+      "Description" : "DNS Name of the HTTP ELB",
       "Value" :  { "Fn::GetAtt" : ["DeisWebELB", "DNSName"] }
+    },
+    "TCPELBName" : {
+      "Description" : "DNS Name of the TCP ELB",
+      "Condition" : "CreateExtraTCPELB",
+      "Value" : { "Fn::GetAtt" : ["DeisTCPELB", "DNSName"] }
     }
   }
 }

--- a/contrib/ec2/gen-json.py
+++ b/contrib/ec2/gen-json.py
@@ -104,6 +104,7 @@ if VPC_ID and VPC_SUBNETS and VPC_ZONES and len(VPC_SUBNETS.split(',')) == len(V
   del template['Resources']['PublicRoute']
   del template['Resources']['CoreOSServerLaunchConfig']['DependsOn']
   del template['Resources']['DeisWebELB']['DependsOn']
+  del template['Resources']['DeisTCPELB']['DependsOn']
 
   # update VpcId fields
   template['Resources']['DeisWebELBSecurityGroup']['Properties']['VpcId'] = VPC_ID
@@ -113,5 +114,6 @@ if VPC_ID and VPC_SUBNETS and VPC_ZONES and len(VPC_SUBNETS.split(',')) == len(V
   template['Resources']['CoreOSServerAutoScale']['Properties']['AvailabilityZones'] = VPC_ZONES.split(',')
   template['Resources']['CoreOSServerAutoScale']['Properties']['VPCZoneIdentifier'] = VPC_SUBNETS.split(',')
   template['Resources']['DeisWebELB']['Properties']['Subnets'] = VPC_SUBNETS.split(',')
+  template['Resources']['DeisTCPELB']['Properties']['Subnets'] = VPC_SUBNETS.split(',')
 
 print json.dumps(template)

--- a/docs/installing_deis/aws.rst
+++ b/docs/installing_deis/aws.rst
@@ -119,6 +119,13 @@ If updated with update-ec2-cluster.sh, the InstanceType will only impact newly d
 NOTE: The smallest recommended instance size is `large`. Having not enough CPU or RAM will result
 in numerous issues when using the cluster.
 
+.. _deis_on_aws_websockets:
+
+WebSockets
+----------
+
+If you plan to use WebSockets. Enable ``ExtraTCPELB`` in the ``cloudformation.json`` and see
+:ref:`configure-websockets`.
 
 Launch into an existing VPC
 ---------------------------

--- a/docs/installing_deis/aws.rst
+++ b/docs/installing_deis/aws.rst
@@ -103,6 +103,10 @@ in `cloudformation.json`_. For example, to configure all of the optional setting
     {
         "ParameterKey":     "ELBScheme",
         "ParameterValue":   "internal"
+    },
+    {
+        "ParameterKey":     "ExtraTCPELB",
+        "ParameterValue":   "true"
     }
 
 

--- a/docs/managing_deis/configure-websockets.rst
+++ b/docs/managing_deis/configure-websockets.rst
@@ -1,0 +1,58 @@
+:title: Using WebSockets
+:description: Learn how to enable WebSockets on your Deis installation
+
+.. _configure-websockets:
+
+Configure WebSockets
+=========================
+The Deis platform supports WebSockets out of the box, however, most Deis deployments have a load
+balancer in front of the Deis :ref:`router`, as seen in the diagram:
+
+.. image:: DeisLoadBalancerDiagram.png
+    :alt: Deis Load Balancer Diagram
+
+The load balancer in front of Deis must also support WebSockets in order to have a fully working
+WebSockets environment on  your Deis deployment. `Amazon Elastic Load Balancer`_,
+`Rackspace Cloud Load Balancer`_, and possibly other providers' load balancers does not support
+WebSockets out of the box without switching the load balancers transport protocol from **HTTP** to
+**TCP**.
+
+.. _`Amazon Elastic Load Balancer`: https://forums.aws.amazon.com/thread.jspa?threadID=84606
+.. _`Rackspace Cloud Load Balancer`: https://community.rackspace.com/products/f/25/t/3362
+
+AWS (EC2)
+----------
+Since AWS ELB does not support WebSockets out of the box in HTTP mode, and setting the ELB in TCP
+mode results in the loss of origin IP address and scheme information (``X-Forwarded-For``,
+``X-Forwarded-Scheme``), the recommended workaround until AWS ELB supports WebSockets is creating a
+extra load balancer for WebSocket traffic in TCP Mode.
+
+To enable the extra load balancer, see :ref:`AWS - WebSockets <deis_on_aws_websockets>`.
+
+Example application setup:
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Application at ``example.com`` with WebSocket endpoint at ``example.com/ws``
+
+Configure DNS for ``www.example.com`` to access ``DeisWebELB`` (CNAME)
+Configure DNS for  ``ws.example.com`` to access ``DeisTCPELB`` (CNAME)
+
+Add both ``www.example.com`` and ``ws.example.com`` as domains to the
+application.
+
+Access websocket endpoint at ``ws.example.com/ws``.
+
+Rackspace
+---------
+Rackspaces Cloud Load Balancer does not support WebSockets out of the box. By changing the protocol
+from HTTP(S) to TCP_CLIENT_FIRST, WebSockets should work.
+
+``X-Forwarded-For`` will be incorrect, and Rackspace does not currently support the PROXY protocol.
+
+An alternative solution would be to have one load balancer use HTTP, and then another load balancer
+for the websocket specific part of the application set to ``TCP_CLIENT_FIRST``.
+
+DigitalOcean
+------------
+The current DigitalOcean setup uses DNS based load balancing, meaning that there is not an
+intermediate load balancer between the end user/customer and Deis. WebSockets should work
+out of the box with proper ``X-Forwarded-For`` headers being sent to your applications.

--- a/docs/managing_deis/index.rst
+++ b/docs/managing_deis/index.rst
@@ -15,6 +15,7 @@ Managing Deis
     backing_up_data
     configure-dns
     configure-load-balancers
+    configure-websockets
     disk_usage
     operational_tasks
     platform_logging


### PR DESCRIPTION
This is my follow up to #2717.

AWS ELB does not currently support WebSockets out of the box with load balancers set in HTTP mode. However, if the ELB is configured in TCP mode WebSockets work, but `deis-router` will be unable to inform the application about the origin request IP and scheme - (`X-Forwarded-For`, `X-Forwarded-Scheme`).

By setting `ExtraTCPELB` to `true` in `cloudformation.json`, two load balancers will be configured: The default one in HTTP mode a extra one in TCP mode allowing WebSocket access over a seperate endpoint.

This is a non-ideal (hopefully temporarily) workaround until AWS proper WebSocket support to ELB.

### Example usage:
Application at `example.com` with WebSocket endpoint at `example.com/ws`

    Configure www.example.com to access DeisWebELB (CNAME)
    Configure  ws.example.com to access DeisTCPELB (CNAME)
    
Add both `www.example.com` and `ws.example.com` as domains to the application.
    
Access websocket endpoint at `ws.example.com/ws`.

--

This PR will require **manual testing** .

Steps to test:
1. In `cloudformation.json` set `ExtraTCPELB` to `true`.
2. Provision
3. You should see a extra ELB being provisioned, and it being added to the AutoScaling group (which is the key to the PR, as the autoscaling group cannot add more load balancers once created). 
4. In `cloudformation.json` set `ExtraTCPELB` to `false` (or nothing)
5. Everything should be as before. No extra load balancer should be created nor added to autoscaling group.