### PR TITLE
docs(customizing_deis): remove unused registry secret key

### DIFF
--- a/docs/customizing_deis/registry_settings.rst
+++ b/docs/customizing_deis/registry_settings.rst
@@ -26,7 +26,6 @@ setting                                  description
 /deis/registry/host                      IP address of the host running registry
 /deis/registry/port                      port used by the registry service (default: 5000)
 /deis/registry/protocol                  protocol for registry (default: http)
-/deis/registry/secretKey                 used for secrets (default: randomly generated)
 ===========================              =================================================================================
 
 Settings used by registry

--- a/registry/bin/boot
+++ b/registry/bin/boot
@@ -42,7 +42,6 @@ function etcd_set_default {
 
 # seed initial service configuration if necessary
 etcd_set_default protocol http
-etcd_set_default secretKey ${REGISTRY_SECRET_KEY:-`openssl rand -base64 64 | tr -d '\n'`}
 etcd_set_default bucketName ${BUCKET_NAME}
 
 # wait for confd to run once and install initial templates


### PR DESCRIPTION
This key was removed in a recent release of the docker registry so it
is no longer in use.