### PR TITLE
feat(cloud-init): disable automatic core dumps

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -155,3 +155,7 @@ write_files:
       https_proxy=
       all_proxy=
       no_proxy=
+  - path: /etc/systemd/coredump.conf
+    content: |
+      [Coredump]
+      Storage=none


### PR DESCRIPTION
By default systemd enables automatic coredumps. 

This could lead to a lot of problems like this one:
1. program consuming a lot of memory generates a core dump
2. the program will restart (systemd) and the same error will happen
3. if the disk space is the default, it will take only a couple of core dumps to fill the disk
4. (the important one) docker will die (no disk space available)
5. all the containers die
6. only rebooting the node solved the issue

Just in case this is a real example (my fault, I didn't resize the coreos disk)

http://www.freedesktop.org/software/systemd/man/systemd-coredump.html