### PR TITLE
fix(builder): error on pipefail

### DIFF
--- a/builder/image/templates/builder
+++ b/builder/image/templates/builder
@@ -3,7 +3,7 @@
 # builder hook called on every git receive-pack
 # NOTE: this script must be run as root (for docker access)
 #
-set -e
+set -eo pipefail
 
 ARGS=3
 


### PR DESCRIPTION
In newer refactors of the builder, some commands are piped. In bash,
the last command's exit code in the pipe is considered. With
`set -o pipefail`, any command that fails in the pipe means that it's a
non-zero pipe fail, which is what we expect to occur.

closes #2996
closes #3207