### PR TITLE
feat(cloud-init): temporal fix for ntpd error and clock skew

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -171,3 +171,8 @@ write_files:
     content: |
       [Coredump]
       Storage=none
+  - path: /etc/systemd/system/ntpd.service.d/debug.conf
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=/usr/sbin/ntpd -g -n -f /var/lib/ntp/ntp.drift


### PR DESCRIPTION
replaces #3222 

References:
- https://github.com/coreos/bugs/issues/304
- https://github.com/coreos/coreos-overlay/pull/1145

**This should be temporal until the overlay PR is available in CoreOS stable**