### PR TITLE
Update docker-registry to v0.9.1

### DIFF
--- a/builder/image/Dockerfile
+++ b/builder/image/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F9
 RUN apt-get update && apt-get install -yq \
     openssh-server git \
     aufs-tools iptables lxc \
-    lxc-docker-1.3.3
+    lxc-docker-1.4.1
 
 # configure ssh server
 RUN rm /etc/ssh/ssh_host_*

--- a/registry/bin/boot
+++ b/registry/bin/boot
@@ -91,7 +91,7 @@ if [[ ! -z $EXTERNAL_PORT ]]; then
 		|| [[ `etcdctl --no-sync -C $ETCD get ${ETCD_PATH}/masterLock` == "$HOSTNAME" ]] ; then
 			etcdctl --no-sync -C $ETCD set $ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
 			etcdctl --no-sync -C $ETCD set $ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null
-			etcdctl --no-sync -C $ETCD update ${ETCD_PATH}/masterLock $HOSTNAME --ttl $ETCD_TTL >/dev/null 
+			etcdctl --no-sync -C $ETCD update ${ETCD_PATH}/masterLock $HOSTNAME --ttl $ETCD_TTL >/dev/null
 		fi
 		etcdctl --no-sync -C $ETCD set $HOST_ETCD_PATH/host $HOST --ttl $ETCD_TTL >/dev/null
 		etcdctl --no-sync -C $ETCD set $HOST_ETCD_PATH/port $EXTERNAL_PORT --ttl $ETCD_TTL >/dev/null


### PR DESCRIPTION
I updated our private support [tweaks to docker-registry](https://github.com/deis/docker-registry/compare/docker:0.9.1...new-repository-import-v091) against v0.9.1 of docker-registry. This required fixing the tests and some code to match new validation and behavior. Then I fixed our docker checksum calculation to match the behavior in docker-registry's current tests, purged the `TarSum` class we don't use now, had deis-registry build from the new-repository-import-v091 branch, and updated builder's docker to 1.4.1.

Closes #3079.