### PR TITLE
Use LimitNOFILE for etcd service

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -20,6 +20,18 @@ coreos:
   units:
   - name: etcd.service
     command: start
+    content: |
+      [Unit]
+      Description=etcd
+      [Service]
+      User=etcd
+      PermissionsStartOnly=true
+      Environment=ETCD_DATA_DIR=/var/lib/etcd
+      Environment=ETCD_NAME=%m
+      ExecStart=/usr/bin/etcd
+      Restart=always
+      RestartSec=10s
+      LimitNOFILE=40000
   - name: fleet.service
     command: start
   - name: stop-update-engine.service

--- a/tests/bin/test-setup.sh
+++ b/tests/bin/test-setup.sh
@@ -134,6 +134,14 @@ function dump_logs {
   get_logs deis-router@3 deis-store-volume deis-store-volume-3
   get_logs deis-store-gateway
 
+  # get debug-etcd logs
+  fleetctl -strict-host-key-checking=false ssh deis-router@1 journalctl --no-pager -u etcd \
+    > $FAILED_LOGS_DIR/debug-etcd-1.log
+  fleetctl -strict-host-key-checking=false ssh deis-router@2 journalctl --no-pager -u etcd \
+    > $FAILED_LOGS_DIR/debug-etcd-2.log
+  fleetctl -strict-host-key-checking=false ssh deis-router@3 journalctl --no-pager -u etcd \
+    > $FAILED_LOGS_DIR/debug-etcd-3.log
+
   # tarball logs
   BUCKET=jenkins-failure-logs
   FILENAME=deis-test-failure-$TIMESTAMP.tar.gz


### PR DESCRIPTION
Dumping etcd logs showed "too many open files" errors from etcd, which seems related to #1240 and https://github.com/coreos/coreos-overlay/commit/9d4e63bec512eb9ca97844e47afe93be8b2aea1a. This adapts the Azure user-data change from #3173 for the coreos/user-data file, which overrides the etcd service to increase file handles.

Also includes the commit from #3310 since I need to see etcd logs after this change.