### PR TITLE
feat(controller): Allow adminOnly registration

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -756,8 +756,14 @@ Make sure that the Controller URI is correct and the server is running.
             email = raw_input('email: ')
         url = urlparse.urljoin(controller, '/v1/auth/register')
         payload = {'username': username, 'password': password, 'email': email}
+        headers = {}
+
+        token = self._settings.get('token')
+        if token:
+            headers.update({'Authorization': 'token {}'.format(token)})
+
         response = self._session.post(url, data=payload, allow_redirects=False,
-                                      verify=ssl_verify)
+                                      verify=ssl_verify, headers=headers)
         if response.status_code == requests.codes.created:
             self._settings['controller'] = controller
             self._settings.save()

--- a/controller/api/authentication.py
+++ b/controller/api/authentication.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import AnonymousUser
 from rest_framework import authentication
+from rest_framework.authentication import TokenAuthentication
 
 
 class AnonymousAuthentication(authentication.BaseAuthentication):
@@ -9,3 +10,15 @@ class AnonymousAuthentication(authentication.BaseAuthentication):
         Authenticate the request for anyone!
         """
         return AnonymousUser(), None
+
+
+class AnonymousOrAuthenticatedAuthentication(authentication.BaseAuthentication):
+
+    def authenticate(self, request):
+        """
+        Authenticate the request for anyone or if a valid token is provided, a user.
+        """
+        try:
+            return TokenAuthentication.authenticate(TokenAuthentication(), request)
+        except:
+            return AnonymousUser(), None

--- a/controller/api/permissions.py
+++ b/controller/api/permissions.py
@@ -97,7 +97,22 @@ class HasRegistrationAuth(permissions.BasePermission):
     Checks to see if registration is enabled
     """
     def has_permission(self, request, view):
-        return settings.REGISTRATION_ENABLED
+        """
+        If settings.REGISTRATION_MODE does not exist, such as during a test, return True
+        Return `True` if permission is granted, `False` otherwise.
+        """
+        try:
+            if settings.REGISTRATION_MODE == 'disabled':
+                return False
+            if settings.REGISTRATION_MODE == 'enabled':
+                return True
+            elif settings.REGISTRATION_MODE == 'admin_only':
+                return request.user.is_superuser
+            else:
+                raise Exception("{} is not a valid registation mode"
+                                .format(settings.REGISTRATION_MODE))
+        except AttributeError:
+            return True
 
 
 class HasBuilderAuth(permissions.BasePermission):

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -20,8 +20,8 @@ from api import authentication, models, permissions, serializers, viewsets
 class UserRegistrationViewSet(GenericViewSet,
                               mixins.CreateModelMixin):
     """ViewSet to handle registering new users. The logic is in the serializer."""
-    authentication_classes = [authentication.AnonymousAuthentication]
-    permission_classes = [permissions.IsAnonymous, permissions.HasRegistrationAuth]
+    authentication_classes = [authentication.AnonymousOrAuthenticatedAuthentication]
+    permission_classes = [permissions.HasRegistrationAuth]
     serializer_class = serializers.UserSerializer
 
 

