### PR TITLE
feat(cloud-init): check if deisctl does not exists before install it

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -37,6 +37,7 @@ coreos:
     content: |
       [Unit]
       Description=Install deisctl utility
+      ConditionPathExists=!/opt/bin/deisctl
 
       [Service]
       Type=oneshot


### PR DESCRIPTION
It makes no sense to download `deisctl` in every boot. It only delays the end of `systemd` boot