### PR TITLE
feat(client): add deis config:push

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -984,6 +984,7 @@ class DeisClient(object):
         config:set         set environment variables for an app
         config:unset       unset environment variables for an app
         config:pull        extract environment variables to .env
+        config:push        set environment variables from .env
 
         Use `deis help [command]` to learn more.
         """
@@ -1183,6 +1184,30 @@ class DeisClient(object):
                 sys.exit(1)
         else:
             raise ResponseError(response)
+
+    def config_push(self, args):
+        """
+        Sets environment variables for an application.
+
+        Your environment is read from a file named .env. This file can be
+        read by foreman to load the local environment for your app.
+
+        Usage: deis config:push [options]
+
+        Options:
+          -a --app=<app>
+            the uniquely identifiable name for the application.
+        """
+        app = args.get('--app')
+        if not app:
+            app = self._session.app
+        # read from .env
+        try:
+            with open('.env', 'r') as f:
+                self._config_set(app, dictify([line.strip() for line in f]))
+        except IOError:
+            self._logger.error('could not read from local env')
+            sys.exit(1)
 
     def domains(self, args):
         """

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -3,6 +3,7 @@
 package tests
 
 import (
+	"io/ioutil"
 	"testing"
 
 	"github.com/deis/deis/tests/utils"
@@ -20,6 +21,7 @@ var (
 func TestConfig(t *testing.T) {
 	params := configSetup(t)
 	configSetTest(t, params)
+	configPushTest(t, params)
 	configListTest(t, params, false)
 	appsOpenTest(t, params)
 	configUnsetTest(t, params)
@@ -69,8 +71,23 @@ func configSetTest(t *testing.T, params *utils.DeisTestConfig) {
 	utils.CheckList(t, appsInfoCmd, params, "(v6)", false)
 }
 
+func configPushTest(t *testing.T, params *utils.DeisTestConfig) {
+	if err := utils.Chdir(params.ExampleApp); err != nil {
+		t.Fatal(err)
+	}
+	// create a .env in the project root
+	if err := ioutil.WriteFile(".env", []byte("POWERED_BY=Deis"), 0664); err != nil {
+		t.Fatal(err)
+	}
+	utils.Execute(t, "config:push --app {{.AppName}}", params, false, "Deis")
+	utils.CheckList(t, appsInfoCmd, params, "(v7)", false)
+	if err := utils.Chdir(".."); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func configUnsetTest(t *testing.T, params *utils.DeisTestConfig) {
 	utils.Execute(t, configUnsetCmd, params, false, "")
-	utils.CheckList(t, appsInfoCmd, params, "(v7)", false)
+	utils.CheckList(t, appsInfoCmd, params, "(v8)", false)
 	utils.CheckList(t, "run env --app={{.AppName}}", params, "FOO", true)
 }


### PR DESCRIPTION
This new feature reads from a local .env and pushes the environment variables to Deis.

closes #1532