### PR TITLE
Docs: Missing note for Vagrant users

### DIFF
--- a/docs/installing_deis/install-platform.rst
+++ b/docs/installing_deis/install-platform.rst
@@ -58,6 +58,10 @@ hosts during ``deis run``:
 
     $ deisctl config platform set sshPrivateKey=~/.ssh/deis
 
+.. note::
+
+    For Vagrant clusters: ``deisctl config platform set sshPrivateKey=$(HOME)/.vagrant.d/insecure_private_key``
+
 We'll also need to tell the controller which domain name we are deploying applications under:
 
 .. code-block:: console

--- a/docs/installing_deis/vagrant.rst
+++ b/docs/installing_deis/vagrant.rst
@@ -31,16 +31,18 @@ The ``Vagrantfile`` requires the plugin `vagrant-triggers`_. To install the plug
     website.
 
 
-Generate SSH Key
-----------------
-
-.. include:: ../_includes/_generate-ssh-key.rst
-
-
 Generate a New Discovery URL
 ----------------------------
 
 .. include:: ../_includes/_generate-discovery-url.rst
+
+
+Generate SSH Key
+----------------
+
+.. note::
+
+    For Vagrant clusters you don't need to create a key pair, instead use the insecure_private_key located in ``~/.vagrant.d/insecure_private_key``.
 
 
 Boot CoreOS


### PR DESCRIPTION
Vagrant Users by default have to set the sshPrivateKey to .vagrant.d/insecure_private_key instead of the deis key. Even the make dev-cluster does this:

```shell
dev-cluster: discovery-url
        vagrant up
        ssh-add ~/.vagrant.d/insecure_private_key
        deisctl config platform set sshPrivateKey=$(HOME)/.vagrant.d/insecure_private_key
        deisctl config platform set domain=local3.deisapp.com
        deisctl install platform
```
In all my installations and tests I always use this key instead the deis key, since the key is not used anywhere when you're in vagrant mode.

closes #2528 -- *edited by @bacongobbler*