### PR TITLE
chore(builder): bump heroku-buildpack-ruby to v134

### DIFF
--- a/builder/image/Dockerfile
+++ b/builder/image/Dockerfile
@@ -41,7 +41,7 @@ RUN chown -R $GITUSER:$GITUSER $GITHOME
 # HACK: import progrium/cedarish as a tarball
 # see https://github.com/deis/deis/issues/1027
 RUN curl -#SL -o /progrium_cedarish.tar.gz \
-    https://s3-us-west-2.amazonaws.com/opdemand/progrium_cedarish_2014_12_15.tar.gz
+    https://github.com/progrium/cedarish/releases/download/v3/cedarish-cedar14_v3.tar.gz
 
 # define the execution environment
 # use VOLUME to remove /var/lib/docker from copy-on-write for performance

--- a/builder/image/slugbuilder/builder/install-buildpacks
+++ b/builder/image/slugbuilder/builder/install-buildpacks
@@ -29,7 +29,7 @@ download_buildpack() {
 mkdir -p $BUILDPACK_INSTALL_PATH
 
 download_buildpack https://github.com/ddollar/heroku-buildpack-multi.git         6e79094
-download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v129
+download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v134
 download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v64
 download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v32
 download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v12


### PR DESCRIPTION
This updates the ruby buildpack to the latest version: https://github.com/heroku/heroku-buildpack-ruby/blob/master/CHANGELOG.md#v134-312015

recently [bundler](https://github.com/bundler/bundler/blob/master/CHANGELOG.md#180-2015-02-10) 1.8 came out, this adds a deprecation warning when using multiple sources in `Gemfiles`

`v129` of the Heroku ruby buildpack uses bundler `1.6.3`, this does not support source blocks in `Gemfiles`.
Source blocks were added in bunder `1.7` (and heroku buildpack updated to bundler `1.7` in `v133` )

So, users who update to bundler `1.8` locally will get depreciation warnings if they use multiple sources. 
If that user fixes the deprecation warning they can't deploy the app to Deis bundler will fail.

A workaround is to use a discrete ENV `BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-ruby.git`