### PR TITLE
fix(docker): wait for drive formatting to complete before mounting

### DIFF
--- a/contrib/gce/gce-user-data-template
+++ b/contrib/gce/gce-user-data-template
@@ -19,6 +19,7 @@ coreos:
         [Unit]
         Description=Mount ephemeral to /var/lib/docker
         Requires=format-ephemeral.service
+        After=format-ephemeral.service
         Before=docker.service
         [Mount]
         What=/dev/disk/by-id/scsi-0Google_PersistentDisk_coredocker


### PR DESCRIPTION
Undefined behavior occurs if format-ephemeral.service has not finished before var-lib-docker.mount is run.