### PR TITLE
fix(builder): install docker from get.docker.com

### DIFF
--- a/builder/image/Dockerfile
+++ b/builder/image/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -sSL -o /usr/local/bin/confd https://s3-us-west-2.amazonaws.com/opdeman
     && chmod +x /usr/local/bin/confd
 
 # install docker-in-docker
-RUN echo "deb http://get.docker.io/ubuntu docker main" > /etc/apt/sources.list.d/docker.list
+RUN echo "deb http://get.docker.com/ubuntu docker main" > /etc/apt/sources.list.d/docker.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 
 # install builder, docker, and hook dependencies

--- a/tests/bin/setup-node.sh
+++ b/tests/bin/setup-node.sh
@@ -5,7 +5,7 @@
 
 # install docker
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
-sh -c "echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
+sh -c "echo deb https://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
 apt-get update && apt-get install -yq lxc-docker-1.5.0
 
 # install java


### PR DESCRIPTION
The endpoint https://get.docker.io is serving up a hearty breakfast of 504s today. The Docker [install docs](https://docs.docker.com/installation/ubuntulinux/) reference https://get.docker.com instead. This change points builder (and our CI node setup script) to what is apparently the preferred endpoint.