### PR TITLE
fix(builder): exit 1 when gitreceive captures a build

### DIFF
--- a/builder/image/templates/gitreceive
+++ b/builder/image/templates/gitreceive
@@ -44,7 +44,7 @@ EOF
     do
       LOCKFILE="/tmp/$RECEIVE_REPO.lock"
       if ( set -o noclobber; echo "$$" > "$LOCKFILE" ) 2> /dev/null; then
-        trap 'rm -f "$LOCKFILE"; exit $?' INT TERM EXIT
+        trap 'rm -f "$LOCKFILE"; exit 1' INT TERM EXIT
 
         # check for authorization on this repo
         $GITHOME/receiver "$RECEIVE_REPO" "$newrev" "$RECEIVE_USER" "$RECEIVE_FINGERPRINT"


### PR DESCRIPTION
The `exit $?` was capturing the call to `rm -rf`, which will almost always exit 0. As a fix, whenever gitreceive captures a failed build, it will exit with exit code 1 so that the commit will get rejected.

closes #3342
closes #3427