### PR TITLE
fix(registry): remove cache from install/start platform

### DIFF
--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -183,17 +183,13 @@ func startDefaultServices(b backend.Backend, wg *sync.WaitGroup, outchan chan st
 	b.Start([]string{"logspout"}, wg, outchan, errchan)
 	wg.Wait()
 
-	// optimization: start all remaining services in the background
-	// cache is a special case because it must start before registry
-	b.Start([]string{"cache"}, &_wg, _outchan, _errchan)
-	wg.Wait()
 	b.Start([]string{
 		"database", "registry@*", "controller", "builder",
 		"publisher", "router@*"},
 		&_wg, _outchan, _errchan)
 
 	outchan <- fmt.Sprintf("Control plane...")
-	b.Start([]string{"cache", "database", "registry@*", "controller"}, wg, outchan, errchan)
+	b.Start([]string{"database", "registry@*", "controller"}, wg, outchan, errchan)
 	wg.Wait()
 	b.Start([]string{"builder"}, wg, outchan, errchan)
 	wg.Wait()
@@ -436,7 +432,7 @@ func installDefaultServices(b backend.Backend, wg *sync.WaitGroup, outchan chan 
 	wg.Wait()
 
 	outchan <- fmt.Sprintf("Control plane...")
-	b.Create([]string{"cache", "database", "registry@1", "controller", "builder"}, wg, outchan, errchan)
+	b.Create([]string{"database", "registry@1", "controller", "builder"}, wg, outchan, errchan)
 	wg.Wait()
 
 	outchan <- fmt.Sprintf("Data plane...")


### PR DESCRIPTION
For existing clusters, they'll have to run the following to disable
the cache:

        $ deisctl stop cache
        $ deisctl uninstall cache
        $ deisctl restart registry@1

I opted away from removing the LRU cache -> registry links as we will still want those in the future once we figure out the root cause of this issue. This is just a stopgap until the root issue arises.

closes #3269