### PR TITLE
ref(controller): use postgres:9.3 for functional tests

### DIFF
--- a/tests/mock/mock.go
+++ b/tests/mock/mock.go
@@ -27,11 +27,9 @@ func RunMockDatabase(t *testing.T, tag string, etcdPort string, dbPort string) {
 			"--name", "deis-test-database-"+tag,
 			"--rm",
 			"-p", dbPort+":5432",
-			"-e", "EXTERNAL_PORT="+dbPort,
-			"-e", "HOST="+ipaddr,
-			"-e", "USER=deis",
-			"-e", "DB=deis",
-			"-e", "PASS=deis",
+			"-e", "POSTGRES_USER=deis",
+			"-e", "POSTGRES_DB=deis",
+			"-e", "POSTGRES_PASSWORD=deis",
 			dbImage)
 	}()
 	time.Sleep(1000 * time.Millisecond)


### PR DESCRIPTION
We've found this image to be more reliable than
paintedfox/test-postgresql.

relies on https://github.com/deis/test-postgresql/pull/1 to be merged first, but initial tests have been showing improved reliability on node2.opdemand.com.