### PR TITLE
Random test fixes

### DIFF
--- a/controller/deis/settings.py
+++ b/controller/deis/settings.py
@@ -4,6 +4,8 @@ Django settings for the Deis project.
 
 from __future__ import unicode_literals
 import os.path
+import random
+import string
 import sys
 import tempfile
 
@@ -303,6 +305,9 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.' + os.environ.get('DATABASE_ENGINE', 'postgresql_psycopg2'),
         'NAME': os.environ.get('DATABASE_NAME', 'deis'),
+        # randomize test database name so we can run multiple unit tests simultaneously
+        'TEST_NAME': "unittest-{}".format(''.join(
+            random.choice(string.ascii_letters + string.digits) for _ in range(8)))
     }
 }
 

--- a/tests/bin/test-integration-ec2.sh
+++ b/tests/bin/test-integration-ec2.sh
@@ -5,7 +5,7 @@
 #
 
 # fail on any command exiting non-zero
-set -e
+set -eo pipefail
 
 # absolute path to current directory
 export THIS_DIR=$(cd $(dirname $0); pwd)
@@ -68,8 +68,7 @@ fi
 
 make discovery-url
 # add random characters after STACK_TAG to avoid collisions
-# TODO: somehow this breaks "set -eo pipefail"
-STACK_TAG=${STACK_TAG:-test}-$(base64 /dev/urandom | tr -dc a-z0-9 | head -c 6)
+STACK_TAG=${STACK_TAG:-test}-$(openssl rand -hex 4)
 STACK_NAME=deis-$STACK_TAG
 echo "Creating CloudFormation stack $STACK_NAME"
 $DEIS_ROOT/contrib/ec2/provision-ec2-cluster.sh $STACK_NAME


### PR DESCRIPTION
Multiple simultaneous runs of `make -C controller/ test-unit` have collided on our CI server, so this uses Django's [`TEST_NAME`](https://docs.djangoproject.com/en/1.6/topics/testing/overview/#the-test-database) setting to add a psuedo-random suffix to the PostgreSQL database name. Also changes the ec2 test script to use `openssl rand` instead of `/dev/urandom`, which allows us to `set -eo pipefail` again.