### PR TITLE
feat(router): set additional X-Forwarded headers

### DIFF
--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -157,10 +157,16 @@ http {
             {{ if eq $useFirewall "true" }}include                     /opt/nginx/firewall/active-mode.rules;{{ end }}
             proxy_buffering             off;
             proxy_set_header            Host $host;
-            {{ if ne $useSSL "false" }}
-            proxy_set_header            X-Forwarded-Proto $scheme;
-            {{ end }}
+            set $access_ssl 'off';
+            set $access_port '80';
+            if ($access_scheme ~ https) {
+                set $access_ssl 'on';
+                set $access_port '443';
+            }
+            proxy_set_header            X-Forwarded-Port  $access_port;
+            proxy_set_header            X-Forwarded-Proto $access_scheme;
             proxy_set_header            X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header            X-Forwarded-Ssl   $access_ssl;
             proxy_redirect              off;
             proxy_connect_timeout       30s;
             proxy_send_timeout          1200s;


### PR DESCRIPTION
Currently X-Forwarded-Proto does not work correctly behind a load balance with SSL termination. This hopes to fix that and ensures the most common protocol related headers are set.

1.) Ensure X-Forwarded-Proto header is always set for greater application compatibility.
2.) Add X-Forwarded-Protocol and X-Forwarded-Ssl headers for greater application compatibility.
3.) Attempt to detect the proper protocol when running behind load balancers or proxies.