### PR TITLE
fix(deisctl/units): eat error output for history and inspect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ CLIENTS=client deisctl
 all: build run
 
 dev-registry: check-docker
-	@docker inspect registry >/dev/null && docker start registry || docker run --restart="always" -d -p 5000:5000 --name registry registry:0.9.1
+	@docker inspect registry >/dev/null 2>&1 && docker start registry || docker run --restart="always" -d -p 5000:5000 --name registry registry:0.9.1
 	@echo
 	@echo "To use local boot2docker registry for Deis development:"
 	@echo "    export DEV_REGISTRY=`boot2docker ip 2>/dev/null`:5000"

--- a/deisctl/README.md
+++ b/deisctl/README.md
@@ -149,8 +149,8 @@ $ deisctl status controller
 ● deis-controller.service - deis-controller
    Loaded: loaded (/run/fleet/units/deis-controller.service; linked-runtime)
    Active: active (running) since Mon 2014-08-25 22:56:50 UTC; 15min ago
-  Process: 22969 ExecStartPre=/bin/sh -c docker inspect deis-controller >/dev/null && docker rm -f deis-controller || true (code=exited, status=0/SUCCESS)
-  Process: 22945 ExecStartPre=/bin/sh -c IMAGE=`/run/deis/bin/get_image /deis/controller`; docker history $IMAGE >/dev/null || docker pull $IMAGE (code=exited, status=0/SUCCESS)
+  Process: 22969 ExecStartPre=/bin/sh -c docker inspect deis-controller >/dev/null 2>&1 && docker rm -f deis-controller || true (code=exited, status=0/SUCCESS)
+  Process: 22945 ExecStartPre=/bin/sh -c IMAGE=`/run/deis/bin/get_image /deis/controller`; docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE (code=exited, status=0/SUCCESS)
  Main PID: 22979 (sh)
    CGroup: /system.slice/system-deis\x2dcontroller.slice/deis-controller.service
            ├─22979 /bin/sh -c IMAGE=`/run/deis/bin/get_image /deis/controller` && docker run --name deis-controller --rm -p 8000:8000 -e PUBLISH=8000 -e HOST=$COREOS_PRIVATE_IPV4 --volumes-from=deis-logger $IMAGE

--- a/deisctl/units/deis-builder.service
+++ b/deisctl/units/deis-builder.service
@@ -5,8 +5,8 @@ Description=deis-builder
 EnvironmentFile=/etc/environment
 TimeoutStartSec=30m
 ExecStartPre=/bin/sh -c "docker inspect deis-builder-data >/dev/null 2>&1 || docker run --name deis-builder-data -v /var/lib/docker ubuntu-debootstrap:14.04 /bin/true"
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-builder >/dev/null && docker rm -f deis-builder || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-builder >/dev/null 2>&1 && docker rm -f deis-builder || true"
 ExecStartPre=-/bin/sh -c "/sbin/losetup -f"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker run --name deis-builder --rm -p 2223:22 --volumes-from=deis-builder-data -c 800 -e EXTERNAL_PORT=2223 -e HOST=$COREOS_PRIVATE_IPV4 --privileged -v /etc/environment_proxy:/etc/environment_proxy $IMAGE"
 ExecStartPost=/bin/sh -c "echo 'Waiting for builder on 2223/tcp...' && until echo 'dummy-value' | ncat $COREOS_PRIVATE_IPV4 2223 >/dev/null 2>&1; do sleep 1; done"

--- a/deisctl/units/deis-cache.service
+++ b/deisctl/units/deis-cache.service
@@ -4,8 +4,8 @@ Description=deis-cache
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache` && docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-cache >/dev/null && docker rm -f deis-cache || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-cache >/dev/null 2>&1 && docker rm -f deis-cache || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache` && docker run --name deis-cache --rm -p 6379:6379 -e EXTERNAL_PORT=6379 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStopPost=-/usr/bin/docker rm -f deis-cache
 Restart=on-failure

--- a/deisctl/units/deis-controller.service
+++ b/deisctl/units/deis-controller.service
@@ -6,8 +6,8 @@ After=deis-store-volume.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-controller >/dev/null && docker rm -f deis-controller || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-controller >/dev/null 2>&1 && docker rm -f deis-controller || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker run --name deis-controller --rm -p 8000:8000 -e EXTERNAL_PORT=8000 -e HOST=$COREOS_PRIVATE_IPV4 -v /var/run/fleet.sock:/var/run/fleet.sock -v /var/lib/deis/store:/data $IMAGE"
 ExecStopPost=-/usr/bin/docker rm -f deis-controller
 Restart=on-failure

