### PR TITLE
fix(store): abort build in case of any error

### DIFF
--- a/store/Makefile
+++ b/store/Makefile
@@ -19,7 +19,7 @@ build: check-docker
 	docker build -t deis/store-base:$(BUILD_TAG) base/
 	$(foreach I, $(TEMPLATE_IMAGES), \
 		sed -e "s/#FROM is generated dynamically by the Makefile/FROM deis\/store-base:${BUILD_TAG}/" $(I)/Dockerfile.template > $(I)/Dockerfile ; \
-		docker build -t deis/store-$(I):$(BUILD_TAG) $(I)/ ; \
+		docker build -t deis/store-$(I):$(BUILD_TAG) $(I)/ || exit 1; \
 		rm $(I)/Dockerfile ; \
 	)
 


### PR DESCRIPTION
From https://ci.deis.io/job/test-vagrant/2410/consoleFull#68219213cb8ad894-464c-4a3e-a6e5-fe9c952136da
```
...
tep 0 : FROM deis/store-base:jenkins-test-vagrant-2410
 ---> dbff0d3b9df6
Step 1 : ADD build.sh /tmp/build.sh
time="2015-03-11T22:04:59-06:00" level="info" msg="build.sh: no such file or directory" 
Sending build context to Docker daemon 6.656 kB
.....
```
that should throw an error and abort the build but it continues and it fails in the test phase.