### PR TITLE
chore(logspout): switch to busybox

### DIFF
--- a/logspout/image/Dockerfile
+++ b/logspout/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM flynn/busybox
+FROM busybox
 MAINTAINER OpDemand <info@opdemand.com>
 
 ENV DOCKER_HOST unix:///tmp/docker.sock


### PR DESCRIPTION
flynn/logspout has not been modified in 15 months, whereas busybox is
an officially supported image by docker.