### PR TITLE
chore(controller): update Django to 1.6.11 security release

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -3,7 +3,7 @@
 # NOTE: For testing on Mac OS X Mavericks, use the following to work around a clang issue:
 # ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future pip install [args]
 #
-Django==1.6.10
+Django==1.6.11
 django-cors-headers==1.0.0
 # required for south migrations
 django-fsm==2.2.0

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -7,7 +7,7 @@
 # NOTE: For testing on Mac OS X Mavericks, use the following to work around a clang issue:
 # ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future pip install [args]
 #
-Django==1.6.10
+Django==1.6.11
 django-cors-headers==1.0.0
 # required for south migrations
 django-fsm==2.2.0


### PR DESCRIPTION
See https://www.djangoproject.com/weblog/2015/mar/18/security-releases/

It looks unlikely that Deis' controller code was affected by either bug, but we keep up with Django security releases anyway.