### PR TITLE
fix(database): add requirements for wal-e build

### DIFF
--- a/database/build.sh
+++ b/database/build.sh
@@ -18,9 +18,12 @@ apt-get update && apt-get install -yq \
                                       daemontools \
                                       file \
                                       gcc \
+                                      g++ \
                                       git \
+                                      libffi-dev \
                                       libxml2-dev \
                                       libxslt1-dev \
+                                      libssl-dev \
                                       lzop \
                                       postgresql-9.3 \
                                       pv \
@@ -44,10 +47,10 @@ mkdir -p /etc/wal-e.d/env
 
 chown -R root:postgres /etc/wal-e.d
 
-# cleanup. indicate that python, libpq and libyanl are required packages.
-apt-mark unmarkauto python curl daemontools file libxml2-dev \
-  libxslt1-dev lzop postgresql-9.3 pv && \
-  apt-get remove -y --purge python-dev gcc cpp libpq-dev libyaml-dev git && \
+# cleanup. indicate python, curl, and others as required packages.
+apt-mark unmarkauto python curl daemontools file libffi-dev libxml2-dev \
+  libxslt1-dev libssl-dev lzop postgresql-9.3 pv && \
+  apt-get remove -y --purge gcc g++ git python-dev && \
   apt-get autoremove -y --purge && \
   apt-get clean -y && \
   rm -Rf /usr/share/man /usr/share/doc && \

--- a/database/build.sh
+++ b/database/build.sh
@@ -39,7 +39,7 @@ cd /tmp
 git clone https://github.com/wal-e/wal-e.git
 
 cd /tmp/wal-e
-git checkout c16e58a
+git checkout v0.8c2
 
 pip install .
 


### PR DESCRIPTION
Builds just began [failing](https://ci.deis.io/job/test-ec2/46/console) with `fatal error: ffi.h: No such file or directory` when building [wal-e](https://github.com/wal-e/wal-e) for deis/database. A python library required by wal-e probably changed its requirements; this fixes it. Also updates wal-e to the [most recent tag](https://github.com/wal-e/wal-e/releases/tag/v0.8c2), which differs from the version Deis was using by [two minor commits](https://github.com/wal-e/wal-e/compare/c16e58a...master).