### PR TITLE
Run integration tests against EC2 clusters

### DIFF
--- a/builder/tests/builder_test.go
+++ b/builder/tests/builder_test.go
@@ -45,6 +45,7 @@ func TestBuilder(t *testing.T) {
 	defer os.Remove(tmpfile.Name())
 
 	tag, etcdPort := utils.BuildTag(), utils.RandomPort()
+	imageName := utils.ImagePrefix() + "builder" + ":" + tag
 	etcdName := "deis-etcd-" + tag
 	cli, stdout, stdoutPipe := dockercli.NewClient()
 	dockercli.RunTestEtcd(t, etcdName, etcdPort)
@@ -52,7 +53,7 @@ func TestBuilder(t *testing.T) {
 	handler := etcdutils.InitEtcd(setdir, setkeys, etcdPort)
 	etcdutils.PublishEtcd(t, handler)
 	host, port := utils.HostAddress(), utils.RandomPort()
-	fmt.Printf("--- Run deis/builder:%s at %s:%s\n", tag, host, port)
+	fmt.Printf("--- Run %s at %s:%s\n", imageName, host, port)
 	name := "deis-builder-" + tag
 	defer cli.CmdRm("-f", "-v", name)
 	go func() {
@@ -67,7 +68,7 @@ func TestBuilder(t *testing.T) {
 			"-e", "EXTERNAL_PORT="+port,
 			"--privileged",
 			"-v", tmpfile.Name()+":/etc/environment_proxy",
-			"deis/builder:"+tag)
+			imageName)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "deis-builder running")
 	if err != nil {

--- a/cache/tests/cache_test.go
+++ b/cache/tests/cache_test.go
@@ -13,13 +13,14 @@ import (
 func TestCache(t *testing.T) {
 	var err error
 	tag := utils.BuildTag()
+	imageName := utils.ImagePrefix() + "cache" + ":" + tag
 	etcdPort := utils.RandomPort()
 	etcdName := "deis-etcd-" + tag
 	cli, stdout, stdoutPipe := dockercli.NewClient()
 	dockercli.RunTestEtcd(t, etcdName, etcdPort)
 	defer cli.CmdRm("-f", etcdName)
 	host, port := utils.HostAddress(), utils.RandomPort()
-	fmt.Printf("--- Run deis/cache:%s at %s:%s\n", tag, host, port)
+	fmt.Printf("--- Run %s at %s:%s\n", imageName, host, port)
 	name := "deis-cache-" + tag
 	defer cli.CmdRm("-f", name)
 	go func() {
@@ -31,7 +32,7 @@ func TestCache(t *testing.T) {
 			"-e", "EXTERNAL_PORT="+port,
 			"-e", "HOST="+host,
 			"-e", "ETCD_PORT="+etcdPort,
-			"deis/cache:"+tag)
+			imageName)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "started")
 	if err != nil {

--- a/controller/tests/controller_test.go
+++ b/controller/tests/controller_test.go
@@ -26,6 +26,7 @@ func TestController(t *testing.T) {
 		"/deis/domains",
 	}
 	tag, etcdPort := utils.BuildTag(), utils.RandomPort()
+	imageName := utils.ImagePrefix() + "controller" + ":" + tag
 
 	//start etcd container
 	etcdName := "deis-etcd-" + tag
@@ -38,7 +39,7 @@ func TestController(t *testing.T) {
 	mock.RunMockDatabase(t, tag, etcdPort, utils.RandomPort())
 	defer cli.CmdRm("-f", "deis-test-database-"+tag)
 	host, port := utils.HostAddress(), utils.RandomPort()
-	fmt.Printf("--- Run deis/controller:%s at %s:%s\n", tag, host, port)
+	fmt.Printf("--- Run %s at %s:%s\n", imageName, host, port)
 	name := "deis-controller-" + tag
 	defer cli.CmdRm("-f", name)
 	go func() {
@@ -51,7 +52,7 @@ func TestController(t *testing.T) {
 			"-e", "EXTERNAL_PORT="+port,
 			"-e", "HOST="+host,
 			"-e", "ETCD_PORT="+etcdPort,
-			"deis/controller:"+tag)
+			imageName)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "Booting")
 	if err != nil {

--- a/database/tests/database_test.go
+++ b/database/tests/database_test.go
@@ -14,6 +14,7 @@ import (
 func TestDatabase(t *testing.T) {
 	var err error
 	tag, etcdPort := utils.BuildTag(), utils.RandomPort()
+	imageName := utils.ImagePrefix() + "database" + ":" + tag
 	cli, stdout, stdoutPipe := dockercli.NewClient()
 
 	// start etcd container
@@ -28,7 +29,7 @@ func TestDatabase(t *testing.T) {
 
 	// run database container
 	host, port := utils.HostAddress(), utils.RandomPort()
-	fmt.Printf("--- Run deis/database:%s at %s:%s\n", tag, host, port)
+	fmt.Printf("--- Run %s at %s:%s\n", imageName, host, port)
 	name := "deis-database-" + tag
 	defer cli.CmdRm("-f", name)
 	go func() {
@@ -40,7 +41,7 @@ func TestDatabase(t *testing.T) {
 			"-e", "EXTERNAL_PORT="+port,
 			"-e", "HOST="+host,
 			"-e", "ETCD_PORT="+etcdPort,
-			"deis/database:"+tag)
+			imageName)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "database: postgres is running...")
 	if err != nil {

--- a/includes.mk
+++ b/includes.mk
@@ -10,7 +10,10 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 DOCKER_HOST = $(shell echo $$DOCKER_HOST)
 REGISTRY = $(shell echo $$DEV_REGISTRY)
 GIT_SHA = $(shell git rev-parse --short HEAD)
-IMAGE_PREFIX := deis/
+
+ifndef IMAGE_PREFIX
+  IMAGE_PREFIX = deis/
+endif
 
 ifndef BUILD_TAG
   BUILD_TAG = git-$(GIT_SHA)

--- a/logger/tests/logger_test.go
+++ b/logger/tests/logger_test.go
@@ -13,6 +13,7 @@ import (
 func TestLogger(t *testing.T) {
 	var err error
 	tag, etcdPort := utils.BuildTag(), utils.RandomPort()
+	imageName := utils.ImagePrefix() + "logger" + ":" + tag
 
 	//start etcd container
 	etcdName := "deis-etcd-" + tag
@@ -21,7 +22,7 @@ func TestLogger(t *testing.T) {
 	defer cli.CmdRm("-f", etcdName)
 
 	host, port := utils.HostAddress(), utils.RandomPort()
-	fmt.Printf("--- Run deis/logger:%s at %s:%s\n", tag, host, port)
+	fmt.Printf("--- Run %s at %s:%s\n", imageName, host, port)
 	name := "deis-logger-" + tag
 	defer cli.CmdRm("-f", name)
 	go func() {
@@ -33,7 +34,7 @@ func TestLogger(t *testing.T) {
 			"-e", "EXTERNAL_PORT="+port,
 			"-e", "HOST="+host,
 			"-e", "ETCD_PORT="+etcdPort,
-			"deis/logger:"+tag)
+			imageName)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "deis-logger running")
 	if err != nil {

--- a/registry/tests/registry_test.go
+++ b/registry/tests/registry_test.go
@@ -26,6 +26,7 @@ func TestRegistry(t *testing.T) {
 		"/deis/store",
 	}
 	tag, etcdPort := utils.BuildTag(), utils.RandomPort()
+	imageName := utils.ImagePrefix() + "registry" + ":" + tag
 	etcdName := "deis-etcd-" + tag
 	cli, stdout, stdoutPipe := dockercli.NewClient()
 	dockercli.RunTestEtcd(t, etcdName, etcdPort)
@@ -39,7 +40,7 @@ func TestRegistry(t *testing.T) {
 	defer cli.CmdRm("-f", cephName)
 
 	host, port := utils.HostAddress(), utils.RandomPort()
-	fmt.Printf("--- Run deis/registry:%s at %s:%s\n", tag, host, port)
+	fmt.Printf("--- Run %s at %s:%s\n", imageName, host, port)
 	name := "deis-registry-" + tag
 	defer cli.CmdRm("-f", name)
 	go func() {
@@ -51,7 +52,7 @@ func TestRegistry(t *testing.T) {
 			"-e", "EXTERNAL_PORT="+port,
 			"-e", "HOST="+host,
 			"-e", "ETCD_PORT="+etcdPort,
-			"deis/registry:"+tag)
+			imageName)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "Booting")
 	if err != nil {

--- a/router/tests/router_test.go
+++ b/router/tests/router_test.go
@@ -30,6 +30,7 @@ func TestRouter(t *testing.T) {
 		"/deis/store",
 	}
 	tag, etcdPort := utils.BuildTag(), utils.RandomPort()
+	imageName := utils.ImagePrefix() + "router" + ":" + tag
 	etcdName := "deis-etcd-" + tag
 	cli, stdout, stdoutPipe := dockercli.NewClient()
 	dockercli.RunTestEtcd(t, etcdName, etcdPort)
@@ -37,7 +38,7 @@ func TestRouter(t *testing.T) {
 	handler := etcdutils.InitEtcd(setdir, setkeys, etcdPort)
 	etcdutils.PublishEtcd(t, handler)
 	host, port := utils.HostAddress(), utils.RandomPort()
-	fmt.Printf("--- Run deis/router:%s at %s:%s\n", tag, host, port)
+	fmt.Printf("--- Run %s at %s:%s\n", imageName, host, port)
 	name := "deis-router-" + tag
 	go func() {
 		_ = cli.CmdRm("-f", name)
@@ -50,7 +51,7 @@ func TestRouter(t *testing.T) {
 			"-e", "HOST="+host,
 			"-e", "ETCD_PORT="+etcdPort,
 			"-e", "LOG=debug",
-			"deis/router:"+tag)
+			imageName)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "deis-router running")
 	if err != nil {

--- a/store/Makefile
+++ b/store/Makefile
@@ -16,23 +16,23 @@ MONITOR_DEV_IMAGE = $(DEV_REGISTRY)/$(MONITOR_IMAGE)
 
 build: check-docker
 	@# Build base as normal
-	docker build -t deis/store-base:$(BUILD_TAG) base/
+	docker build -t $(IMAGE_PREFIX)store-base:$(BUILD_TAG) base/
 	$(foreach I, $(TEMPLATE_IMAGES), \
-		sed -e "s/#FROM is generated dynamically by the Makefile/FROM deis\/store-base:${BUILD_TAG}/" $(I)/Dockerfile.template > $(I)/Dockerfile ; \
-		docker build -t deis/store-$(I):$(BUILD_TAG) $(I)/ || exit 1; \
+		sed -e "s,#FROM is generated dynamically by the Makefile,FROM $(IMAGE_PREFIX)store-base:${BUILD_TAG}," $(I)/Dockerfile.template > $(I)/Dockerfile ; \
+		docker build -t $(IMAGE_PREFIX)store-$(I):$(BUILD_TAG) $(I)/ || exit 1; \
 		rm $(I)/Dockerfile ; \
 	)
 
 clean: check-docker check-registry
 	$(foreach I, $(BUILT_IMAGES), \
-		docker rmi deis/store-$(I):$(BUILD_TAG) ; \
-		docker rmi $(REGISTRY)/deis/store-$(I):$(BUILD_TAG) ; \
+		docker rmi $(IMAGE_PREFIX)store-$(I):$(BUILD_TAG) ; \
+		docker rmi $(REGISTRY)/$(IMAGE_PREFIX)store-$(I):$(BUILD_TAG) ; \
 	)
 
 full-clean: check-docker check-registry
 	$(foreach I, $(BUILT_IMAGES), \
-		docker images -q deis/store-$(I) | xargs docker rmi -f ; \
-		docker images -q $(REGISTRY)/deis/store-$(I) | xargs docker rmi -f ; \
+		docker images -q $(IMAGE_PREFIX)store-$(I) | xargs docker rmi -f ; \
+		docker images -q $(REGISTRY)/$(IMAGE_PREFIX)store-$(I) | xargs docker rmi -f ; \
 	)
 
 install: check-deisctl

--- a/tests/bin/route53-wildcard.py
+++ b/tests/bin/route53-wildcard.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""
+The route53-wildcard utility is used to add and remove wildcard
+DNS entries from an AWS Route53 zonefile.
+
+Usage: route53-wildcard.py <action> <name> <value> [options]
+
+Options:
+
+  --zone=<zone>      name of zone to use [defaults to parsing name]
+  --region=<region>  AWS region to use [default: us-west-2].
+  --ttl=<ttl>        record TTL to use [default: 60].
+
+Examples:
+
+./route53-wildcard.py create mycluster.gabrtv.io deis-elb.blah.amazonaws.com
+./route53-wildcard.py delete mycluster.gabrtv.io deis-elb.blah.amazonaws.com
+"""
+import boto.route53
+import docopt
+import json
+import subprocess
+import time
+
+
+def parse_args():
+    return docopt.docopt(__doc__)
+
+def create_cname(args):
+    conn = boto.route53.connect_to_region(args['--region'])
+    zone = conn.get_zone(args['<zone>'])
+    status = zone.add_cname(args['<name>'], args['<value>'], ttl=args['--ttl'])
+    print("waiting for record to sync: {}".format(status))
+    while status.update() != "INSYNC":
+        time.sleep(2)
+    print(status)
+
+def delete_cname(args, block=False):
+    conn = boto.route53.connect_to_region(args['--region'])
+    zone = conn.get_zone(args['<zone>'])
+    status = zone.delete_cname(args['<name>'])
+    if block:
+        print("waiting for record to sync: {}".format(status))
+        while status.update() != "INSYNC":
+            time.sleep(2)
+        print(status)
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    # calculate zone from provided name
+    zone = '.'.join(args['<name>'].split('.')[-2:])
+    args['<zone>'] = zone
+
+    # add a * to the provided name
+    args['<name>'] = u'\\052.'+unicode(args['<name>'])
+
+    if args['<action>'] == 'create':
+        create_cname(args)
+    elif args['<action>'] == 'delete':
+        delete_cname(args)
+    else:
+        raise NotImplementedError

--- a/tests/bin/test-integration-ec2.sh
+++ b/tests/bin/test-integration-ec2.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+#
+# Preps a test environment and runs `make test-integration`
+# against artifacts produced from the current source tree
+#
+
+# fail on any command exiting non-zero
+set -e
+
+# absolute path to current directory
+export THIS_DIR=$(cd $(dirname $0); pwd)
+
+# setup the test environment
+source $THIS_DIR/test-setup.sh
+
+# AWS credentials required for aws cli and boto
+export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID?}
+export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY?}
+
+# install python requirements for this script
+pip install awscli boto docopt
+
+function cleanup_ec2 {
+    log_phase "Cleaning up"
+    aws cloudformation delete-stack --stack-name $STACK_NAME
+    python $DEIS_ROOT/tests/bin/route53-wildcard.py delete $DEIS_TEST_DOMAIN $ELB_DNS_NAME
+}
+
+# setup callbacks on process exit and error
+trap cleanup_ec2 EXIT
+trap dump_logs ERR
+
+log_phase "Running style tests"
+
+make test-style
+
+log_phase "Running documentation tests"
+
+# test building documentation
+make -C docs/ test
+
+log_phase "Running unit tests"
+
+make test-unit
+
+log_phase "Building from current source tree"
+
+# build all docker images and client binaries
+make build
+
+# use the built client binaries
+export PATH=$DEIS_ROOT/deisctl:$DEIS_ROOT/client/dist:$PATH
+
+log_phase "Running functional tests"
+
+make test-functional
+
+export DEIS_NUM_INSTANCES=3
+log_phase "Provisioning $DEIS_NUM_INSTANCES-node CoreOS"
+
+# TODO: don't hardcode --key-names
+if ! aws ec2 describe-key-pairs --key-names "deis" >/dev/null ; then
+    echo "Importing $DEIS_TEST_AUTH_KEY keypair to EC2"
+    aws ec2 import-key-pair --key-name deis \
+        --public-key-material file://~/.ssh/$DEIS_TEST_AUTH_KEY.pub \
+        --output text
+fi
+
+make discovery-url
+# add random characters after STACK_TAG to avoid collisions
+# TODO: somehow this breaks "set -eo pipefail"
+STACK_TAG=${STACK_TAG:-test}-$(base64 /dev/urandom | tr -dc a-z0-9 | head -c 6)
+STACK_NAME=deis-$STACK_TAG
+echo "Creating CloudFormation stack $STACK_NAME"
+$DEIS_ROOT/contrib/ec2/provision-ec2-cluster.sh $STACK_NAME
+
+# use the first cluster node for now
+INSTANCE_IDS=$(aws ec2 describe-instances \
+    --filters Name=tag:aws:cloudformation:stack-name,Values=$STACK_NAME Name=instance-state-name,Values=running \
+    --query 'Reservations[].Instances[].[ InstanceId ]' \
+    --output text)
+export INSTANCE_ID=$(cut -d " " -f1 <<< $INSTANCE_IDS)
+export DEISCTL_TUNNEL=$(aws ec2 describe-instances \
+    --instance-ids=$INSTANCE_ID \
+    --filters Name=tag:aws:cloudformation:stack-name,Values=$STACK_NAME Name=instance-state-name,Values=running \
+    --query 'Reservations[].Instances[].[ PublicDnsName ]' \
+    --output text)
+
+log_phase "Waiting for etcd/fleet at $DEISCTL_TUNNEL"
+
+# wait for etcd up to 5 minutes
+WAIT_TIME=1
+until deisctl --request-timeout=1 list >/dev/null 2>&1; do
+   (( WAIT_TIME += 1 ))
+   if [ $WAIT_TIME -gt 300 ]; then
+    log_phase "Timeout waiting for etcd/fleet"
+    # run deisctl one last time without eating the error, so we can see what's up
+    deisctl --request-timeout=1 list
+    exit 1;
+  fi
+done
+
+log_phase "etcd available after $WAIT_TIME seconds"
+
+log_phase "Publishing release from source tree"
+
+# TODO: detect where IMAGE_PREFIX=deis/ and DEV_REGISTRY=registry.hub.docker.com
+# and disallow it so we can't pollute the production account.
+make dev-release
+
+log_phase "Provisioning Deis"
+
+export DEIS_TEST_DOMAIN=$STACK_TAG.deis.works
+
+# configure platform settings
+deisctl config platform set domain=$DEIS_TEST_DOMAIN
+deisctl config platform set sshPrivateKey=$DEIS_TEST_SSH_KEY
+
+time deisctl install platform
+time deisctl start platform
+
+# get ELB public DNS name through cloudformation
+# TODO: is "first output value" going to be reliable enough?
+ELB_DNS_NAME=$(aws cloudformation describe-stacks \
+    --stack-name $STACK_NAME \
+    --max-items 1 \
+    --query 'Stacks[].[ Outputs[0].[ OutputValue ] ]' \
+    --output=text)
+
+# get ELB friendly name through aws elb
+ELB_NAME=$(aws elb describe-load-balancers \
+    --query 'LoadBalancerDescriptions[].[ DNSName,LoadBalancerName ]' \
+    --output=text | grep -F $ELB_DNS_NAME | head -n1 | cut -f2)
+echo "Using ELB $ELB_NAME"
+
+# add or update a route53 alias record set to route queries to the ELB
+# this python script won't return until the wildcard domain is accessible
+python $DEIS_ROOT/tests/bin/route53-wildcard.py create $DEIS_TEST_DOMAIN $ELB_DNS_NAME
+
+# loop until at least one instance is "in service" with the ELB
+ATTEMPTS=45
+SLEEPTIME=10
+COUNTER=1
+IN_SERVICE=0
+until [ $IN_SERVICE -ge 1 ]; do
+    if [ $COUNTER -gt $ATTEMPTS ]; then exit 1; fi  # timeout after 7 1/2 minutes
+    if [ $COUNTER -ne 1 ]; then sleep $SLEEPTIME; fi
+    echo "Waiting for ELB to see an instance in service..."
+    IN_SERVICE=$(aws elb describe-instance-health \
+        --load-balancer-name $ELB_NAME \
+        --query 'InstanceStates[].State' \
+        | grep InService | wc -l)
+done
+
+log_phase "Running integration suite"
+
+time make test-integration

--- a/tests/bin/test-integration.sh
+++ b/tests/bin/test-integration.sh
@@ -13,6 +13,10 @@ export THIS_DIR=$(cd $(dirname $0); pwd)
 # setup the test environment
 source $THIS_DIR/test-setup.sh
 
+# clean out vagrant environment
+$THIS_DIR/halt-all-vagrants.sh
+vagrant destroy --force
+
 # setup callbacks on process exit and error
 trap cleanup EXIT
 trap dump_logs ERR

--- a/tests/bin/test-setup.sh
+++ b/tests/bin/test-setup.sh
@@ -67,8 +67,10 @@ go get -v github.com/tools/godep
 # cleanup any stale example applications
 rm -rf $DEIS_ROOT/tests/example-*
 
-# generate ssh key if it doesn't already exist
+# generate ssh keys if they don't already exist
 test -e ~/.ssh/$DEIS_TEST_AUTH_KEY || ssh-keygen -t rsa -f ~/.ssh/$DEIS_TEST_AUTH_KEY -N ''
+# TODO: parameterize this key required for keys_test.go?
+test -e ~/.ssh/deiskey || ssh-keygen -q -t rsa -f ~/.ssh/deiskey -N '' -C deiskey
 
 # prepare the SSH agent
 ssh-add -D || eval $(ssh-agent) && ssh-add -D

--- a/tests/bin/test-setup.sh
+++ b/tests/bin/test-setup.sh
@@ -78,10 +78,6 @@ ssh-add $DEIS_TEST_SSH_KEY
 # clean out deis session data
 rm -rf ~/.deis
 
-# clean out vagrant environment
-$THIS_DIR/halt-all-vagrants.sh
-vagrant destroy --force
-
 # wipe out all vagrants & deis virtualboxen
 function cleanup {
     log_phase "Cleaning up"

--- a/tests/mock/mock.go
+++ b/tests/mock/mock.go
@@ -53,11 +53,12 @@ func RunMockDatabase(t *testing.T, tag string, etcdPort string, dbPort string) {
 // RunMockCeph runs a container used to mock a Ceph storage cluster
 func RunMockCeph(t *testing.T, name string, cli *client.DockerCli, etcdPort string) {
 
+	storeImage := utils.ImagePrefix() + "mock-store:latest"
 	etcdutils.SetSingle(t, "/deis/store/hosts/"+utils.HostAddress(), utils.HostAddress(), etcdPort)
 	var err error
 	cli, stdout, stdoutPipe := dockercli.NewClient()
 	ipaddr := utils.HostAddress()
-	fmt.Printf("--- Running deis/mock-store at %s\n", ipaddr)
+	fmt.Printf("--- Running %s at %s\n", storeImage, ipaddr)
 	done := make(chan bool, 1)
 	go func() {
 		done <- true
@@ -67,7 +68,7 @@ func RunMockCeph(t *testing.T, name string, cli *client.DockerCli, etcdPort stri
 			"-e", "HOST="+ipaddr,
 			"-e", "ETCD_PORT="+etcdPort,
 			"--net=host",
-			"deis/mock-store:latest")
+			storeImage)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "deis-store-gateway running...")
 	if err != nil {

--- a/tests/ps_test.go
+++ b/tests/ps_test.go
@@ -4,7 +4,6 @@ package tests
 
 import (
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -72,18 +71,4 @@ func psScaleTest(t *testing.T, params *utils.DeisTestConfig, cmd string) {
 		cmd = strings.Replace(cmd, "web", "cmd", 1)
 	}
 	utils.Execute(t, cmd, params, false, "")
-	// Regression test for https://github.com/deis/deis/pull/1347
-	// Ensure that systemd unitfile droppings are cleaned up.
-	sshCmd := exec.Command("ssh",
-		"-o", "StrictHostKeyChecking=no",
-		"-o", "UserKnownHostsFile=/dev/null",
-		"-o", "PasswordAuthentication=no",
-		"core@deis."+params.Domain, "ls")
-	out, err := sshCmd.Output()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.Contains(string(out), ".service") {
-		t.Fatalf("systemd files left on filesystem: \n%s", out)
-	}
 }

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -29,6 +29,16 @@ func BuildTag() string {
 	return strings.TrimSpace(tag)
 }
 
+// ImagePrefix returns the $IMAGE_PREFIX environment variable or `deis/`
+func ImagePrefix() string {
+	var prefix string
+	prefix = os.Getenv("IMAGE_PREFIX")
+	if prefix != "" {
+		return prefix
+	}
+	return "deis/"
+}
+
 // Chdir sets the current working directory to the relative path specified.
 func Chdir(app string) error {
 	var wd, _ = os.Getwd()


### PR DESCRIPTION
This forks `test-integration.sh` into `test-integration-ec2.sh` so we can target both providers. EC2 testing ~~seems to be more reliable currently than vagrant and~~ will allow us to scale CI more easily. This has run several times as [test-ec2](https://ci.deis.io/job/test-ec2/).

Closes #1680.
