### PR TITLE
fix(tests): replace hard-coded test domain in ec2 script

### DIFF
--- a/tests/bin/test-integration-ec2.sh
+++ b/tests/bin/test-integration-ec2.sh
@@ -109,7 +109,7 @@ make dev-release
 
 log_phase "Provisioning Deis"
 
-export DEIS_TEST_DOMAIN=$STACK_TAG.deis.works
+export DEIS_TEST_DOMAIN=$STACK_TAG.$DEIS_TEST_DOMAIN
 
 # configure platform settings
 deisctl config platform set domain=$DEIS_TEST_DOMAIN


### PR DESCRIPTION
`test-integration-ec2.sh` generates a subdomain in route53 for testing, but failed to make the root domain configurable.

```console
$ DEIS_TEST_DOMAIN=deis.rocks ./tests/bin/test-integration-ec2.sh
```