### PR TITLE
chore(client): update python-dateutil to 2.4.2

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -1,6 +1,6 @@
 
 build: setup-venv
-	venv/bin/pip install docopt==0.6.2 python-dateutil==2.4.1 PyYAML==3.11 requests==2.5.1 git+https://github.com/pyinstaller/pyinstaller@7413317 tabulate==0.7.4 termcolor==1.1.0
+	venv/bin/pip install docopt==0.6.2 python-dateutil==2.4.2 PyYAML==3.11 requests==2.5.1 git+https://github.com/pyinstaller/pyinstaller@7413317 tabulate==0.7.4 termcolor==1.1.0
 	venv/bin/pyinstaller deis.spec
 	chmod +x dist/deis
 

--- a/client/setup.py
+++ b/client/setup.py
@@ -57,7 +57,7 @@ setup(name='deis',
       ],
       long_description=LONG_DESCRIPTION,
       install_requires=[
-          'docopt==0.6.2', 'python-dateutil==2.4.1',
+          'docopt==0.6.2', 'python-dateutil==2.4.2',
           'PyYAML==3.11', 'requests==2.5.1',
           'tabulate==0.7.4', 'termcolor==1.1.0'
       ],

--- a/controller/dev_requirements.txt
+++ b/controller/dev_requirements.txt
@@ -1,6 +1,6 @@
 # Deis client requirements
 docopt==0.6.2
-python-dateutil==2.4.1
+python-dateutil==2.4.2
 requests==2.5.1
 termcolor==1.1.0
 

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -25,7 +25,7 @@ python-ldap==2.4.19
 
 # Deis client requirements
 docopt==0.6.2
-python-dateutil==2.4.1
+python-dateutil==2.4.2
 requests==2.5.1
 tabulate==0.7.4
 termcolor==1.1.0


### PR DESCRIPTION
Includes an update to [zoneinfo](http://en.wikipedia.org/wiki/Tz_database) and bug fixes, see https://github.com/dateutil/dateutil/releases/tag/2.4.2