### PR TITLE
docs(contributing): remove reference to `deisctl ssh`

### DIFF
--- a/docs/contributing/hacking.rst
+++ b/docs/contributing/hacking.rst
@@ -202,7 +202,8 @@ Django Shell
 
 .. code-block:: console
 
-    $ deisctl ssh controller   # SSH into the controller
+    $ deisctl list             # determine which host runs the controller
+    $ ssh core@<host>          # SSH into the controller host
     $ nse deis-controller      # inject yourself into the container
     $ cd /app                  # change into the django project root
     $ ./manage.py shell        # get a django shell


### PR DESCRIPTION
@mhahn pointed out in IRC that this command doesn't actually exist.