### PR TITLE
feat(contrib/ec2/gen-json.py): split private and public subnets

### DIFF
--- a/contrib/ec2/gen-json.py
+++ b/contrib/ec2/gen-json.py
@@ -89,6 +89,7 @@ template['Parameters']['ClusterSize']['Default'] = str(os.getenv('DEIS_NUM_INSTA
 
 VPC_ID = os.getenv('VPC_ID', None)
 VPC_SUBNETS = os.getenv('VPC_SUBNETS', None)
+VPC_PRIVATE_SUBNETS = os.getenv('VPC_PRIVATE_SUBNETS', VPC_SUBNETS)
 VPC_ZONES = os.getenv('VPC_ZONES', None)
 
 if VPC_ID and VPC_SUBNETS and VPC_ZONES and len(VPC_SUBNETS.split(',')) == len(VPC_ZONES.split(',')):
@@ -111,7 +112,7 @@ if VPC_ID and VPC_SUBNETS and VPC_ZONES and len(VPC_SUBNETS.split(',')) == len(V
 
   # update subnets and zones
   template['Resources']['CoreOSServerAutoScale']['Properties']['AvailabilityZones'] = VPC_ZONES.split(',')
-  template['Resources']['CoreOSServerAutoScale']['Properties']['VPCZoneIdentifier'] = VPC_SUBNETS.split(',')
+  template['Resources']['CoreOSServerAutoScale']['Properties']['VPCZoneIdentifier'] = VPC_PRIVATE_SUBNETS.split(',')
   template['Resources']['DeisWebELB']['Properties']['Subnets'] = VPC_SUBNETS.split(',')
 
 print json.dumps(template)

--- a/docs/installing_deis/aws.rst
+++ b/docs/installing_deis/aws.rst
@@ -140,6 +140,24 @@ For example, if your VPC has ID ``vpc-a26218bf`` and consists of the subnets ``s
     export VPC_SUBNETS=subnet-04d7f942,subnet-2b03ab7f
     export VPC_ZONES=us-east-1b,us-east-1c
 
+If you have set up private subnets in which you'd like to run your Deis hosts, and public subnets
+for the ELB, you should export the following environment variables instead:
+
+ - ``VPC_ID``
+ - ``VPC_SUBNETS``
+ - ``VPC_PRIVATE_SUBNETS``
+ - ``VPC_ZONES``
+
+For example, if you have a public subnet ``subnet-8cd457b3`` for the ELB and a private subnet
+``subnet-8cd457b0`` (both in ``us-east-1a``) you would export:
+
+.. code-block:: console
+
+    export VPC_ID=vpc-a26218bf
+    export VPC_SUBNETS=subnet-8cd457b3
+    export VPC_PRIVATE_SUBNETS=subnet-8cd457b0
+    export VPC_ZONES=us-east-1a
+
 
 Run the Provision Script
 ------------------------


### PR DESCRIPTION
When installing a Deis cluster in an existing VPC, it is currently only
possible to specify one set of (public) subnets in which both the
Deis EC2 instances and the ELB are placed. It is not possible to
enhance security by placing the Deis hosts in a private section of the
VPC, into subnets that have no direct connection to the Internet.

This change adds two new environment variables `VPC_EC2_SUBNETS` and
`VPC_ELB_SUBNETS` to help set up a Deis cluster in such a 'split' VPC
environment.