### PR TITLE
fix(deisctl): omit cache from `deisctl stop platform"

### DIFF
--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -510,7 +510,7 @@ func uninstallAllServices(b backend.Backend, wg *sync.WaitGroup, outchan chan st
 	wg.Wait()
 
 	outchan <- fmt.Sprintf("Control plane...")
-	b.Destroy([]string{"controller", "builder", "cache", "database", "registry@*"}, wg, outchan, errchan)
+	b.Destroy([]string{"controller", "builder", "database", "registry@*"}, wg, outchan, errchan)
 	wg.Wait()
 
 	outchan <- fmt.Sprintf("Logging subsystem...")

--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -270,8 +270,6 @@ func stopDefaultServices(b backend.Backend, wg *sync.WaitGroup, outchan chan str
 	outchan <- fmt.Sprintf("Control plane...")
 	b.Stop([]string{"controller", "builder", "database", "registry@*"}, wg, outchan, errchan)
 	wg.Wait()
-	b.Stop([]string{"cache"}, wg, outchan, errchan)
-	wg.Wait()
 
 	outchan <- fmt.Sprintf("Logging subsystem...")
 	b.Stop([]string{"logger", "logspout"}, wg, outchan, errchan)


### PR DESCRIPTION
`deisctl start platform` omits deis-cache as of #3273, but `deisctl stop platform` and `deisctl uninstall platform` weren't updated:
```console
$ deisctl stop platform
● ▴ ■
■ ● ▴ Stopping Deis...
▴ ■ ●

Routing mesh...
deis-router@1.service: inactive/dead                                 
deis-router@2.service: inactive/dead                                 
deis-router@3.service: inactive/dead                                 
Data plane...
deis-publisher.service: inactive/dead                                 
Control plane...
deis-builder.service: inactive/dead                                 
deis-controller.service: inactive/dead                                 
deis-database.service: inactive/dead                                 
deis-registry@1.service: inactive/dead                                 
could not find unit: deis-cache.service
```