### PR TITLE
fix(builder): retrieve process types from slugbuilder's Procfile

### DIFF
--- a/builder/image/templates/builder
+++ b/builder/image/templates/builder
@@ -138,7 +138,14 @@ echo
 if [ -f Procfile ]; then
     PROCFILE=$(cat Procfile | /app/bin/yaml2json-procfile)
 elif [ -f $TMP_DIR/slug.tgz ]; then
-    PROCFILE=$(tar --to-stdout -xf $TMP_DIR/slug.tgz ./.release | /app/bin/extract-types)
+    # Sometimes, the buildpack will generate a Procfile instead of populating /bin/release
+    # /bin/release was unofficially deprecated for declaring default process types
+    if tar -tf $TMP_DIR/slug.tgz ./Procfile &> /dev/null;
+    then
+        PROCFILE="$(tar --to-stdout -xf $TMP_DIR/slug.tgz ./Procfile | /app/bin/yaml2json-procfile)"
+    else
+        PROCFILE=$(tar --to-stdout -xf $TMP_DIR/slug.tgz ./.release | /app/bin/extract-types)
+    fi
 else
     PROCFILE="{}"
 fi


### PR DESCRIPTION
/bin/release was unofficially deprecated for declaring default process
types a while back, which is why some buildpacks don't supply any
default process types in /bin/release. Instead, the buildpack will
generate a Procfile if none is supplied.

Before: https://gist.github.com/bacongobbler/0a530ebaf08685b20d09
After: https://gist.github.com/bacongobbler/6ae9fc07f2fd7b248953

closes #3404