### PR TITLE
fix(database+registry): check for S3 bucket name before creating it

### DIFF
--- a/database/templates/create_bucket
+++ b/database/templates/create_bucket
@@ -1,14 +1,16 @@
 #!/usr/bin/env python
+
 import boto
 import sys
 from boto.s3.connection import OrdinaryCallingFormat
 
-conn = boto.connect_s3(host='{{ getv "/deis/store/gateway/host" }}',
-                       port={{ getv "/deis/store/gateway/port" }},
-                       is_secure=False,
-                       calling_format=OrdinaryCallingFormat(),
-                      )
-bucket = sys.argv[1]
 
-if not bucket in conn.get_all_buckets():
-  conn.create_bucket(bucket)
+conn = boto.connect_s3(
+    host='{{ getv "/deis/store/gateway/host" }}',
+    port={{ getv "/deis/store/gateway/port" }},
+    is_secure=False,
+    calling_format=OrdinaryCallingFormat())
+name = sys.argv[1]
+
+if name not in (bucket.name for bucket in conn.get_all_buckets()):
+    conn.create_bucket(name)

--- a/registry/templates/create_bucket
+++ b/registry/templates/create_bucket
@@ -1,16 +1,17 @@
 #!/usr/bin/env python
+
 import boto
 import sys
 from boto.s3.connection import OrdinaryCallingFormat
 
-conn = boto.connect_s3(aws_access_key_id='{{ getv "/deis/store/gateway/accessKey" }}',
-                       aws_secret_access_key='{{ getv "/deis/store/gateway/secretKey" }}',
-                       host='{{ getv "/deis/store/gateway/host" }}',
-                       port={{ getv "/deis/store/gateway/port" }},
-                       is_secure=False,
-                       calling_format=OrdinaryCallingFormat(),
-                      )
-bucket = sys.argv[1]
+conn = boto.connect_s3(
+    aws_access_key_id='{{ getv "/deis/store/gateway/accessKey" }}',
+    aws_secret_access_key='{{ getv "/deis/store/gateway/secretKey" }}',
+    host='{{ getv "/deis/store/gateway/host" }}',
+    port={{ getv "/deis/store/gateway/port" }},
+    is_secure=False,
+    calling_format=OrdinaryCallingFormat())
+name = sys.argv[1]
 
-if not bucket in conn.get_all_buckets():
-  conn.create_bucket(bucket)
+if name not in (bucket.name for bucket in conn.get_all_buckets()):
+    conn.create_bucket(name)


### PR DESCRIPTION
The previous test was always returning `False` since it compared a string to a `boto.s3.bucket.Bucket` instance. So before this change we always tried to create the bucket and presumably hit errors if it already existed. 

I tested this change interactively in `ipython` and it fixes the comparison. I also ran `flake8` on the template scripts and cleaned them up. Thanks to @Blystad for catching this bug!

Closes #3430.