### PR TITLE
feat(router): Removed X-Deis-Upstream

### DIFF
--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -171,8 +171,6 @@ http {
             }
             {{ end }}
 
-            add_header                  X-Deis-Upstream   $upstream_addr;
-
             proxy_pass                  http://{{ Base $service.Key }};
         }
         {{ else }}


### PR DESCRIPTION
I'm with @TrollWarlord and his comment in https://github.com/deis/deis/issues/1078#issuecomment-74879266, that leaking internal IPs is a bad thing.

The information, which instance handled which request, should be also available via `deis logs`.
