### PR TITLE
Proposal: feat(controller): Add token based registration

### DIFF
--- a/docs/reference/api-v1.1.rst
+++ b/docs/reference/api-v1.1.rst
@@ -48,7 +48,8 @@ Optional Parameters:
 
     {
         "first_name": "test",
-        "last_name": "testerson"
+        "last_name": "testerson",
+        "token" : "abc123"
     }
 
 Example Response:
@@ -75,6 +76,82 @@ Example Response:
         "user_permissions": []
     }
 
+Create a Registration Token
+```````````````````````````
+
+.. note::
+
+    This command requires administrative privileges
+
+Example Request:
+
+.. code-block:: console
+
+    POST /v1/auth/register/tokens/ HTTP/1.1
+    Host: deis.example.com
+    Content-Type: application/json
+    Authorization: token abc123
+
+Example Response:
+
+.. code-block:: console
+
+    HTTP/1.1 200 OK
+    X_DEIS_API_VERSION: 1.1
+    X_DEIS_PLATFORM_VERSION: 1.4.1
+    Content-Type: application/json
+
+    {"token": "abc123"}
+
+Delete a Registration Token
+```````````````````````````
+
+.. note::
+
+    This command requires administrative privileges
+
+Example Request:
+
+.. code-block:: console
+
+    DELETE /v1/auth/register/tokens/abc123/ HTTP/1.1
+    Host: deis.example.com
+    Content-Type: application/json
+    Authorization: token abc123
+
+Example Response:
+
+.. code-block:: console
+
+    HTTP/1.1 204 NO CONTENT
+    X_DEIS_API_VERSION: 1.1
+    X_DEIS_PLATFORM_VERSION: 1.4.1
+    Content-Type: application/json
+
+Delete All Registration Tokens
+``````````````````````````````
+
+.. note::
+
+    This command requires administrative privileges
+
+Example Request:
+
+.. code-block:: console
+
+    DELETE /v1/auth/register/tokens/ HTTP/1.1
+    Host: deis.example.com
+    Content-Type: application/json
+    Authorization: token abc123
+
+Example Response:
+
+.. code-block:: console
+
+    HTTP/1.1 204 NO CONTENT
+    X_DEIS_API_VERSION: 1.1
+    X_DEIS_PLATFORM_VERSION: 1.4.1
+    Content-Type: application/json
 
 Log in
 ``````


### PR DESCRIPTION
Right now, deis has two options for user registration, enabled or disabled. I propose adding a third method as a middle ground, token based registration.

An admin can generate a one time use token that they can give to somebody to allow them to register a user. Ideally this token would be emailed to the prospective user, but for now the admin could copy and paste the token into a email or write it down. 

Enabling or disabling this feature would be done using `ectd` via the same methods used before to enable or disable auth.

Example usage:

``` console
$ deis register:token
abc124
$ deis register:token --delete abc123
$ deis register:token --delete-all
$ deis register http://deis.local3.deisapp.com
username: test
email: test@test.com
password: testing
password (confirm): testing
# Deis controller returns a token missing error
token: abc123
```

What do you guys think about this?