### PR TITLE
fix(tests): remove mock-store containers after functional tests

### DIFF
--- a/database/tests/database_test.go
+++ b/database/tests/database_test.go
@@ -24,10 +24,7 @@ func TestDatabase(t *testing.T) {
 	// run mock ceph containers
 	cephName := "deis-ceph-" + tag
 	mock.RunMockCeph(t, cephName, cli, etcdPort)
-	defer cli.CmdRm("-f", "-v", cephName+"-monitor")
-	defer cli.CmdRm("-f", "-v", cephName+"-daemon")
-	defer cli.CmdRm("-f", cephName+"-metadata")
-	defer cli.CmdRm("-f", cephName+"-gateway")
+	defer cli.CmdRm("-f", cephName)
 
 	// run database container
 	host, port := utils.HostAddress(), utils.RandomPort()

--- a/registry/tests/registry_test.go
+++ b/registry/tests/registry_test.go
@@ -36,10 +36,7 @@ func TestRegistry(t *testing.T) {
 	// run mock ceph containers
 	cephName := "deis-ceph-" + tag
 	mock.RunMockCeph(t, cephName, cli, etcdPort)
-	defer cli.CmdRm("-f", "-v", cephName+"-monitor")
-	defer cli.CmdRm("-f", "-v", cephName+"-daemon")
-	defer cli.CmdRm("-f", cephName+"-metadata")
-	defer cli.CmdRm("-f", cephName+"-gateway")
+	defer cli.CmdRm("-f", cephName)
 
 	host, port := utils.HostAddress(), utils.RandomPort()
 	fmt.Printf("--- Run deis/registry:%s at %s:%s\n", tag, host, port)

--- a/tests/bin/prime-docker-images.sh
+++ b/tests/bin/prime-docker-images.sh
@@ -7,7 +7,7 @@
 
 # Remove all Dockernalia
 docker kill `docker ps -q`
-docker rm `docker ps -a -q`
+docker rm -v `docker ps -a -q`
 docker rmi -f `docker images -q`
 
 # Pull Deis testing essentials

--- a/tests/mock/mock.go
+++ b/tests/mock/mock.go
@@ -52,26 +52,24 @@ func RunMockDatabase(t *testing.T, tag string, etcdPort string, dbPort string) {
 	}
 }
 
-// RunMockCeph runs a set of containers used to mock a Ceph storage cluster
+// RunMockCeph runs a container used to mock a Ceph storage cluster
 func RunMockCeph(t *testing.T, name string, cli *client.DockerCli, etcdPort string) {
 
 	etcdutils.SetSingle(t, "/deis/store/hosts/"+utils.HostAddress(), utils.HostAddress(), etcdPort)
 	var err error
 	cli, stdout, stdoutPipe := dockercli.NewClient()
-	cephImage := "deis/mock-store:latest"
 	ipaddr := utils.HostAddress()
 	fmt.Printf("--- Running deis/mock-store at %s\n", ipaddr)
-	done2 := make(chan bool, 1)
+	done := make(chan bool, 1)
 	go func() {
-		done2 <- true
-		_ = cli.CmdRm("-f", name)
+		done <- true
 		err = dockercli.RunContainer(cli,
 			"--name", name,
 			"--rm",
 			"-e", "HOST="+ipaddr,
 			"-e", "ETCD_PORT="+etcdPort,
 			"--net=host",
-			cephImage)
+			"deis/mock-store:latest")
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "deis-store-gateway running...")
 	if err != nil {


### PR DESCRIPTION
Test code hadn't been updated and was cleaning up some nonexistent containers instead of mock-store in the database and registry functional tests. Tested on my Mac and a Linux node several times, followed by `docker ps`.

Closes #3138.