### PR TITLE
fix(azure): add support for Azure affinity groups

### DIFF
--- a/contrib/azure/azure-coreos-cluster
+++ b/contrib/azure/azure-coreos-cluster
@@ -30,7 +30,9 @@ parser.add_argument('--vm-name-prefix', default='coreos',
 parser.add_argument('--availability-set', default='coreos-as',
                    help='optional, name of availability set for cluster [coreos-as]')
 parser.add_argument('--location', default='West US',
-                   help='optional, [West US]')
+                   help='optional - overriden by affinity-group, [West US]')
+parser.add_argument('--affinity-group', default='',
+                   help='optional, overrides location if specified')
 parser.add_argument('--ssh', default=22001, type=int,
                    help='optional, starts with 22001 and +1 for each machine in cluster')
 parser.add_argument('--coreos-image', default='2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-607.0.0',
@@ -176,8 +178,12 @@ sms = ServiceManagementService(args.subscription, args.azure_cert)
 try:
   print 'Creating the hosted service...',
   sys.stdout.flush()
-  sms.create_hosted_service(
-      args.cloud_service_name, label=args.cloud_service_name, location=args.location)
+  if args.affinity_group:
+    sms.create_hosted_service(
+        args.cloud_service_name, label=args.cloud_service_name, affinity_group=args.affinity_group)
+  else:
+    sms.create_hosted_service(
+        args.cloud_service_name, label=args.cloud_service_name, location=args.location)
   print('Successfully created hosted service ' + args.cloud_service_name)
   sys.stdout.flush()
   time.sleep(2)

--- a/docs/installing_deis/azure.rst
+++ b/docs/installing_deis/azure.rst
@@ -69,7 +69,7 @@ With the management certificate and cloud config in place, we are ready to creat
 
 * Create a container called ``vhds`` within a storage account in the same region as your cluster using the Azure portal. Note the URL of the container for the cluster creation script below.
 * Choose a cloud service name for your Deis cluster for the script below. The script will automatically create this cloud service for you.
-* Choose an Azure `region`_ to use. Supply it in quotes with the ``--location`` parameter. The default is "West US".
+* Create an `affinity group`_ if you already don't have one. Supply it in quotes with the ``--affinity-group`` parameter. Although *using an affinity group is not mandatory*, it is **highly recommended** since it tells the Azure fabric to place all VMs in the cluster physically close to each other, reducing inter-node latency by a great deal. If you don't want ot use affinity groups, specify a `region`_ for Azure to use with a ``--location`` parameter. The default is ``"West US"``. If you specify both parameters, ``location`` will be ignored. Please note that the script *will not* create an affinity group by itself; it expects the affinity group exists.
 
 With that, let's run the azure-coreos-cluster script which will create the CoreOS cluster. Fill in the bracketed values with the values for your deployment you created above.
 
@@ -79,7 +79,7 @@ With that, let's run the azure-coreos-cluster script which will create the CoreO
          --subscription [subscription id]
          --azure-cert azure-cert.pem
          --num-nodes 3
-         --location "[location]"
+         --affinity-group [affinity group name]
          --vm-size Large
          --pip
          --deis
@@ -112,3 +112,4 @@ start installing the platform.
 .. _`etcd`: https://github.com/coreos/etcd
 .. _`etcd disaster recovery`: https://github.com/coreos/etcd/blob/master/Documentation/admin_guide.md#disaster-recovery
 .. _`region`: http://azure.microsoft.com/en-us/regions/
+.. _`affinity group`: https://msdn.microsoft.com/en-gb/library/azure/jj156085.aspx


### PR DESCRIPTION
**NOTE**: this replaces #3173 since I was too lazy to do a full rebase

This PR adds two fixes that will make a 5-vm Deis cluster stable on Windows Azure:

#### Enhancements
1. Support for specifying `affinity-group` as a valid argument to the `azure-coreos-cluster` script.
  * Overall platform startup speed reduced by about 15 minutes (ballpark) for a 5-vm cluster on Azure.
  * Overall platorm stability and inter-fleet latency reduced to an average of 59ms. [See full cluster stats](https://gist.github.com/gvilarino/aa20c427b5e08b959083)
2. Specific settings for `etcd.service` that will prevent the cluster from dying because of reaching the file-open limit
  * Cluster becomes stable and stops throwing "too many open files" error anymore (possibly related to #1240).

#### TODO
* Add setting an `affinity-group` option as a **very recommended** option in the official Deis docs for an Azure setup.

#### Acknowlegements
Enormous thanks to @aledbf , @sedouard and @carmstrong for helping me with the cluster setup and debugging my situation.