### PR TITLE
ref(docs): clean up app ssl documentation

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -11,7 +11,6 @@ Reference Guide
 
     usage
     terms/index
-    domain-ssl
     self-signed-certs
     client
     server/index

--- a/docs/reference/self-signed-certs.rst
+++ b/docs/reference/self-signed-certs.rst
@@ -6,7 +6,7 @@
 Creating a Self-Signed SSL Certificate
 ======================================
 
-When :ref:`using the domain ssl <domain_ssl>` feature for non-production applications or when
+When :ref:`using the app ssl <app_ssl>` feature for non-production applications or when
 :ref:`installing SSL for the platform <platform_ssl>`, you can avoid the costs associated with the SSL
 certificate by using a self-signed SSL certificate. Though the certificate implements full
 encryption, visitors to your site will see a browser warning indicating that the certificate should
@@ -70,4 +70,4 @@ The self-signed SSL certificate is generated from the server.key private key and
     $ openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt
 
 The server.crt file is your site certificate suitable for use with
-:ref:`Deis's SSL endpoint <domain_ssl>` along with the server.key private key.
+:ref:`Deis's SSL endpoint <app_ssl>` along with the server.key private key.

--- a/docs/using_deis/app-ssl.rst
+++ b/docs/using_deis/app-ssl.rst
@@ -2,10 +2,10 @@
 :description: Enabling and configuring SSL on applications using the SSL endpoint.
 
 
-.. _domain_ssl:
+.. _app_ssl:
 
-Using an SSL Certificate with Deis
-==================================
+Application SSL Certificates
+============================
 
 SSL is a cryptographic protocol that provides end-to-end encryption and integrity for all web
 requests. Apps that transmit sensitive data should enable SSL to ensure all information is

--- a/docs/using_deis/index.rst
+++ b/docs/using_deis/index.rst
@@ -21,3 +21,4 @@ Using Deis
     using-docker-images
     config-application
     manage-application
+    app-ssl


### PR DESCRIPTION
"Using App SSL" belongs in "Using Deis". I've also cleaned up some of
the more confusing terms like "domain ssl" in favour of "app ssl".