### PR TITLE
feat(Vagrantfile): add forwarded ports configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,8 @@ $share_home = false
 $vm_gui = false
 $vm_memory = 2048
 $vm_cpus = 1
+$shared_folders = {}
+$forwarded_ports = {}
 
 # Attempt to apply the deprecated environment variable NUM_INSTANCES to
 # $num_instances while allowing config.rb to override it
@@ -111,6 +113,10 @@ Vagrant.configure("2") do |config|
         config.vm.network "forwarded_port", guest: 2375, host: ($expose_docker_tcp + i - 1), auto_correct: true
       end
 
+      $forwarded_ports.each do |guest, host|
+        config.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
+      end
+
       ["vmware_fusion", "vmware_workstation"].each do |vmware|
         config.vm.provider vmware do |v|
           v.gui = vm_gui
@@ -130,6 +136,9 @@ Vagrant.configure("2") do |config|
 
       # Uncomment below to enable NFS for sharing the host machine into the coreos-vagrant VM.
       #config.vm.synced_folder ".", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
+      $shared_folders.each_with_index do |(host_folder, guest_folder), index|
+        config.vm.synced_folder host_folder.to_s, guest_folder.to_s, id: "core-share%02d" % index, nfs: true, mount_options: ['nolock,vers=3,udp']
+      end
 
       if $share_home
         config.vm.synced_folder ENV['HOME'], ENV['HOME'], id: "home", :nfs => true, :mount_options => ['nolock,vers=3,udp']


### PR DESCRIPTION
From upstream coreos/coreos-vagrant#211. Allows adding VM guest => host [port forwarding rules](https://github.com/coreos/coreos-vagrant/blob/master/config.rb.sample#L68-L69) in `config.rb`. Credit to @sym3tri.