### PR TITLE
fix(controller): remove dead web link to logout page

### DIFF
--- a/controller/web/templates/web/account.html
+++ b/controller/web/templates/web/account.html
@@ -19,15 +19,10 @@
       {{ user.email }}
     </div>
   </div>
-  <form method="post" action="{% url 'rest_framework:logout' %}">
-    {% csrf_token %}
-    {% if redirect_field_value %}
-    <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
-    {% endif %}
-    <button type="submit" class="btn btn-link">{% trans 'Log Out' %}</button>
+  <div class="row-fluid">
     {% if user.is_staff %}
     <a href="{% url 'admin:index' %}" class="btn btn-link">Admin</a>
     {% endif %}
-  </form>
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
deis-controller has a (deprecated, not unmaintained) set of web pages; this fixes an error trying to render the `/account/` page.

Closes #3321.