### PR TITLE
docs(testing): note that some containers don't rebuild automatically

### DIFF
--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -56,6 +56,14 @@ continuous deployment, start one locally:
     To use local boot2docker registry for Deis development:
         export DEV_REGISTRY=192.168.59.103:5000
 
+.. important::
+
+    The functional tests also use several mock or example containers:
+    **deis/test-etcd**, **deis/test-postgresql**, and **deis/mock-store**.
+    These are referenced by the ``:latest`` tag, so in the rare case that one
+    of these test containers needs to change, ``docker rmi`` its image and
+    the tests will pull it from Docker Hub or rebuild it.
+
 
 Run the Tests
 -------------

--- a/tests/fixtures/mock-store/README.md
+++ b/tests/fixtures/mock-store/README.md
@@ -27,6 +27,9 @@ offering a S3-compatible bucket APIs using the local filesystem as storage.
 Please consult the [Makefile](Makefile) for current instructions on how to build, test, push,
 install, and start **deis/mock-store**.
 
+Note that changes to **deis/mock-store** will *not* be built automatically by the test suite.
+Run `make mock-store` from the tests/ directory to update the Docker image used by tests.
+
 ## License
 
 © 2015 OpDemand LLC


### PR DESCRIPTION
These test containers change so rarely, it didn't seem worth the machinery necessary to rebuild them. This documents that compromise.

Closes #3151.