### PR TITLE
ref(Makefile): break build stage up into build and compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ repo_path = github.com/deis/deis
 GO_PACKAGES = pkg/time version
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
 
+COMPILED_COMPONENTS=builder logger logspout publisher
 COMPONENTS=builder cache controller database logger logspout publisher registry router store
 START_ORDER=publisher store logger logspout database cache registry controller builder router
 CLIENTS=client deisctl
@@ -31,6 +32,9 @@ dev-cluster: discovery-url
 
 discovery-url:
 	sed -e "s,# discovery:,discovery:," -e "s,discovery: https://discovery.etcd.io/.*,discovery: $$(curl -s -w '\n' https://discovery.etcd.io/new)," contrib/coreos/user-data.example > contrib/coreos/user-data
+
+compile:
+	@$(foreach C, $(COMPILED_COMPONENTS), $(MAKE) -C $(C) compile &&) echo done
 
 build: check-docker
 	@$(foreach C, $(COMPONENTS), $(MAKE) -C $(C) build &&) echo done
@@ -71,7 +75,7 @@ set-image:
 release: check-registry
 	@$(foreach C, $(COMPONENTS), $(MAKE) -C $(C) release &&) echo done
 
-deploy: build dev-release restart
+deploy: compile build dev-release restart
 
 test: test-style test-unit test-functional push test-integration
 

--- a/builder/Makefile
+++ b/builder/Makefile
@@ -13,10 +13,12 @@ DEV_IMAGE = $(DEV_REGISTRY)/$(IMAGE)
 BINARIES := extract-domain extract-types extract-version generate-buildhook get-app-config get-app-values publish-release-controller yaml2json-procfile
 BINARY_DEST_DIR := image/bin
 
-build: check-docker
+compile:
 	for i in $(BINARIES); do \
 		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix cgo -v -ldflags '-s' -o $(BINARY_DEST_DIR)/$$i bin/$$i.go || exit 1; \
 	done
+
+build: check-docker
 	docker build -t $(IMAGE) image
 
 clean: check-docker check-registry
@@ -56,7 +58,7 @@ set-image: check-deisctl
 release:
 	docker push $(IMAGE)
 
-deploy: build dev-release restart
+deploy: compile build dev-release restart
 
 test: test-style test-unit test-functional
 

--- a/cache/Makefile
+++ b/cache/Makefile
@@ -12,8 +12,10 @@ DEV_IMAGE = $(DEV_REGISTRY)/$(IMAGE)
 BUILD_IMAGE = $(COMPONENT)-build
 BINARY_DEST_DIR = image/bin
 
-build: check-docker
+compile:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix cgo -v -ldflags '-s' -o $(BINARY_DEST_DIR)/boot main.go || exit 1
+
+build: check-docker
 	docker build -t $(BUILD_IMAGE) .
 	docker cp `docker run -d $(BUILD_IMAGE)`:/usr/local/bin/redis-server $(BINARY_DEST_DIR)/
 	docker build -t $(IMAGE) image
@@ -54,7 +56,7 @@ set-image: check-deisctl
 release:
 	docker push $(IMAGE)
 
-deploy: build dev-release restart
+deploy: compile build dev-release restart
 
 test: test-style test-unit test-functional
 

--- a/docs/contributing/hacking.rst
+++ b/docs/contributing/hacking.rst
@@ -146,6 +146,7 @@ Deis includes ``Makefile`` targets designed to simplify the development workflow
 This workflow is typically:
 
   #. Update source code and commit your changes using ``git``
+  #. Use ``make -C <component> compile`` to compile go code, if component uses go
   #. Use ``make -C <component> build`` to build a new Docker image
   #. Use ``make -C <component> dev-release`` to push a snapshot release
   #. Use ``make -C <component> restart`` to restart the component

--- a/logger/Makefile
+++ b/logger/Makefile
@@ -13,8 +13,10 @@ IMAGE = $(IMAGE_PREFIX)$(COMPONENT):$(BUILD_TAG)
 DEV_IMAGE = $(DEV_REGISTRY)/$(IMAGE)
 BINARY_DEST_DIR = image/bin
 
