### PR TITLE
fix(router): use nginx $host in HTTPS redirects

### DIFF
--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -98,7 +98,7 @@ http {
 
         {{ if eq $enforceHTTPS "true" }}
         if ($access_scheme != "https") {
-          return 301 https://$server_name$request_uri;
+          return 301 https://$host$request_uri;
         }
         {{ end }}
     }
@@ -195,7 +195,7 @@ http {
 
             {{ if eq $enforceHTTPS "true" }}
             if ($access_scheme != "https") {
-              return 301 https://$server_name$request_uri;
+              return 301 https://$host$request_uri;
             }
             {{ end }}
 
@@ -245,7 +245,7 @@ http {
 
             {{ if eq $enforceHTTPS "true" }}
             if ($access_scheme != "https") {
-              return 301 https://$server_name$request_uri;
+              return 301 https://$host$request_uri;
             }
             {{ end }}
 


### PR DESCRIPTION
This broke in #3266 when removing taxing regex rewrites from nginx. See http://wiki.nginx.org/HttpCoreModule#.24host

TESTING: on a cluster with this router patch applied, do `deisctl config router set enforceHTTPS=true`, then use `wget` to query an HTTP endpoint on the server. You should see a proper HTTPS redirect to the same URL, rather than the bogus one created previously.

Closes #3438, #3437.