### PR TITLE
fix(builder): skip `docker rmi` if there are no images to remove

### DIFF
--- a/builder/image/templates/check-repos
+++ b/builder/image/templates/check-repos
@@ -16,8 +16,8 @@ do
     if ! listcontains "{{ join (lsdir "/deis/services/*") " " }}" "$reponame";
     then
         rm -rf "$repo"
-        docker images | grep $appname | awk '{ print $3 }' | xargs docker rmi -f
+        docker images | grep $appname | awk '{ print $3 }' | xargs -r docker rmi -f
         # remove any dangling images left over from the cleanup
-        docker images --filter "dangling=true" | awk '{ print $3 }' | grep -v IMAGE | xargs docker rmi -f
+        docker images --filter "dangling=true" | awk '{ print $3 }' | grep -v IMAGE | xargs -r docker rmi -f
     fi
 done


### PR DESCRIPTION
deis-builder startup logs an `ERROR exit status 123` message. This is due to the `docker rmi` command being run through `xargs` with no arguments. The [`-r` or `-no-run-if-empty` flag](https://www.gnu.org/software/findutils/manual/html_node/find_html/xargs-options.html) ensures that GNU `xargs` doesn't run its target command if no args were provided.

```console
--- Run deisci/builder:git-e9f7093 at 192.168.59.103:61203
Error response from daemon: No such container: deis-builder-git-e9f7093
2015-04-01T21:02:53Z b013f1daa439 confd[71]: WARNING Skipping confd config file.
2015-04-01T21:02:53Z b013f1daa439 confd[114]: WARNING Skipping confd config file.
time="2015-04-01T21:02:53Z" level="info" msg="+job serveapi(unix:///var/run/docker.sock)" 
time="2015-04-01T21:02:53Z" level="info" msg="+job init_networkdriver()" 
```

Closes #3382.

I would have made this change everywhere to our codebase since we have similar `xargs docker rmi` statements in several places, but I develop on a Mac which has a BSD `xargs`. It doesn't recognize `-r` and doesn't appear to need it. This change is inside a container where we know we have GNU `xargs` 4.4.2.