### PR TITLE
fix(docs): bracket $HOME properly in "deisctl config" example

### DIFF
--- a/docs/installing_deis/install-platform.rst
+++ b/docs/installing_deis/install-platform.rst
@@ -60,7 +60,7 @@ hosts during ``deis run``:
 
 .. note::
 
-    For Vagrant clusters: ``deisctl config platform set sshPrivateKey=$(HOME)/.vagrant.d/insecure_private_key``
+    For Vagrant clusters: ``deisctl config platform set sshPrivateKey=${HOME}/.vagrant.d/insecure_private_key``
 
 We'll also need to tell the controller which domain name we are deploying applications under:
 


### PR DESCRIPTION
IRC user [bkleef](https://botbot.me/freenode/deis/2015-03-31/?msg=35482821&page=2) pointed out this shell bracketing typo in [Installing Deis](http://docs.deis.io/en/latest/installing_deis/install-platform/).

```console
$ deisctl config platform set sshPrivateKey=$(HOME)/.vagrant.d/insecure_private_key
-bash: HOME: command not found
$ deisctl config platform set sshPrivateKey=${HOME}/.vagrant.d/insecure_private_key
```

