### PR TITLE
Revert "properly escape backticks in envvars"

### DIFF
--- a/builder/bin/get-app-values.go
+++ b/builder/bin/get-app-values.go
@@ -26,9 +26,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	var retVal string
 	for _, value := range values {
-		retVal = fmt.Sprintf("%s%s", retVal, value)
+		fmt.Println(value)
 	}
-	fmt.Println(retVal)
 }

--- a/builder/image/slugbuilder/builder/build.sh
+++ b/builder/image/slugbuilder/builder/build.sh
@@ -77,9 +77,6 @@ selected_buildpack=
 if [[ -n "$BUILDPACK_URL" ]]; then
     echo_title "Fetching custom buildpack"
 
-    # FIXME: strip single quotes coming from the builder
-    BUILDPACK_URL=$(echo $BUILDPACK_URL | tr -d "'")
-
     buildpack="$buildpack_root/custom"
     rm -fr "$buildpack"
 

--- a/builder/image/templates/builder
+++ b/builder/image/templates/builder
@@ -113,7 +113,7 @@ if [ ! -f Dockerfile ]; then
     BUILD_OPTS+=' deis/slugbuilder'
 
     # build the application and attach to the process
-    JOB=$(eval '$(parse-string "${BUILD_OPTS[@]}")' )
+    JOB=$(eval $(parse-string "${BUILD_OPTS[@]}") )
     docker attach $JOB
 
     # copy out the compiled slug

--- a/builder/image/templates/builder
+++ b/builder/image/templates/builder
@@ -27,6 +27,14 @@ usage() {
     echo "Usage: $0 <user> <repo> <sha>"
 }
 
+parse-string(){
+    # helper to avoid the single quote escape
+    # occurred in command substitution
+    local args=() idx=0 IFS=' ' c
+    for c; do printf -v args[idx++] '%s ' "$c"; done
+    printf "%s\n" "${args[*]}"
+}
+
 if [ $# -ne $ARGS ]; then
     usage
     exit 1
@@ -105,7 +113,7 @@ if [ ! -f Dockerfile ]; then
     BUILD_OPTS+=' deis/slugbuilder'
 
     # build the application and attach to the process
-    JOB=$(${BUILD_OPTS[@]})
+    JOB=$(eval '$(parse-string "${BUILD_OPTS[@]}")' )
     docker attach $JOB
 
     # copy out the compiled slug

--- a/builder/utils.go
+++ b/builder/utils.go
@@ -109,7 +109,7 @@ func ParseControllerConfig(bytes []byte) ([]string, error) {
 
 	retVal := []string{}
 	for k, v := range controllerConfig.Values {
-		retVal = append(retVal, fmt.Sprintf(" -e %s='%v'", k, v))
+		retVal = append(retVal, fmt.Sprintf(" -e %s=\"%v\"", k, v))
 	}
 	return retVal, nil
 }

--- a/builder/utils_test.go
+++ b/builder/utils_test.go
@@ -163,8 +163,8 @@ func TestParseControllerConfigGood(t *testing.T) {
 		t.Errorf("expected 2, got %d", len(config))
 	}
 
-	if !stringInSlice(config, " -e CAR='star'") {
-		t.Error("expected ' -e CAR='star'' in slice")
+	if !stringInSlice(config, " -e CAR=\"star\"") {
+		t.Error("expected ' -e CAR=\"star\"' in slice")
 	}
 }
 

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -13,7 +13,6 @@ var (
 	configSetCmd          = "config:set FOO=讲台 --app={{.AppName}}"
 	configSet2Cmd         = "config:set FOO=10 --app={{.AppName}}"
 	configSet3Cmd         = "config:set POWERED_BY=\"the Deis team\" --app={{.AppName}}"
-	configSet4Cmd         = "config:set CAR='`star' --app={{.AppName}}"
 	configSetBuildpackCmd = "config:set BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-go#98f37cc --app={{.AppName}}"
 	configUnsetCmd        = "config:unset FOO --app={{.AppName}}"
 )
@@ -46,9 +45,6 @@ func configSetup(t *testing.T) *utils.DeisTestConfig {
 	// ensure envvars with spaces work fine on `git push`
 	// https://github.com/deis/deis/issues/2477
 	utils.Execute(t, configSet3Cmd, cfg, false, "the Deis team")
-	// ensure envvars with backticks work too
-	// https://github.com/deis/deis/issues/2980
-	utils.Execute(t, configSet4Cmd, cfg, false, "`star")
 	// ensure custom buildpack URLS are in order
 	utils.Execute(t, configSetBuildpackCmd, cfg, false, "https://github.com/heroku/heroku-buildpack-go#98f37cc")
 	utils.Execute(t, gitPushCmd, cfg, false, "")
@@ -66,13 +62,13 @@ func configListTest(
 
 func configSetTest(t *testing.T, params *utils.DeisTestConfig) {
 	utils.Execute(t, configSetCmd, params, false, "讲台")
-	utils.CheckList(t, appsInfoCmd, params, "(v6)", false)
+	utils.CheckList(t, appsInfoCmd, params, "(v5)", false)
 	utils.Execute(t, configSet2Cmd, params, false, "10")
-	utils.CheckList(t, appsInfoCmd, params, "(v7)", false)
+	utils.CheckList(t, appsInfoCmd, params, "(v6)", false)
 }
 
 func configUnsetTest(t *testing.T, params *utils.DeisTestConfig) {
 	utils.Execute(t, configUnsetCmd, params, false, "")
-	utils.CheckList(t, appsInfoCmd, params, "(v8)", false)
+	utils.CheckList(t, appsInfoCmd, params, "(v7)", false)
 	utils.CheckList(t, "run env --app={{.AppName}}", params, "FOO", true)
 }


### PR DESCRIPTION
Builder is extremely finnicky, and the lack of tests around this workflow has caused issues like #3212.

This reverts #3129 and #3020, effectively re-opening #2980 and #3010 until we have a better way to test these workflows.

closes #3212