### PR TITLE
feat(client): Add multiple profile support to the client

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -172,7 +172,8 @@ class Settings(dict):
         # Create the $HOME/.deis dir if it doesn't exist
         if not os.path.isdir(path):
             os.mkdir(path, 0700)
-        self._path = os.path.join(path, 'client.json')
+        filename = '%s.json' % os.environ.get('DEIS_PROFILE', 'client')
+        self._path = os.path.join(path, filename)
         if not os.path.exists(self._path):
             settings = {}
             with open(self._path, 'w') as f:

--- a/docs/using_deis/install-client.rst
+++ b/docs/using_deis/install-client.rst
@@ -78,3 +78,21 @@ To get help on subcommands, use ``deis help [subcommand]``:
 
 .. _pip: http://www.pip-installer.org/en/latest/installing.html
 .. _Python: https://www.python.org/
+
+Multiple Profile Support
+------------------------
+
+The Deis client supports running commands against multiple installations
+and/or accounts by setting the ``$DEIS_PROFILE`` environment variable
+before logging in and running any subsequent commands. If not set, all
+commands will default to the ``client`` profile which maps to
+a configuration file at ``$HOME/.deis/client.json``. Here's an example
+of running the ps command against an app with the same name from two profiles:
+
+
+.. code-block:: console
+
+    $ DEIS_PROFILE=production deis ps -a helloworld
+    $ DEIS_PROFILE=staging deis ps -a helloworld
+    
+


### PR DESCRIPTION
Profile names map to deis client configuration file. The profile
name is picked up from the DEIS_PROFILE environment variable if it exists.
The default is 'client' which points to 'client.json'. To run deis
client under a different profile use: DEIS_PROFILE=dev deis