### PR TITLE
fix(deisctl): add systemd reload hack as workaround

### DIFF
--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -162,6 +162,9 @@ func startDefaultServices(b backend.Backend, wg *sync.WaitGroup, outchan chan st
 	var _wg sync.WaitGroup
 
 	// wait for groups to come up
+	outchan <- fmt.Sprintf("Workaround for Fleet v0.9.1...")
+	b.Start([]string{"reload-hack"}, wg, outchan, errchan)
+	wg.Wait()
 	outchan <- fmt.Sprintf("Storage subsystem...")
 	b.Start([]string{"store-monitor"}, wg, outchan, errchan)
 	wg.Wait()
@@ -283,6 +286,10 @@ func stopDefaultServices(b backend.Backend, wg *sync.WaitGroup, outchan chan str
 	b.Stop([]string{"store-daemon"}, wg, outchan, errchan)
 	wg.Wait()
 	b.Stop([]string{"store-monitor"}, wg, outchan, errchan)
+	wg.Wait()
+
+	outchan <- fmt.Sprintf("Workaround for Fleet v0.9.1...")
+	b.Stop([]string{"reload-hack"}, wg, outchan, errchan)
 	wg.Wait()
 }
 
@@ -421,6 +428,10 @@ func InstallPlatform(b backend.Backend) error {
 
 func installDefaultServices(b backend.Backend, wg *sync.WaitGroup, outchan chan string, errchan chan error) {
 
+	outchan <- fmt.Sprintf("Workaround for Fleet v0.9.1...")
+	b.Create([]string{"reload-hack"}, wg, outchan, errchan)
+	wg.Wait()
+
 	outchan <- fmt.Sprintf("Storage subsystem...")
 	b.Create([]string{"store-daemon", "store-monitor", "store-metadata", "store-volume", "store-gateway@1"}, wg, outchan, errchan)
 	wg.Wait()
@@ -525,6 +536,10 @@ func uninstallAllServices(b backend.Backend, wg *sync.WaitGroup, outchan chan st
 	b.Destroy([]string{"store-daemon"}, wg, outchan, errchan)
 	wg.Wait()
 	b.Destroy([]string{"store-monitor"}, wg, outchan, errchan)
+	wg.Wait()
+
+	outchan <- fmt.Sprintf("Workaround for Fleet v0.9.1...")
+	b.Start([]string{"reload-hack"}, wg, outchan, errchan)
 	wg.Wait()
 
 	return nil

--- a/deisctl/units/deis-reload-hack.service
+++ b/deisctl/units/deis-reload-hack.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Systemd Reload Hack for Fleet Bug https://github.com/coreos/fleet/issues/1158
+After=fleet.service
+
+[Service]
+Restart=always
+RestartSec=20s
+ExecStart=/bin/bash -c "while true; do if systemctl -all list-units | grep -e '@.*not-found.*inactive.*dead.*'; then systemctl daemon-reload; fi; systemctl -all list-units | grep '@[0-9].*loaded.*inactive.*dead.*'  | awk '{print $1}' | xargs --no-run-if-empty systemctl restart; sleep 120s; done"
+
+[X-Fleet]
+Global=true


### PR DESCRIPTION
By installing this temporary hack, this should help prevent the
"no such file or directory" bug in fleet v0.9.1 without being too
invasive to the filesystem.

replaces #3422