-build: check-docker
+compile:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix cgo -v -ldflags '-s' -o $(BINARY_DEST_DIR)/logger github.com/deis/deis/logger || exit 1
+
+build: check-docker
 	docker build -t $(IMAGE) image
 
 clean: check-docker check-registry
@@ -52,7 +54,7 @@ set-image: check-deisctl
 release:
 	docker push $(IMAGE)
 
-deploy: build dev-release restart
+deploy: compile build dev-release restart
 
 setup-root-gotools:
 	sudo GOPATH=/tmp/tmpGOPATH go get -u -v code.google.com/p/go.tools/cmd/cover

--- a/logspout/Makefile
+++ b/logspout/Makefile
@@ -12,8 +12,10 @@ DOCKER_IMAGE := deis/$(COMPONENT)
 RELEASE_IMAGE := $(DOCKER_IMAGE):$(BUILD_TAG)
 DEV_DOCKER_IMAGE := $(DEV_REGISTRY)/$(RELEASE_IMAGE)
 
-build: check-docker
+compile:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix cgo -v -ldflags '-s' -o image/logspout
+
+build: check-docker
 	docker build -t $(RELEASE_IMAGE) image
 
 clean:
@@ -52,7 +54,7 @@ set-image: check-deisctl
 release:
 	docker push $(RELEASE_IMAGE)
 
-deploy: build dev-release restart
+deploy: compile build dev-release restart
 
 setup-root-gotools:
 	sudo GOPATH=/tmp/tmpGOPATH go get -u -v code.google.com/p/go.tools/cmd/cover

--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -13,8 +13,10 @@ RELEASE_IMAGE := $(DOCKER_IMAGE):$(BUILD_TAG)
 REMOTE_IMAGE := $(REGISTRY)/$(RELEASE_IMAGE)
 BINARY_DEST_DIR = image/bin
 
-build: check-docker
+compile:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix cgo -v -ldflags '-s' -o $(BINARY_DEST_DIR)/publisher github.com/deis/deis/publisher || exit 1
+
+build: check-docker
 	docker build -t $(RELEASE_IMAGE) image
 
 clean: check-docker check-registry
@@ -40,7 +42,7 @@ set-image: check-deisctl
 release: check-docker
 	docker push $(DOCKER_IMAGE)
 
-deploy: build dev-release restart
+deploy: compile build dev-release restart
 
 restart: stop start
 

--- a/tests/bin/test-acceptance.sh
+++ b/tests/bin/test-acceptance.sh
@@ -29,6 +29,7 @@ make test-unit
 log_phase "Building from current source tree"
 
 # build all docker images and client binaries
+make compile
 make build
 
 # use the built client binaries

--- a/tests/bin/test-integration.sh
+++ b/tests/bin/test-integration.sh
@@ -33,6 +33,7 @@ make test-unit
 log_phase "Building from current source tree"
 
 # build all docker images and client binaries
+make compile
 make build
 
 # use the built client binaries

--- a/tests/bin/test-smoke.sh
+++ b/tests/bin/test-smoke.sh
@@ -29,6 +29,7 @@ make test-unit
 log_phase "Building from current source tree"
 
 # build all docker images and client binaries
+make compile
 make build
 
 # use the built client binaries


### PR DESCRIPTION
This can be really useful if you need to build the go components using nonstandard methods.

For example:

I use gvm, a go version switcher. It manages go and `$GOPATH` for me locally. This make it impossible to run `make build` because if I run with root I don't have go in my `$PATH` and for security reasons you can't pass it, and if I run without root than I can't create docker images.

Now, I can run `make compile` to build the go components and then `sudo make build` to create the docker images.

This can also make cross compiling go easier as well. You can compile go however you want and then run `make build` to create the docker image.

Since build go binaries and building a docker image are two fairly separate steps anyway, I think it makes a lot of sense to separate them. 