### PR TITLE
chore(controller): update docker-py to 1.1.0

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -11,7 +11,7 @@ django-guardian==1.2.5
 django-json-field==0.5.7
 django-auth-ldap==1.2.5
 djangorestframework==3.0.5
-docker-py==0.7.2
+docker-py==1.1.0
 gunicorn==19.3.0
 paramiko==1.15.2
 psycopg2==2.6

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -15,7 +15,7 @@ django-guardian==1.2.5
 django-json-field==0.5.7
 django-auth-ldap==1.2.5
 djangorestframework==3.0.5
-docker-py==0.7.2
+docker-py==1.1.0
 gunicorn==19.3.0
 paramiko==1.15.2
 python-etcd==0.3.2


### PR DESCRIPTION
See https://github.com/docker/docker-py/compare/0.7.2-release...1.1.0-release

Deis still uses only the (unchanged) [`utils.parse_repository_tag`](https://github.com/docker/docker-py/blob/master/docker/utils/utils.py#L183) function, so this is purely housekeeping for now, although #3134 may want this.