### PR TITLE
chore(*): replace btrfs with overlayfs

### DIFF
--- a/builder/image/bin/boot
+++ b/builder/image/bin/boot
@@ -53,8 +53,15 @@ CONFD_PID=$!
 # remove any pre-existing docker.sock
 test -e /var/run/docker.sock && rm -f /var/run/docker.sock
 
+# force overlay if it's supported
+mkdir --parents --mode=0700 /
+fstype=$(findmnt --noheadings --output FSTYPE --target /)
+if [[ "$fstype" == "overlay" ]]; then
+	DRIVER_OVERRIDE="--storage-driver=overlay"
+fi
+
 # spawn a docker daemon to run builds
-docker -d --bip=172.19.42.1/16 --insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 --insecure-registry 100.64.0.0/10 &
+docker -d --bip=172.19.42.1/16 $DRIVER_OVERRIDE --insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 --insecure-registry 100.64.0.0/10 &
 DOCKER_PID=$!
 
 # wait for docker to start

--- a/contrib/azure/azure-user-data-template
+++ b/contrib/azure/azure-user-data-template
@@ -11,7 +11,7 @@ coreos:
         Type=oneshot
         RemainAfterExit=yes
         ExecStart=/usr/sbin/wipefs -f /dev/sdc
-        ExecStart=/usr/sbin/mkfs.btrfs -f /dev/sdc
+        ExecStart=/usr/sbin/mkfs.ext4 -i 4096 -b 4096 /dev/sdc
         ExecStart=/bin/touch /etc/azure-formatted
     - name: var-lib-docker.mount
       command: start
@@ -24,4 +24,4 @@ coreos:
         [Mount]
         What=/dev/sdc
         Where=/var/lib/docker
-        Type=btrfs
+        Type=ext4

--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -88,6 +88,14 @@ coreos:
       Type=oneshot
       ExecStartPre=/usr/sbin/modprobe nf_conntrack
       ExecStart=/bin/sh -c "sysctl -w net.netfilter.nf_conntrack_max=262144"
+  - name: load-overlay-module.service
+    content: |
+      [Unit]
+      Description=Load overlay module before docker start
+      Before=docker.service
+
+      [Service]
+      ExecStart=/bin/bash -c "modprobe overlay"
 write_files:
   - path: /etc/deis-release
     content: |

--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -89,13 +89,14 @@ coreos:
       ExecStartPre=/usr/sbin/modprobe nf_conntrack
       ExecStart=/bin/sh -c "sysctl -w net.netfilter.nf_conntrack_max=262144"
   - name: load-overlay-module.service
+    command: start
     content: |
       [Unit]
       Description=Load overlay module before docker start
       Before=docker.service
 
       [Service]
-      ExecStart=/bin/bash -c "modprobe overlay"
+      ExecStart=/bin/bash -c "lsmod | grep overlay || modprobe overlay"
 write_files:
   - path: /etc/deis-release
     content: |

--- a/contrib/ec2/gen-json.py
+++ b/contrib/ec2/gen-json.py
@@ -14,7 +14,7 @@ FORMAT_EPHEMERAL_VOLUME = '''
   Type=oneshot
   RemainAfterExit=yes
   ExecStart=/usr/sbin/wipefs -f /dev/xvdb
-  ExecStart=/usr/sbin/mkfs.ext4 /dev/xvdb
+  ExecStart=/usr/sbin/mkfs.ext4 -i 4096 -b 4096 /dev/xvdb
   ExecStart=/bin/touch /etc/ephemeral-volume-formatted
 '''
 MOUNT_EPHEMERAL_VOLUME = '''
@@ -47,7 +47,7 @@ FORMAT_DOCKER_VOLUME = '''
   Type=oneshot
   RemainAfterExit=yes
   ExecStart=/usr/sbin/wipefs -f /dev/xvdf
-  ExecStart=/usr/sbin/mkfs.btrfs -f /dev/xvdf
+  ExecStart=/usr/sbin/mkfs.ext4 -i 4096 -b 4096 /dev/xvdf
   ExecStart=/bin/touch /etc/docker-volume-formatted
 '''
 MOUNT_DOCKER_VOLUME = '''
@@ -59,7 +59,7 @@ MOUNT_DOCKER_VOLUME = '''
   [Mount]
   What=/dev/xvdf
   Where=/var/lib/docker
-  Type=btrfs
+  Type=ext4
 '''
 
 new_units = [

--- a/contrib/gce/gce-user-data-template
+++ b/contrib/gce/gce-user-data-template
@@ -11,7 +11,7 @@ coreos:
         Type=oneshot
         RemainAfterExit=yes
         ExecStart=/usr/sbin/wipefs -f /dev/disk/by-id/scsi-0Google_PersistentDisk_coredocker
-        ExecStart=/usr/sbin/mkfs.btrfs -f /dev/disk/by-id/scsi-0Google_PersistentDisk_coredocker
+        ExecStart=/usr/sbin/mkfs.ext4 -i 4096 -b 4096 /dev/disk/by-id/scsi-0Google_PersistentDisk_coredocker
         ExecStart=/bin/touch /etc/gce-formatted
     - name: var-lib-docker.mount
       command: start
@@ -24,4 +24,4 @@ coreos:
         [Mount]
         What=/dev/disk/by-id/scsi-0Google_PersistentDisk_coredocker
         Where=/var/lib/docker
-        Type=btrfs
+        Type=ext4


### PR DESCRIPTION
This includes the commits from #3316.

We switch from btrfs to ext4 to support overlayfs in Docker. Note that we also format the device with a particular number of inodes. This is what CoreOS does to the root volume to prepare it to run Docker, and since we're running Docker with a separate volume, we must prepare it in the same way. 

Since we're no longer using devmapper in the Docker-in-Docker builder component, this PR also:
closes #3294 
refs #3317

~~TODO: Write wrapper script in builder's /bin/boot to override overlayfs if it's supported.~~

/cc @marineam 