--- a/deisctl/units/deis-database.service
+++ b/deisctl/units/deis-database.service
@@ -5,7 +5,7 @@ Description=deis-database
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "docker inspect deis-database-data >/dev/null 2>&1 || docker run --name deis-database-data -v /var/lib/postgresql ubuntu-debootstrap:14.04 /bin/true"
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker history $IMAGE >/dev/null || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-database >/dev/null 2>&1 && docker rm -f deis-database >/dev/null 2>&1 || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker run --name deis-database --volumes-from=deis-database-data -p 5432:5432 -e EXTERNAL_PORT=5432 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStopPost=-/usr/bin/docker exec deis-database sudo service postgresql stop

--- a/deisctl/units/deis-logger.service
+++ b/deisctl/units/deis-logger.service
@@ -6,8 +6,8 @@ After=deis-store-volume.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-logger >/dev/null && docker rm -f deis-logger || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-logger >/dev/null 2>&1 && docker rm -f deis-logger || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker run --name deis-logger --rm -p 514:514/udp -e EXTERNAL_PORT=514 -e HOST=$COREOS_PRIVATE_IPV4 -v /var/lib/deis/store:/data $IMAGE"
 ExecStopPost=-/usr/bin/docker rm -f deis-logger
 Restart=on-failure

--- a/deisctl/units/deis-logspout.service
+++ b/deisctl/units/deis-logspout.service
@@ -6,8 +6,8 @@ After=docker.socket etcd.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logspout` && docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-logspout >/dev/null && docker rm -f deis-logspout || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logspout` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-logspout >/dev/null 2>&1 && docker rm -f deis-logspout || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logspout` && docker run --name deis-logspout --rm -v /var/run/docker.sock:/tmp/docker.sock -e ETCD_HOST=$COREOS_PRIVATE_IPV4 -e HOST=$COREOS_PRIVATE_IPV4 -e DEBUG=1 $IMAGE"
 ExecStopPost=-/usr/bin/docker rm -f deis-logspout
 Restart=on-failure

--- a/deisctl/units/deis-publisher.service
+++ b/deisctl/units/deis-publisher.service
@@ -6,8 +6,8 @@ After=docker.socket etcd.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-publisher >/dev/null && docker rm -f deis-publisher || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-publisher >/dev/null 2>&1 && docker rm -f deis-publisher || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker run --name deis-publisher --rm -e HOST=$COREOS_PRIVATE_IPV4 -e ETCD_HOST=$COREOS_PRIVATE_IPV4 -v /var/run/docker.sock:/var/run/docker.sock $IMAGE"
 ExecStopPost=-/usr/bin/docker rm -f deis-publisher
 Restart=on-failure

--- a/deisctl/units/deis-registry.service
+++ b/deisctl/units/deis-registry.service
@@ -4,8 +4,8 @@ Description=deis-registry
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=30m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-registry >/dev/null && docker rm -f deis-registry || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-registry >/dev/null 2>&1 && docker rm -f deis-registry || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docker run --name deis-registry --rm -p 5000:5000 -e EXTERNAL_PORT=5000 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStopPost=-/usr/bin/docker rm -f deis-registry
 Restart=on-failure

--- a/deisctl/units/deis-router.service
+++ b/deisctl/units/deis-router.service
@@ -4,8 +4,8 @@ Description=deis-router
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router` && docker history $IMAGE >/dev/null || docker pull $IMAGE"
-ExecStartPre=/bin/sh -c "docker inspect deis-router >/dev/null && docker rm -f deis-router || true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "docker inspect deis-router >/dev/null 2>&1 && docker rm -f deis-router || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router` && docker run --name deis-router --rm -p 80:80 -p 2222:2222 -p 443:443 -e EXTERNAL_PORT=80 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStopPost=-/usr/bin/docker rm -f deis-router
 Restart=on-failure

--- a/docs/managing_deis/platform_monitoring.rst
+++ b/docs/managing_deis/platform_monitoring.rst
@@ -42,8 +42,8 @@ To run cAdvisor on all hosts in the cluster, you can submit and start a fleet se
     After=docker.socket
 
     [Service]
-    ExecStartPre=/bin/sh -c "docker history google/cadvisor:latest >/dev/null || docker pull google/cadvisor:latest"
-    ExecStartPre=/bin/sh -c "docker inspect cadvisor >/dev/null && docker rm -f cadvisor || true"
+    ExecStartPre=/bin/sh -c "docker history google/cadvisor:latest >/dev/null 2>&1 || docker pull google/cadvisor:latest"
+    ExecStartPre=/bin/sh -c "docker inspect cadvisor >/dev/null 2>&1 && docker rm -f cadvisor || true"
     ExecStart=/usr/bin/docker run --volume=/:/rootfs:ro --volume=/var/run:/var/run:rw --volume=/sys:/sys:ro --volume=/var/lib/docker/:/var/lib/docker:ro --publish=8080:8080 --name=cadvisor google/cadvisor:latest
     ExecStopPost=-/usr/bin/docker rm -f cadvisor
     Restart=on-failure


### PR DESCRIPTION
Currently, whenever we run `docker history` and `docker inspect`
before pulling components for the first time, we emit an
"Image not found" error, which is confusing.

This commit suppresses this output.