### PR TITLE
ref(*): clean up most code linter warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,8 @@ test-style:
 # display output, then check
 	$(GOFMT) $(GO_PACKAGES)
 	@$(GOFMT) $(GO_PACKAGES) | read; if [ $$? == 0 ]; then echo "gofmt check failed."; exit 1; fi
-# FIXME: make this mandatory
-	-$(GOVET) $(GO_PACKAGES_REPO_PATH)
-# FIXME: make this mandatory
+	$(GOVET) $(GO_PACKAGES_REPO_PATH)
 	@for i in $(addsuffix /...,$(GO_PACKAGES)); do \
 		$(GOLINT) $$i; \
 	done
-	@$(foreach C, $(COMPONENTS), $(MAKE) -C $(C) test-style &&) echo done
-	@$(foreach C, $(CLIENTS), $(MAKE) -C $(C) test-style &&) echo done
+	@$(foreach C, tests $(CLIENTS) $(COMPONENTS), $(MAKE) -C $(C) test-style &&) echo done

--- a/builder/Makefile
+++ b/builder/Makefile
@@ -4,7 +4,7 @@ include ../includes.mk
 repo_path = github.com/deis/deis/builder
 
 GO_FILES = types.go utils.go utils_test.go
-GO_PACKAGES = bin
+GO_PACKAGES = bin tests
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
 
 COMPONENT = $(notdir $(repo_path))
@@ -71,10 +71,8 @@ test-style:
 # display output, then check
 	$(GOFMT) $(GO_PACKAGES) $(GO_FILES)
 	@$(GOFMT) $(GO_PACKAGES) $(GO_FILES) | read; if [ $$? == 0 ]; then echo "gofmt check failed."; exit 1; fi
-# FIXME: make this mandatory
-	-$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
-# FIXME: make this mandatory
-	-$(GOLINT) ./...
+	$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
+	$(GOLINT) ./...
 
 cedarish/build:
 	mkdir -p build

