### PR TITLE
chore(*): update pip installer tool to 6.1.1

### DIFF
--- a/controller/build.sh
+++ b/controller/build.sh
@@ -19,7 +19,7 @@ apt-get update && \
     apt-get install -yq python-dev libffi-dev libpq-dev libyaml-dev git libldap2-dev libsasl2-dev
 
 # install pip
-curl -sSL https://raw.githubusercontent.com/pypa/pip/6.0.8/contrib/get-pip.py | python -
+curl -sSL https://raw.githubusercontent.com/pypa/pip/6.1.1/contrib/get-pip.py | python -
 
 # add a deis user
 useradd deis --home-dir /app --shell /bin/bash

--- a/database/build.sh
+++ b/database/build.sh
@@ -32,7 +32,7 @@ apt-get update && apt-get install -yq \
 /etc/init.d/postgresql stop
 
 # install pip
-curl -sSL https://raw.githubusercontent.com/pypa/pip/6.0.8/contrib/get-pip.py | python -
+curl -sSL https://raw.githubusercontent.com/pypa/pip/6.1.1/contrib/get-pip.py | python -
 
 # install wal-e
 cd /tmp

--- a/registry/build.sh
+++ b/registry/build.sh
@@ -20,7 +20,7 @@ apt-get update && \
     libevent-dev libssl-dev libyaml-0-2 libyaml-dev python-openssl liblzma-dev swig
 
 # install pip
-curl -sSL https://raw.githubusercontent.com/pypa/pip/6.0.8/contrib/get-pip.py | python -
+curl -sSL https://raw.githubusercontent.com/pypa/pip/6.1.1/contrib/get-pip.py | python -
 
 # create a registry user
 useradd -s /bin/bash registry

--- a/tests/bin/setup-node.sh
+++ b/tests/bin/setup-node.sh
@@ -34,7 +34,7 @@ echo "You must reboot for the global $PATH changes to take effect."
 
 # install test suite requirements
 apt-get install -yq curl mercurial python-dev libffi-dev libpq-dev libyaml-dev git postgresql postgresql-client libldap2-dev libsasl2-dev
-curl -sSL https://raw.githubusercontent.com/pypa/pip/6.0.8/contrib/get-pip.py | python -
+curl -sSL https://raw.githubusercontent.com/pypa/pip/6.1.1/contrib/get-pip.py | python -
 pip install virtualenv
 
 # create jenkins user and install node bootstrap script

--- a/tests/fixtures/mock-store/build.sh
+++ b/tests/fixtures/mock-store/build.sh
@@ -25,7 +25,7 @@ cd /app/mock-s3
 curl https://gist.githubusercontent.com/anonymous/c565f11a8d90d6e2d92b/raw/c5815f6c83aa5c2cfb7b0a34cfab4a075c97be16/mock-s3-post.diff|git apply
 
 # install pip
-curl -sSL https://raw.githubusercontent.com/pypa/pip/6.0.8/contrib/get-pip.py | python -
+curl -sSL https://raw.githubusercontent.com/pypa/pip/6.1.1/contrib/get-pip.py | python -
 
 python setup.py install
 


### PR DESCRIPTION
I got tired of seeing these warnings:
```console
venv/bin/pip install -q -r requirements.txt -r dev_requirements.txt
You are using pip version 6.0.8, however version 6.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```