### PR TITLE
ref(tests): rely on docker build cache in mock-store build

### DIFF
--- a/database/Makefile
+++ b/database/Makefile
@@ -52,6 +52,6 @@ test-style:
 	@echo no style tests
 
 test-functional:
-	@docker history deis/mock-store >/dev/null 2>&1 || $(MAKE) -C ../tests/ mock-store
+	$(MAKE) -C ../tests/ mock-store
 	@docker history deis/test-etcd >/dev/null 2>&1 || docker pull deis/test-etcd:latest
 	GOPATH=`cd ../tests/ && godep path`:$(GOPATH) go test -v ./tests/...

--- a/registry/Makefile
+++ b/registry/Makefile
@@ -46,7 +46,7 @@ deploy: build dev-release restart
 test: test-style test-unit test-functional
 
 test-functional:
-	@docker history deis/mock-store >/dev/null 2>&1 || $(MAKE) -C ../tests/ mock-store
+	$(MAKE) -C ../tests/ mock-store
 	@docker history deis/test-etcd >/dev/null 2>&1 || docker pull deis/test-etcd:latest
 	GOPATH=`cd ../tests/ && godep path`:$(GOPATH) go test -v ./tests/...
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,6 +13,12 @@ MOCK_STORE_IMAGE = $(IMAGE_PREFIX)mock-store:latest
 MOCK_STORE_SRC=fixtures/mock-store
 MOCK_STORE_GIT_SHA = $(shell git log -n 1 --format="%h" -- $(MOCK_STORE_SRC))
 
+check-envsubst:
+ifneq ($(shell which envsubst &> /dev/null; echo $$?), 0)
+	$(info Could not find GNU envsubst utility, which usually comes with gettext or gettext-base package)
+	exit 1
+endif
+
 test: test-smoke
 
 test-smoke: test-style
@@ -37,7 +43,7 @@ setup-root-gotools:
 setup-gotools:
 	go get -v github.com/golang/lint/golint
 
-mock-store:
+mock-store: check-envsubst
 	cat $(MOCK_STORE_SRC)/Dockerfile | \
 	  GIT_SHA=$(MOCK_STORE_GIT_SHA) envsubst | \
 	  ./utils/dockerfeed -d - $(MOCK_STORE_SRC) | \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,6 +10,8 @@ GO_PACKAGES = dockercli etcdutils mock utils
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
 
 MOCK_STORE_IMAGE = $(IMAGE_PREFIX)mock-store:latest
+MOCK_STORE_SRC=fixtures/mock-store
+MOCK_STORE_GIT_SHA = $(shell git log -n 1 --format="%h" -- $(MOCK_STORE_SRC))
 
 test: test-smoke
 
@@ -36,7 +38,10 @@ setup-gotools:
 	go get -v github.com/golang/lint/golint
 
 mock-store:
-	docker build -t $(MOCK_STORE_IMAGE) fixtures/mock-store/
+	cat $(MOCK_STORE_SRC)/Dockerfile | \
+	  GIT_SHA=$(MOCK_STORE_GIT_SHA) envsubst | \
+	  ./utils/dockerfeed -d - $(MOCK_STORE_SRC) | \
+	  docker build -t $(MOCK_STORE_IMAGE) -
 
 test-style:
 # display output, then check

--- a/tests/fixtures/mock-store/Dockerfile
+++ b/tests/fixtures/mock-store/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu-debootstrap:14.04
+ENV GIT_SHA $GIT_SHA
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Replaces https://github.com/deis/deis/pull/3140

Also adds *dockerfeed* util (https://github.com/itsafire/dockerfeed) to pack context on the fly.

NOTE: Requires gettext-base (or gettext) installed on building machine.