### PR TITLE
feat(Makefile): always restart dev registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ CLIENTS=client deisctl
 all: build run
 
 dev-registry: check-docker
-	@docker inspect registry >/dev/null && docker start registry || docker run -d -p 5000:5000 --name registry registry:0.9.1
+	@docker inspect registry >/dev/null && docker start registry || docker run --restart="always" -d -p 5000:5000 --name registry registry:0.9.1
 	@echo
 	@echo "To use local boot2docker registry for Deis development:"
 	@echo "    export DEV_REGISTRY=`boot2docker ip 2>/dev/null`:5000"


### PR DESCRIPTION
This helps when CI test nodes are rebooted in particular--the registry will start again when docker comes up. I've been using this flag locally and on test nodes for months.