### PR TITLE
ref(tests): mock store lazy build with git ref tracking

### DIFF
--- a/database/Makefile
+++ b/database/Makefile
@@ -52,6 +52,6 @@ test-style:
 	@echo no style tests
 
 test-functional:
-	@docker history deis/mock-store >/dev/null 2>&1 || $(MAKE) -C ../tests/ mock-store
+	$(MAKE) -C ../tests/ LAZY=1 mock-store
 	@docker history deis/test-etcd >/dev/null 2>&1 || docker pull deis/test-etcd:latest
 	GOPATH=`cd ../tests/ && godep path`:$(GOPATH) go test -v ./tests/...

--- a/registry/Makefile
+++ b/registry/Makefile
@@ -46,7 +46,7 @@ deploy: build dev-release restart
 test: test-style test-unit test-functional
 
 test-functional:
-	@docker history deis/mock-store >/dev/null 2>&1 || $(MAKE) -C ../tests/ mock-store
+	$(MAKE) -C ../tests/ LAZY=1 mock-store
 	@docker history deis/test-etcd >/dev/null 2>&1 || docker pull deis/test-etcd:latest
 	GOPATH=`cd ../tests/ && godep path`:$(GOPATH) go test -v ./tests/...
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,7 +9,17 @@ GO_FILES = apps_test.go auth_test.go builds_test.go config_test.go integration_t
 GO_PACKAGES = dockercli etcdutils mock utils
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
 
-MOCK_STORE_IMAGE = $(IMAGE_PREFIX)mock-store:latest
+MOCK_STORE_IMAGE = $(IMAGE_PREFIX)mock-store
+MOCK_STORE_IMAGE_PATH = fixtures/mock-store
+
+MOCK_STORE_TAG = $(shell git log -n 1 --format="%h" -- $(MOCK_STORE_IMAGE_PATH))
+ifeq (${LAZY},1)
+  MOCK_STORE_TAG_CHECK = $(docker history $(MOCK_STORE_IMAGE):$(MOCK_STORE_TAG) > /dev/null; echo $$?)
+else
+  MOCK_STORE_TAG_CHECK = 0
+endif
+
+
 
 test: test-smoke
 
@@ -35,8 +45,13 @@ setup-root-gotools:
 setup-gotools:
 	go get -v github.com/golang/lint/golint
 
+
+
 mock-store:
-	docker build -t $(MOCK_STORE_IMAGE) fixtures/mock-store/
+ifeq ($(MOCK_STORE_TAG_CHECK), 0)
+	docker build -t $(MOCK_STORE_IMAGE):latest $(MOCK_STORE_IMAGE_PATH) \
+	  && docker tag $(MOCK_STORE_IMAGE):latest $(MOCK_STORE_IMAGE):$(MOCK_STORE_TAG)
+endif
 
 test-style:
 # display output, then check


### PR DESCRIPTION
Emerged from the need in https://github.com/deis/deis/pull/3128 to pick up changes in mock-store and recompile it as well. The way it is currently, it wouldn't recompile as long as at least some `deis/mock-store` image exists.

When `LAZY=1` is specified, it would rebuild `mock-store` only if docker tag corresponding to the current git ref for `tests/fixtures/mock-store` is missing.