### PR TITLE
feat(controller): print stack trace when worker is killed

### DIFF
--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -73,14 +73,14 @@ sudo -E -u deis ./manage.py syncdb --migrate --noinput
 # spawn a gunicorn server in the background
 sudo -E -u deis gunicorn -c deis/gconf.py deis.wsgi &
 
-# smart shutdown on SIGINT and SIGTERM
+# smart shutdown on SIGTERM (SIGINT is handled by gunicorn)
 function on_exit() {
 	GUNICORN_PID=$(cat /tmp/gunicorn.pid)
 	kill -TERM $GUNICORN_PID 2>/dev/null
 	wait $GUNICORN_PID 2>/dev/null
 	exit 0
 }
-trap on_exit INT TERM
+trap on_exit TERM
 
 # spawn confd in the background to update services based on etcd changes
 confd -node $ETCD -config-file /app/confd.toml &

--- a/controller/deis/gconf.py
+++ b/controller/deis/gconf.py
@@ -7,3 +7,17 @@ loglevel = 'info'
 errorlog = '-'
 accesslog = '-'
 access_log_format = '%(h)s "%(r)s" %(s)s %(b)s "%(a)s"'
+
+
+def worker_int(worker):
+    """Print a stack trace when a worker receives a SIGINT or SIGQUIT signal."""
+    worker.log.warning('worker terminated')
+    import traceback
+    traceback.print_stack()
+
+
+def worker_abort(worker):
+    """Print a stack trace when a worker receives a SIGABRT signal, generally on timeout."""
+    worker.log.warning('worker aborted')
+    import traceback
+    traceback.print_stack()


### PR DESCRIPTION
When a gunicorn worker process inside the controller times out, the only thing that shows up in `deisctl journal controller` is:
```
Mar 20 18:22:07 deis-03 sh[2692]: [2015-03-20 18:22:07 +0000] [254] [CRITICAL] WORKER TIMEOUT (pid:260)
```
This uses gunicorn's [server hooks](http://docs.gunicorn.org/en/latest/settings.html#server-hooks) to add python stack trace output when a worker times out or is killed, for help in debugging:
```
Mar 20 18:22:07 deis-03 sh[2692]: [2015-03-20 18:22:07 +0000] [254] [CRITICAL] WORKER TIMEOUT (pid:260)
Mar 20 18:22:07 deis-03 sh[2692]: [2015-03-20 18:22:07 +0000] [260] [WARNING] worker aborted
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/bin/gunicorn", line 11, in <module>
Mar 20 18:22:07 deis-03 sh[2692]: sys.exit(run())
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/gunicorn/app/wsgiapp.py", line 74, in run
Mar 20 18:22:07 deis-03 sh[2692]: WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]").run()
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/gunicorn/app/base.py", line 189, in run
Mar 20 18:22:07 deis-03 sh[2692]: super(Application, self).run()
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/gunicorn/app/base.py", line 72, in run
Mar 20 18:22:07 deis-03 sh[2692]: Arbiter(self).run()
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/gunicorn/arbiter.py", line 174, in run
Mar 20 18:22:07 deis-03 sh[2692]: self.manage_workers()
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/gunicorn/arbiter.py", line 477, in manage_workers
Mar 20 18:22:07 deis-03 sh[2692]: self.spawn_workers()
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/gunicorn/arbiter.py", line 540, in spawn_workers
Mar 20 18:22:07 deis-03 sh[2692]: self.spawn_worker()
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/gunicorn/arbiter.py", line 507, in spawn_worker
Mar 20 18:22:07 deis-03 sh[2692]: worker.init_process()
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/base.py", line 124, in init_process
Mar 20 18:22:07 deis-03 sh[2692]: self.run()
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/sync.py", line 119, in run
Mar 20 18:22:07 deis-03 sh[2692]: self.run_for_one(timeout)
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/sync.py", line 66, in run_for_one
Mar 20 18:22:07 deis-03 sh[2692]: self.accept(listener)
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/sync.py", line 30, in accept
Mar 20 18:22:07 deis-03 sh[2692]: self.handle(listener, client, addr)
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/sync.py", line 130, in handle
Mar 20 18:22:07 deis-03 sh[2692]: self.handle_request(listener, req, client, addr)
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/sync.py", line 171, in handle_request
Mar 20 18:22:07 deis-03 sh[2692]: respiter = self.wsgi(environ, resp.start_response)
Mar 20 18:22:07 deis-03 sh[2692]: File "/app/deis/wsgi.py", line 35, in __call__
Mar 20 18:22:07 deis-03 sh[2692]: return self.django_handler(environ, start_response)
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/wsgi.py", line 206, in __call__
Mar 20 18:22:07 deis-03 sh[2692]: response = self.get_response(request)
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 112, in get_response
Mar 20 18:22:07 deis-03 sh[2692]: response = wrapped_callback(request, *callback_args, **callback_kwargs)
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/django/views/decorators/csrf.py", line 57, in wrapped_view
Mar 20 18:22:07 deis-03 sh[2692]: return view_func(*args, **kwargs)
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/rest_framework/viewsets.py", line 85, in view
Mar 20 18:22:07 deis-03 sh[2692]: return self.dispatch(request, *args, **kwargs)
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/rest_framework/views.py", line 404, in dispatch
Mar 20 18:22:07 deis-03 sh[2692]: response = handler(request, *args, **kwargs)
Mar 20 18:22:07 deis-03 sh[2692]: File "/app/api/views.py", line 163, in run
Mar 20 18:22:07 deis-03 sh[2692]: output_and_rc = app.run(self.request.user, request.data['command'])
Mar 20 18:22:07 deis-03 sh[2692]: File "/app/api/models.py", line 371, in run
Mar 20 18:22:07 deis-03 sh[2692]: return c.run(escaped_command)
Mar 20 18:22:07 deis-03 sh[2692]: File "/app/api/models.py", line 505, in run
Mar 20 18:22:07 deis-03 sh[2692]: rc, output = self._scheduler.run(job_id, image, entrypoint, command)
Mar 20 18:22:07 deis-03 sh[2692]: File "/app/scheduler/fleet.py", line 306, in run
Mar 20 18:22:07 deis-03 sh[2692]: time.sleep(1)
Mar 20 18:22:07 deis-03 sh[2692]: File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/base.py", line 158, in handle_abort
Mar 20 18:22:07 deis-03 sh[2692]: self.cfg.worker_abort(self)
Mar 20 18:22:07 deis-03 sh[2692]: File "deis/gconf.py", line 19, in worker_abort
Mar 20 18:22:07 deis-03 sh[2692]: import traceback; traceback.print_stack()
```
