### PR TITLE
fix(builder): return error message as string

### DIFF
--- a/builder/bin/get-app-config.go
+++ b/builder/bin/get-app-config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -85,9 +86,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	if err != nil || res.StatusCode != 200 {
 		fmt.Println("failed retrieving config from controller")
-		fmt.Println(res.Body)
+		fmt.Println(body)
 		os.Exit(1)
 	}
 

--- a/builder/bin/get-app-config.go
+++ b/builder/bin/get-app-config.go
@@ -94,13 +94,14 @@ func main() {
 
 	if err != nil || res.StatusCode != 200 {
 		fmt.Println("failed retrieving config from controller")
-		fmt.Println(body)
+		fmt.Printf("%v\n", body)
 		os.Exit(1)
 	}
 
-	config, err := builder.ParseConfig(res)
+	config, err := builder.ParseConfig(body)
 	if err != nil {
 		fmt.Println("failed parsing config from controller")
+		fmt.Printf("%v\n", err)
 		os.Exit(1)
 	}
 	toString, err := json.Marshal(config)

--- a/builder/bin/publish-release-controller.go
+++ b/builder/bin/publish-release-controller.go
@@ -82,19 +82,20 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	if res.StatusCode == 503 {
-		log.Fatalln("check the controller. is it running?")
-	} else if res.StatusCode != 200 {
-		log.Fatalf("failed retrieving config from controller: %s\n", res.Body)
-	}
-
 	defer res.Body.Close()
-	// Read json response from body
+
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+
+	if res.StatusCode == 503 {
+		log.Fatalln("check the controller. is it running?")
+	} else if res.StatusCode != 200 {
+		log.Fatalf("failed retrieving config from controller: %s\n", body)
+	}
+
 	var response map[string]interface{}
 	if err := json.Unmarshal(body, &response); err != nil {
 		fmt.Println("invalid controller json response")

--- a/builder/utils.go
+++ b/builder/utils.go
@@ -3,8 +3,6 @@ package builder
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 
 	"gopkg.in/yaml.v2"
 )
@@ -27,15 +25,9 @@ func YamlToJSON(bytes []byte) (string, error) {
 }
 
 // ParseConfig takes a response body from the controller and returns a Config object.
-func ParseConfig(res *http.Response) (*Config, error) {
-	body, err := ioutil.ReadAll(res.Body)
-
-	if err != nil {
-		return nil, err
-	}
-
+func ParseConfig(body []byte) (*Config, error) {
 	var config Config
-	err = json.Unmarshal(body, &config)
+	err := json.Unmarshal(body, &config)
 	return &config, err
 }
 

--- a/builder/utils_test.go
+++ b/builder/utils_test.go
@@ -3,7 +3,6 @@ package builder
 import (
 	"bytes"
 	"encoding/json"
-	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -58,8 +57,7 @@ worker: while true; do echo hello; sleep 1; done`),
 
 func TestParseConfigGood(t *testing.T) {
 	// mock the controller response
-	resp := &http.Response{
-		Body: &ClosingBuffer{bytes.NewBufferString(`{"owner": "test",
+	resp := bytes.NewBufferString(`{"owner": "test",
 			"app": "example-go",
 			"values": {"FOO": "bar", "CAR": 1234},
 			"memory": {},
@@ -67,11 +65,9 @@ func TestParseConfigGood(t *testing.T) {
 			"tags": {},
 			"created": "2014-01-01T00:00:00UTC",
 			"updated": "2014-01-01T00:00:00UTC",
-			"uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"}`),
-		},
-	}
+			"uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"}`)
 
-	config, err := ParseConfig(resp)
+	config, err := ParseConfig(resp.Bytes())
 
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
This change this error message
```
2015/02/23 21:01:47 failed retrieving config from controller: &{%!s(*http.body=&{0xc20800aea0 0xc208058120 0xc208062420 true {0 0} false}) {%!s(int32=0) %!s(uint32=0)} %!s(bool=false) <nil> %!s(func(error)=0x49c0b0) %!s(func() error=0x49c040)}
```

with:
```
2015/02/23 22:43:43 failed retrieving config from controller: <h1>Server Error (500)</h1>
```

closes #2883
closes #2984 -- *edited by @bacongobbler*