### PR TITLE
fix(tests): source /etc/environment only if it exists

### DIFF
--- a/builder/image/bin/boot
+++ b/builder/image/bin/boot
@@ -6,7 +6,9 @@
 # fail hard and fast even on pipelines
 set -eo pipefail
 
-source /etc/environment_proxy
+if [[ -f /etc/environment_proxy ]]; then
+	source /etc/environment_proxy
+fi
 
 # set debug based on envvar
 [[ $DEBUG ]] && set -x

--- a/builder/image/bin/entry
+++ b/builder/image/bin/entry
@@ -1,17 +1,19 @@
 #!/bin/bash
 set -eo pipefail
 
-source /etc/environment_proxy
+if [[ -f /etc/environment_proxy ]]; then
+	source /etc/environment_proxy
+fi
 
 # START jpetazzo/dind wrapper
 
 # First, make sure that cgroups are mounted correctly.
 CGROUP=/sys/fs/cgroup
 
-[ -d $CGROUP ] || 
+[ -d $CGROUP ] ||
 	mkdir $CGROUP
 
-mountpoint -q $CGROUP || 
+mountpoint -q $CGROUP ||
 	mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup $CGROUP || {
 		echo "Could not make a tmpfs mount. Did you use -privileged?"
 		exit 1
@@ -29,7 +31,7 @@ fi
 for SUBSYS in $(cut -d: -f2 /proc/1/cgroup)
 do
         [ -d $CGROUP/$SUBSYS ] || mkdir $CGROUP/$SUBSYS
-        mountpoint -q $CGROUP/$SUBSYS || 
+        mountpoint -q $CGROUP/$SUBSYS ||
                 mount -n -t cgroup -o $SUBSYS cgroup $CGROUP/$SUBSYS
 
         # The two following sections address a bug which manifests itself

--- a/builder/image/slugbuilder/builder/build.sh
+++ b/builder/image/slugbuilder/builder/build.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eo pipefail
 
-source /etc/environment_proxy
+if [[ -f /etc/environment_proxy ]]; then
+	source /etc/environment_proxy
+fi
 
 if [[ "$1" == "-" ]]; then
     slug_file="$1"

--- a/builder/image/slugrunner/runner/init
+++ b/builder/image/slugrunner/runner/init
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eo pipefail
 
-source /etc/environment_proxy
+if [[ -f /etc/environment_proxy ]]; then
+	source /etc/environment_proxy
+fi
 
 ## Load slug from Bind Mount, URL or STDIN
 


### PR DESCRIPTION
The proxy settings added in #2825 included a [workaround](https://github.com/deis/deis/blob/master/builder/tests/builder_test.go#L69) for the builder functional tests that does not work for `boot2docker`. The mount either fails or appears as a directory inside the container, which hangs up `/app/bin/entry/` or `/app/bin/boot`.

This changes each `source /etc/environment_proxy` line in builder to be conditional on whether that file exists. This fixes running the functional tests on a Mac, and seems to me more backward-compatible.