### PR TITLE
fix(controller): read from SSH channel before checking exit status

### DIFF
--- a/controller/scheduler/fleet.py
+++ b/controller/scheduler/fleet.py
@@ -268,7 +268,8 @@ class FleetHTTPClient(object):
                 chan.get_pty()
                 out = chan.makefile()
                 chan.exec_command(cmd)
-                rc, output = chan.recv_exit_status(), out.read()
+                output = out.read()
+                rc = chan.recv_exit_status()
                 return rc, output
 
             # wait for container to launch


### PR DESCRIPTION
Controller code was checking the SSH channel's exit status *before* reading data from it, which surprisingly worked--up to a certain size in the neighborhood of [2182300 bytes](https://github.com/deis/deis/issues/3035#issuecomment-73433740). The similar issue paramiko/paramiko#448 suggested calling `recv_exit_status()` first was the problem, and changing the call order does fix large file output from `deis run` for the largest test files I've used, which previously failed.

```console
$ deis run -- "cat pg3008.txt | wc -c"
Running `cat pg3008.txt | wc -c`...
2474769
$ deis run -- "cat pg3008.txt"
Running `cat pg3008.txt`...
...
15331. jarg422h.htm#The%20Cuckoo's%20Egg
15332. jarg422h.htm#wizard
15333. jarg422h.htm#wannabee




End of The Project Gutenberg Etext of The New Hacker's Dictionary version
4.2.2

$
```

Closes #3035.