### PR TITLE
feat(client): add flags for automating auth:cancel

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -745,17 +745,29 @@ class DeisClient(object):
         """
         Cancels and removes the current account.
 
-        Usage: deis auth:cancel
+        Usage: deis auth:cancel [options]
+
+        Options:
+          --username=<username>
+            provide a username for the account.
+          --password=<password>
+            provide a password for the account.
+          --yes
+            force "yes" when prompted.
         """
         controller = self._settings.get('controller')
         if not controller:
             self._logger.error('Not logged in to a Deis controller')
             sys.exit(1)
         self._logger.info('Please log in again in order to cancel this account')
-        username = self.auth_login({'<controller>': controller})
+        args['<controller>'] = controller
+        username = self.auth_login(args)
         if username:
-            confirm = raw_input("Cancel account \"{}\" at {}? (y/N) ".format(username, controller))
-            if confirm == 'y':
+            confirm = args.get('--yes')
+            if not confirm:
+                confirm = raw_input(
+                    "Cancel account \"{}\" at {}? (y/N) ".format(username, controller))
+            if confirm in ['y', True]:
                 self._dispatch('delete', '/v1/auth/cancel')
                 self._settings['controller'] = None
                 self._settings['token'] = None

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -12,6 +12,7 @@ var (
 	authLoginCmd    = "auth:login http://deis.{{.Domain}} --username={{.UserName}} --password={{.Password}}"
 	authLogoutCmd   = "auth:logout"
 	authRegisterCmd = "auth:register http://deis.{{.Domain}} --username={{.UserName}} --password={{.Password}} --email={{.Email}}"
+	authCancelCmd   = "auth:cancel --username={{.UserName}} --password={{.Password}} --yes"
 )
 
 func TestAuth(t *testing.T) {
@@ -31,7 +32,7 @@ func authSetup(t *testing.T) *utils.DeisTestConfig {
 }
 
 func authCancel(t *testing.T, params *utils.DeisTestConfig) {
-	utils.AuthCancel(t, params)
+	utils.Execute(t, authCancelCmd, params, false, "Account cancelled")
 }
 
 func authLoginTest(t *testing.T, params *utils.DeisTestConfig) {

--- a/tests/utils/itutils.go
+++ b/tests/utils/itutils.go
@@ -143,37 +143,6 @@ func CurlWithFail(t *testing.T, params *DeisTestConfig, failFlag bool, expect st
 	}
 }
 
-// AuthCancel tests whether `deis auth:cancel` destroys a user's account.
-func AuthCancel(t *testing.T, params *DeisTestConfig) {
-	fmt.Println("deis auth:cancel")
-	child, err := gexpect.Spawn(Deis + " auth:cancel")
-	if err != nil {
-		t.Fatalf("command not started\n%v", err)
-	}
-	fmt.Println("username:")
-	err = child.Expect("username:")
-	if err != nil {
-		t.Fatalf("expect username failed\n%v", err)
-	}
-	child.SendLine(params.UserName)
-	fmt.Print("password:")
-	err = child.Expect("password:")
-	if err != nil {
-		t.Fatalf("expect password failed\n%v", err)
-	}
-	child.SendLine(params.Password)
-	err = child.ExpectRegex("(y/N)")
-	if err != nil {
-		t.Fatalf("expect cancel \n%v", err)
-	}
-	child.SendLine("y")
-	err = child.Expect("Account cancelled")
-	if err != nil {
-		t.Fatalf("command executiuon failed\n%v", err)
-	}
-	child.Close()
-}
-
 // AuthPasswd tests whether `deis auth:passwd` updates a user's password.
 func AuthPasswd(t *testing.T, params *DeisTestConfig, password string) {
 	fmt.Println("deis auth:passwd")


### PR DESCRIPTION
this fixes up those random `/dev/ptmx` errors we're finding in ci.deis.io every so often when piping manual I/O to `auth:cancel`.