### PR TITLE
fix(database): stub out reload script before starting confd

### DIFF
--- a/database/bin/boot
+++ b/database/bin/boot
@@ -48,6 +48,10 @@ etcd_set_default password ${PG_USER_PASS:-changeme123}
 etcd_set_default name ${PG_USER_DB:-deis}
 etcd_set_default bucketName ${BUCKET_NAME}
 
+# stub out the confd reload script before it gets templated
+echo '#!/bin/sh' > /usr/local/bin/reload
+chmod 0755 /usr/local/bin/reload
+
 # wait for confd to run once and install initial templates
 until confd -onetime -node $ETCD -confdir /app --interval 5 --quiet; do
 	echo "database: waiting for confd to write initial templates..."


### PR DESCRIPTION
deis-database startup logs a couple of `ERROR exit status 127` messages. Adding `-debug=true -verbose=true` and removing `--quiet` from `confd` flags showed that we had a chicken-and-egg situation where our check_cmd `/usr/local/bin/reload` script was called before it existed, since it is also templated by `confd`.

This PR installs a no-op shell script to `/usr/local/bin/reload` to make `confd` quieter during initial startup.

```console
--- Run deisci/database:git-5246753 at 192.168.59.103:58203
Error response from daemon: No such container: deis-database-git-5246753
2015-04-01T19:52:55Z c5022545f3b2 confd[49]: WARNING Skipping confd config file.
database: no existing database found.
database: no backups found. Initializing a new database...
2015-04-01T19:52:55Z c5022545f3b2 confd[82]: WARNING Skipping confd config file.
2015-04-01 19:52:55 UTC LOG:  database system was shut down at 2015-03-26 17:25:01 UTC
2015-04-01 19:52:55 UTC LOG:  autovacuum launcher started
2015-04-01 19:52:55 UTC LOG:  database system is ready to accept connections
ALTER ROLE
CREATE ROLE
...
```

Closes #3381.