### PR TITLE
ref(security): REJECT target uses port-unreachable

### DIFF
--- a/contrib/util/custom-firewall.sh
+++ b/contrib/util/custom-firewall.sh
@@ -42,7 +42,7 @@ template=$(cat <<EOF
 
 # Log and drop everything else
 -A Firewall-INPUT -j LOG
--A Firewall-INPUT -j REJECT --reject-with icmp-host-prohibited
+-A Firewall-INPUT -j REJECT
 
 COMMIT
 EOF
@@ -65,4 +65,3 @@ echo "Loading custom iptables firewall"
 sudo /sbin/iptables-restore --noflush /var/lib/iptables/rules-save
 
 echo "Done"
-


### PR DESCRIPTION
This allows for more clear error messages. Instead of
coreos-3.example.com [x.x.x.x] 554 (rtsp) : No route to host
it gives
coreos-3.example.com [x.x.x.x] 554 (rtsp) : Connection refused