### PR TITLE
fix(router): disable SSLv3 CVE-2014-3566

### DIFF
--- a/router/image/templates/deis.conf
+++ b/router/image/templates/deis.conf
@@ -6,4 +6,5 @@ listen 80;
 listen 443 ssl spdy;
 ssl_certificate /etc/ssl/deis.cert;
 ssl_certificate_key /etc/ssl/deis.key;
+ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 {{ end }}


### PR DESCRIPTION
This can break compatibility with IE6. Good news everyone! Microsoft released [a fix]. Tell your raging dinos to download [the msi].

Or just don't enforce ssl. For more see https://disablessl3.com/

[CVE-2014-3566](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3566)
related #3097

[a fix]: https://support.microsoft.com/kb/3009008
[the msi]: http://go.microsoft.com/?linkid=9863266