--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -47,7 +47,7 @@ function etcd_safe_mkdir {
 etcd_set_default protocol ${DEIS_PROTOCOL:-http}
 etcd_set_default secretKey ${DEIS_SECRET_KEY:-`openssl rand -base64 64 | tr -d '\n'`}
 etcd_set_default builderKey ${DEIS_BUILDER_KEY:-`openssl rand -base64 64 | tr -d '\n'`}
-etcd_set_default registrationEnabled 1
+etcd_set_default registrationMode "enabled"
 etcd_set_default webEnabled 0
 etcd_set_default unitHostname default
 

--- a/controller/migrations/data/0002.sh
+++ b/controller/migrations/data/0002.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+ETCD_PORT=${ETCD_PORT:-4001}
+ETCD="$HOST:$ETCD_PORT"
+ETCDCTL="etcdctl -C $ETCD"
+
+# April 8, 2015: If registrationEnabled key exists, migrate it to registrationMode and delete it.
+
+if [[ "$($ETCDCTL get /deis/migrations/data/0002 2> /dev/null)" != "done" ]];
+then
+    if $ETCDCTL ls /deis/controller | grep -q '/deis/controller/registrationEnabled'
+    then
+        if [[ "$($ETCDCTL get /deis/controller/registrationEnabled 2> /dev/null)" == "false" ]]
+        then
+        $ETCDCTL set /deis/controller/registrationMode "disabled"
+        else
+          $ETCDCTL set /deis/controller/registrationMode "enabled"
+        fi
+
+        $ETCDCTL rm /deis/controller/registrationEnabled
+    else
+        echo "registrationEnabled key doesn't exist, skipping migration"
+    fi
+
+    $ETCDCTL set /deis/migrations/data/0002 "done"
+fi

--- a/controller/templates/confd_settings.py
+++ b/controller/templates/confd_settings.py
@@ -37,8 +37,8 @@ DATABASES = {
 # move log directory out of /app/deis
 DEIS_LOG_DIR = '/data/logs'
 
-{{ if exists "/deis/controller/registrationEnabled" }}
-REGISTRATION_ENABLED = bool({{ getv "/deis/controller/registrationEnabled" }})
+{{ if exists "/deis/controller/registrationMode" }}
+REGISTRATION_MODE = '{{ getv "/deis/controller/registrationMode" }}'
 {{ end }}
 
 {{ if exists "/deis/controller/webEnabled" }}

--- a/docs/customizing_deis/controller_settings.rst
+++ b/docs/customizing_deis/controller_settings.rst
@@ -39,7 +39,7 @@ The following etcd keys are used by the controller component.
 ====================================      ======================================================
 setting                                   description
 ====================================      ======================================================
-/deis/controller/registrationEnabled      enable registration for new Deis users (default: true)
+/deis/controller/registrationMode         set registration to "enabled", "disabled", or "admin_only" (default: "enabled")
 /deis/controller/webEnabled               enable controller web UI (default: false)
 /deis/cache/host                          host of the cache component (set by cache)
 /deis/cache/port                          port of the cache component (set by cache)
@@ -77,9 +77,9 @@ Deis. Specifically, ensure that it sets and reads appropriate etcd keys.
 
 Unit hostname
 -------------
-Per default, Docker automatically generates a hostname for your application unit, such as: 
-``5c149b397cd6``. Auto generated hostnames is not always preferred. For instance, 
-New Relic would classify each Docker container as an unique server since they use hostname 
+Per default, Docker automatically generates a hostname for your application unit, such as:
+``5c149b397cd6``. Auto generated hostnames is not always preferred. For instance,
+New Relic would classify each Docker container as an unique server since they use hostname
 for grouping applications running on the same server together.
 
 Deis supports configuring hostname assignment through the ``unitHostname`` setting.
@@ -98,12 +98,12 @@ application
     The hostname is assigned based on the unit name. Example: ``dancing-cat.v2.web.1``
 
 server
-    The hostname is assigned based on the CoreOS hostname. Example: 
+    The hostname is assigned based on the CoreOS hostname. Example:
     ``ip-10-21-2-168.eu-west-1.compute.internal``
 
 .. note::
 
-    Changes to ``/deis/controller/unitHostname`` requires either pushing a new build to 
+    Changes to ``/deis/controller/unitHostname`` requires either pushing a new build to
     every application or scaling them down and up.
     The change is only detected when a container unit is deployed.
 


### PR DESCRIPTION
Use etcd key `/deis/controller/registrationMode` to manage registration mode, which can now be "enabled", "disabled", or "adminOnly".

If a user is logged into the deis client and tries to register, the token is now sent to the controller so that the controller can check if the current user is a admin and allow them to register if the registration mode is "adminOnly".

I also created a migration from `/deis/controller/registrationEnabled` to `/deis/controller/registrationMode`.

Fixes #3343 