--- a/builder/bin/generate-buildhook.go
+++ b/builder/bin/generate-buildhook.go
@@ -28,7 +28,7 @@ func main() {
 	var procfile builder.ProcessType
 	assert(json.Unmarshal([]byte(os.Args[5]), &procfile))
 
-	var dockerfile string = os.Args[6]
+	var dockerfile = os.Args[6]
 	if dockerfile == "false" {
 		dockerfile = ""
 	}

--- a/builder/bin/yaml2json-procfile.go
+++ b/builder/bin/yaml2json-procfile.go
@@ -21,7 +21,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	procfile, err := builder.YamlToJson(bytes)
+	procfile, err := builder.YamlToJSON(bytes)
 
 	if err != nil {
 		fmt.Println("the procfile does not contains a valid yaml structure")

--- a/builder/utils.go
+++ b/builder/utils.go
@@ -9,8 +9,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// YamlToJson takes an input yaml string, parses it and returns a string formatted as json.
-func YamlToJson(bytes []byte) (string, error) {
+// YamlToJSON takes an input yaml string, parses it and returns a string formatted as json.
+func YamlToJSON(bytes []byte) (string, error) {
 	var anomaly map[string]string
 
 	if err := yaml.Unmarshal(bytes, &anomaly); err != nil {
@@ -39,6 +39,7 @@ func ParseConfig(res *http.Response) (*Config, error) {
 	return &config, err
 }
 
+// ParseDomain returns the domain field from the bytes of a build hook response.
 func ParseDomain(bytes []byte) (string, error) {
 	var hook BuildHookResponse
 	if err := json.Unmarshal(bytes, &hook); err != nil {
@@ -56,6 +57,7 @@ func ParseDomain(bytes []byte) (string, error) {
 	return hook.Domains[0], nil
 }
 
+// ParseReleaseVersion returns the version field from the bytes of a build hook response.
 func ParseReleaseVersion(bytes []byte) (int, error) {
 	var hook BuildHookResponse
 	if err := json.Unmarshal(bytes, &hook); err != nil {
@@ -69,9 +71,10 @@ func ParseReleaseVersion(bytes []byte) (int, error) {
 	return hook.Release["version"], nil
 }
 
+// GetDefaultType returns the default process types given a YAML byte array.
 func GetDefaultType(bytes []byte) (string, error) {
 	type YamlTypeMap struct {
-		DefaultProcessTypes ProcessType `default_process_types`
+		DefaultProcessTypes ProcessType `yaml:"default_process_types"`
 	}
 
 	var p YamlTypeMap
@@ -93,6 +96,7 @@ func GetDefaultType(bytes []byte) (string, error) {
 	return string(retVal), nil
 }
 
+// ParseControllerConfig returns configuration key/value pair strings from a config.
 func ParseControllerConfig(bytes []byte) ([]string, error) {
 	var controllerConfig Config
 	if err := json.Unmarshal(bytes, &controllerConfig); err != nil {

--- a/builder/utils_test.go
+++ b/builder/utils_test.go
@@ -29,7 +29,7 @@ func stringInSlice(list []string, s string) bool {
 	return false
 }
 
-func TestYamlToJsonGood(t *testing.T) {
+func TestYamlToJSONGood(t *testing.T) {
 	goodProcfiles := [][]byte{
 		[]byte(`web: while true; do echo hello; sleep 1; done`),
 
@@ -42,7 +42,7 @@ worker: while true; do echo hello; sleep 1; done`),
 	goodProcess := "while true; do echo hello; sleep 1; done"
 
 	for _, procfile := range goodProcfiles {
-		data, err := YamlToJson(procfile)
+		data, err := YamlToJSON(procfile)
 		if err != nil {
 			t.Errorf("expected procfile to be valid, got '%v'", err)
 		}
@@ -169,7 +169,7 @@ func TestParseControllerConfigGood(t *testing.T) {
 }
 
 func TestTimeSerialize(t *testing.T) {
-	time, err := json.Marshal(&dtime.Time{time.Now().UTC()})
+	time, err := json.Marshal(&dtime.Time{Time: time.Now().UTC()})
 
 	if err != nil {
 		t.Errorf("expected to be able to serialize time as json, got '%v'", err)

--- a/cache/Makefile
+++ b/cache/Makefile
@@ -3,7 +3,7 @@ include ../includes.mk
 # the filepath to this repository, relative to $GOPATH/src
 repo_path = github.com/deis/deis/cache
 
-GO_PACKAGES = image
+GO_PACKAGES = . tests
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
 
 COMPONENT = $(notdir $(repo_path))
@@ -65,10 +65,8 @@ test-style:
 # display output, then check
 	$(GOFMT) $(GO_PACKAGES)
 	@$(GOFMT) $(GO_PACKAGES) | read; if [ $$? == 0 ]; then echo "gofmt check failed."; exit 1; fi
-# FIXME: make this mandatory
-	-$(GOVET) $(GO_PACKAGES_REPO_PATH)
-# FIXME: make this mandatory
-	-$(GOLINT) ./...
+	$(GOVET) $(GO_PACKAGES_REPO_PATH)
+	$(GOLINT) ./...
 
 test-functional:
 	@docker history deis/test-etcd >/dev/null 2>&1 || docker pull deis/test-etcd:latest

--- a/deisctl/Makefile
+++ b/deisctl/Makefile
@@ -47,10 +47,8 @@ test-style:
 # display output, then check
 	$(GOFMT) $(GO_PACKAGES) $(GO_FILES)
 	@$(GOFMT) $(GO_PACKAGES) $(GO_FILES) | read; if [ $$? == 0 ]; then echo "gofmt check failed."; exit 1; fi
-# FIXME: make this mandatory
-	-$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
-# FIXME: make this mandatory
-	-$(GOLINT) ./...
+	$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
+	$(GOLINT) ./...
 
 test-unit:
 	godep go test -v -cover ./...

--- a/logger/Makefile
+++ b/logger/Makefile
@@ -4,8 +4,9 @@ include ../includes.mk
 repo_path = github.com/deis/deis/logger
 
 GO_FILES = main.go
-GO_PACKAGES = syslog syslogd
+GO_PACKAGES = syslog syslogd tests
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
+GO_TESTABLE_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,syslog syslogd)
 
 COMPONENT = $(notdir $(repo_path))
 IMAGE = $(IMAGE_PREFIX)$(COMPONENT):$(BUILD_TAG)
@@ -71,13 +72,11 @@ test-style:
 # display output, then check
 	$(GOFMT) $(GO_PACKAGES) $(GO_FILES)
 	@$(GOFMT) $(GO_PACKAGES) $(GO_FILES) | read; if [ $$? == 0 ]; then echo "gofmt check failed."; exit 1; fi
-# FIXME: make this mandatory
-	-$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
-# FIXME: make this mandatory
-	-$(GOLINT) ./...
+	$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
+	$(GOLINT) ./...
 
 test-unit: test-style
-	$(GOTEST) $(GO_PACKAGES_REPO_PATH)
+	$(GOTEST) $(GO_TESTABLE_PACKAGES_REPO_PATH)
 
 coverage:
 	go test -coverprofile coverage.out ./syslog

--- a/logspout/Makefile
+++ b/logspout/Makefile
@@ -71,10 +71,8 @@ test-style:
 # display output, then check
 	$(GOFMT) $(GO_PACKAGES) $(GO_FILES)
 	@$(GOFMT) $(GO_PACKAGES) $(GO_FILES) | read; if [ $$? == 0 ]; then echo "gofmt check failed."; exit 1; fi
-# FIXME: make this mandatory
-	-$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
-# FIXME: make this mandatory
-	-$(GOLINT) ./...
+	$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
+	$(GOLINT) ./...
 
 test-unit:
 	@echo no unit tests

--- a/logspout/logspout.go
+++ b/logspout/logspout.go
@@ -73,7 +73,7 @@ func syslogStreamer(target Target, types []string, logstream chan *Log) {
 		// HACK: Go's syslog package hardcodes the log format, so let's send our own message
 		_, err = fmt.Fprintf(conn,
 			"%s %s[%s]: %s",
-			time.Now().Format(getopt("DATETIME_FORMAT", dtime.DEIS_DATETIME_FORMAT)),
+			time.Now().Format(getopt("DATETIME_FORMAT", dtime.DeisDatetimeFormat)),
 			tag,
 			pid,
 			logline.Data)

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -2,7 +2,8 @@ package time
 
 import "time"
 
-const DEIS_DATETIME_FORMAT string = "2006-01-02T15:04:05MST"
+// DeisDatetimeFormat is the standard date/time representation used in Deis.
+const DeisDatetimeFormat string = "2006-01-02T15:04:05MST"
 
 // Time represents the standard datetime format used across the Deis Platform.
 type Time struct {
@@ -10,19 +11,19 @@ type Time struct {
 }
 
 func (t *Time) format() string {
-	return t.Time.Format(DEIS_DATETIME_FORMAT)
+	return t.Time.Format(DeisDatetimeFormat)
 }
 
 // MarshalJSON implements the json.Marshaler interface.
 // The time is a quoted string in Deis' datetime format.
 func (t *Time) MarshalJSON() ([]byte, error) {
-	return []byte(t.Time.Format(`"` + DEIS_DATETIME_FORMAT + `"`)), nil
+	return []byte(t.Time.Format(`"` + DeisDatetimeFormat + `"`)), nil
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 // The time is expected to be in Deis' datetime format.
 func (t *Time) UnmarshalText(data []byte) (err error) {
-	tt, err := time.Parse(DEIS_DATETIME_FORMAT, string(data))
+	tt, err := time.Parse(DeisDatetimeFormat, string(data))
 	*t = Time{tt}
 	return
 }
@@ -31,7 +32,7 @@ func (t *Time) UnmarshalText(data []byte) (err error) {
 // The time is expected to be a quoted string in Deis' datetime format.
 func (t *Time) UnmarshalJSON(data []byte) (err error) {
 	// Fractional seconds are handled implicitly by Parse.
-	tt, err := time.Parse(`"`+DEIS_DATETIME_FORMAT+`"`, string(data))
+	tt, err := time.Parse(`"`+DeisDatetimeFormat+`"`, string(data))
 	*t = Time{tt}
 	return
 }

--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -61,10 +61,8 @@ test-style:
 # display output, then check
 	$(GOFMT) $(GO_PACKAGES) $(GO_FILES)
 	@$(GOFMT) $(GO_PACKAGES) $(GO_FILES) | read; if [ $$? == 0 ]; then echo "gofmt check failed."; exit 1; fi
-# FIXME: make this mandatory
-	-$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
-# FIXME: make this mandatory
-	-$(GOLINT) ./...
+	$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
+	$(GOLINT) ./...
 
 test-unit:
 	godep go test -v ./...

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -34,7 +34,7 @@ func main() {
 	}
 	etcdClient := etcd.NewClient([]string{"http://" + etcdHost + ":4001"})
 
-	server := &server.Server{client, etcdClient}
+	server := &server.Server{DockerClient: client, EtcdClient: etcdClient}
 
 	go server.Listen(etcdTTL)
 

--- a/publisher/server/publisher.go
+++ b/publisher/server/publisher.go
@@ -100,7 +100,7 @@ func (s *Server) publishContainer(container *docker.APIContainers, ttl time.Dura
 	}
 }
 
-// isPublishableApp determines if the application should be published to etcd.
+// IsPublishableApp determines if the application should be published to etcd.
 func (s *Server) IsPublishableApp(name string) bool {
 	r := regexp.MustCompile(appNameRegex)
 	match := r.FindStringSubmatch(name)
@@ -115,9 +115,8 @@ func (s *Server) IsPublishableApp(name string) bool {
 	}
 	if version >= latestRunningVersion(s.EtcdClient, appName) {
 		return true
-	} else {
-		return false
 	}
+	return false
 }
 
 // latestRunningVersion retrieves the highest version of the application published

--- a/router/Makefile
+++ b/router/Makefile
@@ -4,7 +4,7 @@ include ../includes.mk
 repo_path = github.com/deis/deis/router
 
 GO_FILES = boot.go
-GO_PACKAGES = logger
+GO_PACKAGES = logger tests
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
 
 COMPONENT = $(notdir $(repo_path))
@@ -68,10 +68,8 @@ test-style:
 # display output, then check
 	$(GOFMT) $(GO_PACKAGES) $(GO_FILES)
 	@$(GOFMT) $(GO_PACKAGES) $(GO_FILES) | read; if [ $$? == 0 ]; then echo "gofmt check failed."; exit 1; fi
-# FIXME: make this mandatory
-	-$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
-# FIXME: make this mandatory
-	-$(GOLINT) ./...
+	$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
+	$(GOLINT) ./...
 
 test-unit:
 	@echo no unit tests

--- a/router/logger/stdout_formatter.go
+++ b/router/logger/stdout_formatter.go
@@ -8,9 +8,11 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
+// StdOutFormatter formats log messages from the router component.
 type StdOutFormatter struct {
 }
 
+// Format rewrites a log entry for stdout as a byte array.
 func (f *StdOutFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	b := &bytes.Buffer{}
 	fmt.Fprintf(b, "[%s] - %s\n", strings.ToUpper(entry.Level.String()), entry.Message)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -42,12 +42,10 @@ test-style:
 # display output, then check
 	$(GOFMT) $(GO_PACKAGES) $(GO_FILES)
 	@$(GOFMT) $(GO_PACKAGES) $(GO_FILES) | read; if [ $$? == 0 ]; then echo "gofmt check failed."; exit 1; fi
-# FIXME: make this mandatory
-	-$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
-# FIXME: make this mandatory
-	-$(GOLINT) ./...
+	$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
+	$(GOLINT) ./...
 
 nuke_from_orbit:
 	-docker kill `docker ps -q`
-	-docker rm `docker ps -a -q`
+	-docker rm -v `docker ps -a -q`
 	-docker rmi -f `docker images -q`

--- a/tests/dockercli/dockercli.go
+++ b/tests/dockercli/dockercli.go
@@ -1,5 +1,4 @@
 // Package dockercli provides helper functions for testing with Docker.
-
 package dockercli
 
 import (

--- a/tests/etcdutils/etcdutils.go
+++ b/tests/etcdutils/etcdutils.go
@@ -1,5 +1,4 @@
 // Package etcdutils helps test interactions with etcd.
-
 package etcdutils
 
 import (

--- a/tests/mock/mock.go
+++ b/tests/mock/mock.go
@@ -1,5 +1,4 @@
 // Package mock provides mock objects and setup for Deis tests.
-
 package mock
 
 import (

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -1,5 +1,4 @@
 // Package utils contains commonly useful functions from Deis testing.
-
 package utils
 
 import (

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,4 @@
 package version
 
+// Version identifies this Deis product revision.
 const Version = "1.4.0-dev"


### PR DESCRIPTION
This change cleans up some go language constructs and adds comments. It also makes the `go vet` command in `make test-style` mandatory. (`golint` always returns 0, so it can't easily be made mandatory, and that is not recommended anyway.)

I left a few warnings alone--all those in logspout, plus:
```
backend/fleet/fleet.go:6:6: type name will be used as fleet.FleetClient by other packages, and that stutters; consider calling this Client
syslog/message.go:9:6: type name will be used as syslog.SyslogMessage by other packages, and that stutters; consider calling this Message
```
That code originated elsewhere and I wasn't willing to change the package names without more thought. And logspout has no code comments at all, even upstream. :disappointed: 

Refs #2158, which we can still fix separately if we want to, although we might want to also look at changes in logspout upstream at the same time.