### PR TITLE
docs(logger): change incorrect ref to db component

### DIFF
--- a/docs/customizing_deis/logger_settings.rst
+++ b/docs/customizing_deis/logger_settings.rst
@@ -17,7 +17,7 @@ Considerations: none
 
 Settings set by logger
 ------------------------
-The following etcd keys are set by the database component, typically in its /bin/boot script.
+The following etcd keys are set by the logger component, typically in its /bin/boot script.
 
 ===========================              =================================================================================
 setting                                  description


### PR DESCRIPTION
Change an incorrect reference to the database component in the documentation for customizing the logger component.