### PR TITLE
fix(user-data): ensure nf_conntrack kernel module is loaded

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -73,6 +73,7 @@ coreos:
 
       [Service]
       Type=oneshot
+      ExecStartPre=/usr/sbin/modprobe nf_conntrack
       ExecStart=/bin/sh -c "sysctl -w net.netfilter.nf_conntrack_max=262144"
 write_files:
   - path: /etc/deis-release


### PR DESCRIPTION
At some point CoreOS stopped loading the `nf_conntrack` kernel module by default, which broke the increase-nf_conntrack-connections.service we added in #2942. I tried to fix it in a more elegant way as @ineu suggested in #3105, but for some reason a /etc/modules-load.d/conntrack.conf file did not cause the module to be loaded on boot, so instead I added a `modprobe` command to the existing one-shot unit.

Before:
```console
core@deis-01 ~ $ sysctl net.netfilter.nf_conntrack_max
sysctl: cannot stat /proc/sys/net/netfilter/nf_conntrack_max: No such file or directory
core@deis-01 ~ $ lsmod | grep conntrack
core@deis-01 ~ $ 
```
After:
```console
core@deis-01 ~ $ sysctl net.netfilter.nf_conntrack_max
net.netfilter.nf_conntrack_max = 262144
```

Closes #3105. ping @aledbf.