### PR TITLE
Proposal: deis ps:restart

### DIFF
--- a/controller/api/urls.py
+++ b/controller/api/urls.py
@@ -41,6 +41,9 @@ urlpatterns = patterns(
     # application actions
     url(r'^apps/(?P<id>{})/scale/?'.format(settings.APP_URL_REGEX),
         views.AppViewSet.as_view({'post': 'scale'})),
+    url(r'^apps/(?P<id>{})/restart/(?P<type>[-_\w]+)/(?P<num>[-_\w]+)/?'.format(
+        settings.APP_URL_REGEX),
+        views.AppViewSet.as_view({'post': 'restart'})),
     url(r'^apps/(?P<id>{})/logs/?'.format(settings.APP_URL_REGEX),
         views.AppViewSet.as_view({'get': 'logs'})),
     url(r'^apps/(?P<id>{})/run/?'.format(settings.APP_URL_REGEX),

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -148,6 +148,18 @@ class AppViewSet(BaseDeisViewSet):
             return Response({'detail': str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
+    def restart(self, request, **kwargs):
+        app = self.kwargs.get('id')
+        container_type = self.kwargs.get('type')
+        container_id = self.kwargs.get('num')
+        try:
+            app.restart(request.user, container_type, container_id)
+        except (EnvironmentError, ValidationError) as e:
+            return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except RuntimeError as e:
+            return Response({'detail': str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
     def logs(self, request, **kwargs):
         app = self.get_object()
         try:

--- a/controller/scheduler/chaos.py
+++ b/controller/scheduler/chaos.py
@@ -4,6 +4,7 @@ CREATE_ERROR_RATE = 0
 DESTROY_ERROR_RATE = 0
 START_ERROR_RATE = 0
 STOP_ERROR_RATE = 0
+RESTART_ERROR_RATE = 0
 
 
 class ChaosSchedulerClient(object):
@@ -34,6 +35,14 @@ class ChaosSchedulerClient(object):
         Stop a running job
         """
         if random.random() < STOP_ERROR_RATE:
+            raise RuntimeError
+        return True
+
+    def restart(self, name):
+        """
+        Restart a running job
+        """
+        if random.random() < RESTART_ERROR_RATE:
             raise RuntimeError
         return True
 

--- a/controller/scheduler/fleet.py
+++ b/controller/scheduler/fleet.py
@@ -189,6 +189,10 @@ class FleetHTTPClient(object):
         """Stop a container"""
         raise NotImplementedError
 
+    def restart(self, name):
+        """Restart a container"""
+        raise NotImplementedError
+
     def destroy(self, name):
         """Destroy a container"""
         # call all destroy functions, ignoring any errors

--- a/controller/scheduler/mock.py
+++ b/controller/scheduler/mock.py
@@ -31,6 +31,12 @@ class MockSchedulerClient(object):
         """
         return
 
+    def restart(self, name):
+        """
+        Restart a container
+        """
+        return
+
     def destroy(self, name):
         """
         Destroy a container

--- a/docs/reference/api-v1.1.rst
+++ b/docs/reference/api-v1.1.rst
@@ -407,6 +407,69 @@ Example Response:
     X_DEIS_PLATFORM_VERSION: 1.3.1
 
 
+Restart Application
+```````````````````
+
+Example Request:
+
+.. code-block:: console
+
+    POST /v1/apps/example-go/restart/ HTTP/1.1
+    Host: deis.example.com
+    Content-Type: application/json
+    Authorization: token abc123
+
+Example Response:
+
+.. code-block:: console
+
+    HTTP/1.1 204 NO CONTENT
+    X_DEIS_API_VERSION: 1.1
+    X_DEIS_PLATFORM_VERSION: 1.3.1
+
+
+Restart Application Containers by Type
+``````````````````````````````````````
+
+Example Request:
+
+.. code-block:: console
+
+    POST /v1/apps/example-go/restart/web HTTP/1.1
+    Host: deis.example.com
+    Content-Type: application/json
+    Authorization: token abc123
+
+Example Response:
+
+.. code-block:: console
+
+    HTTP/1.1 204 NO CONTENT
+    X_DEIS_API_VERSION: 1.1
+    X_DEIS_PLATFORM_VERSION: 1.3.1
+
+
+Restart Specific Container
+``````````````````````````
+
+Example Request:
+
+.. code-block:: console
+
+    POST /v1/apps/example-go/restart/web/1 HTTP/1.1
+    Host: deis.example.com
+    Content-Type: application/json
+    Authorization: token abc123
+
+Example Response:
+
+.. code-block:: console
+
+    HTTP/1.1 204 NO CONTENT
+    X_DEIS_API_VERSION: 1.1
+    X_DEIS_PLATFORM_VERSION: 1.3.1
+
+
 Configuration
 -------------
 


### PR DESCRIPTION
This is a proposal for a `deis` cli command, `ps:restart` with the alias `restart`

`deis ps:restart` should restart an application.

I'll investigate the possibility of only restarting specific container types like the similar Heroku command:

The use case for this command is restarting an app in times of instability without using the existing workaround of the `ps:scale` command.

```
$ heroku help restart
Alias: restart redirects to ps:restart
Usage: heroku ps:restart [DYNO]

 restart an app dyno

 if DYNO is not specified, restarts all dynos on the app

Examples:

 $ heroku ps:restart web.1
 Restarting web.1 dyno... done

 $ heroku ps:restart web
 Restarting web dyno... done

 $ heroku ps:restart
 Restarting dynos... done
```
I'll convert this to a PR and attach docs once I've looked at the relevant code and have feedback that this is a desired function + any opinions on the interface.

Refs #467, #1929, #2758