### PR TITLE
Add .git to builds

### DIFF
--- a/builder/image/templates/builder
+++ b/builder/image/templates/builder
@@ -56,7 +56,14 @@ mkdir -p $BUILD_DIR $CACHE_DIR
 TMP_DIR=$(mktemp -d --tmpdir=$BUILD_DIR)
 
 cd $REPO_DIR
-git archive $GIT_SHA | tar -xmC $TMP_DIR
+git clone $REPO_DIR/ "${TMP_DIR}.raw/"
+pushd "${TMP_DIR}.raw"
+export GIT_DIR="${TMP_DIR}.raw/.git" GIT_WORK_TREE="${TMP_DIR}.raw"
+git config core.bare false
+git checkout $(git branch -a | tail -1)
+( echo .git; git ls-tree --full-name -z -r --name-only  $GIT_SHA ) | tar cf - -T - --null | tar -xmC $TMP_DIR
+rm -fr "${TMP_DIR}.raw"
+popd
 
 # switch to app context
 cd $TMP_DIR

--- a/builder/image/templates/builder
+++ b/builder/image/templates/builder
@@ -61,7 +61,6 @@ pushd "$TMP_DIR"
 export GIT_DIR="$TMP_DIR/.git" GIT_WORK_TREE="$TMP_DIR"
 git config core.bare false
 git reset --hard $GIT_SHA
-( echo .git; git ls-tree --full-name -z -r --name-only $GIT_SHA ) | tar cf - -T - --null | tar -xmC "$TMP_DIR"
 popd
 
 # switch to app context

--- a/builder/image/templates/builder
+++ b/builder/image/templates/builder
@@ -57,14 +57,12 @@ TMP_DIR=$(mktemp -d --tmpdir=$BUILD_DIR)
 
 cd $REPO_DIR
 git clone $REPO_DIR/ "$TMP_DIR/"
-pushd "$TMP_DIR"
-export GIT_DIR="$TMP_DIR/.git" GIT_WORK_TREE="$TMP_DIR"
-git config core.bare false
-git reset --hard $GIT_SHA
-popd
 
 # switch to app context
 cd $TMP_DIR
+export GIT_DIR="$TMP_DIR/.git" GIT_WORK_TREE="$TMP_DIR"
+git config core.bare false
+git reset --hard $GIT_SHA
 
 USING_DOCKERFILE=false
 

--- a/builder/image/templates/builder
+++ b/builder/image/templates/builder
@@ -56,13 +56,12 @@ mkdir -p $BUILD_DIR $CACHE_DIR
 TMP_DIR=$(mktemp -d --tmpdir=$BUILD_DIR)
 
 cd $REPO_DIR
-git clone $REPO_DIR/ "${TMP_DIR}.raw/"
-pushd "${TMP_DIR}.raw"
-export GIT_DIR="${TMP_DIR}.raw/.git" GIT_WORK_TREE="${TMP_DIR}.raw"
+git clone $REPO_DIR/ "$TMP_DIR/"
+pushd "$TMP_DIR"
+export GIT_DIR="$TMP_DIR/.git" GIT_WORK_TREE="$TMP_DIR"
 git config core.bare false
-git checkout $(git branch -a | tail -1)
-( echo .git; git ls-tree --full-name -z -r --name-only  $GIT_SHA ) | tar cf - -T - --null | tar -xmC $TMP_DIR
-rm -fr "${TMP_DIR}.raw"
+git reset --hard $GIT_SHA
+( echo .git; git ls-tree --full-name -z -r --name-only $GIT_SHA ) | tar cf - -T - --null | tar -xmC "$TMP_DIR"
 popd
 
 # switch to app context

--- a/builder/image/templates/builder
+++ b/builder/image/templates/builder
@@ -56,7 +56,7 @@ mkdir -p $BUILD_DIR $CACHE_DIR
 TMP_DIR=$(mktemp -d --tmpdir=$BUILD_DIR)
 
 cd $REPO_DIR
-git clone $REPO_DIR/ "$TMP_DIR/"
+git clone --depth=1 $REPO_DIR/ "$TMP_DIR/"
 
 # switch to app context
 cd $TMP_DIR


### PR DESCRIPTION
feat(deis-builder/add_dot_git): Add .git to builds

The current deis git push behavior strips .git from the build. This happens during the "git archive" step in the deis-builder template/builder script. In order to use submodules, the "git archive" method of sending the tarball to "docker build" needs to be replaced. As the repo is bare, it needs to be cloned to the TMP_DIR and checked out to the $GIT_SHA of the deployment. This also allows for the use of submodules in deployments.