### PR TITLE
fix(router) enforce HTTPS correctly when not behind an elb

### DIFF
--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -55,6 +55,12 @@ http {
         ''      close;
     }
 
+    # trust http_x_forwarded_proto headers correctly indicate ssl offloading
+    map $http_x_forwarded_proto $access_scheme {
+      default $http_x_forwarded_proto;
+      ''      $scheme;
+    }
+
     {{ $enforceHTTPS := or .deis_router_enforceHTTPS "false" }}
 
     ## start deis-controller
@@ -92,7 +98,7 @@ http {
         }{{ end }}
 
         {{ if eq $enforceHTTPS "true" }}
-        if ($http_x_forwarded_proto != "https") {
+        if ($access_scheme != "https") {
           rewrite ^(.*)$ https://$host$1 permanent;
         }
         {{ end }}
@@ -166,7 +172,7 @@ http {
             proxy_next_upstream         error timeout http_502 http_503 http_504;
 
             {{ if eq $enforceHTTPS "true" }}
-            if ($http_x_forwarded_proto != "https") {
+            if ($access_scheme != "https") {
               rewrite ^(.*)$ https://$host$1 permanent;
             }
             {{ end }}


### PR DESCRIPTION
$http_x_forwarded_proto is only set by a load balancer. The rest of us just want to check if `$https = "on"`

closes #3245