### PR TITLE
chore(*): bump CoreOS to 633.1.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
 
   config.vm.box = "coreos-%s" % $update_channel
-  config.vm.box_version = ">= 607.0.0"
+  config.vm.box_version = ">= 633.1.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
 
   ["vmware_fusion", "vmware_workstation"].each do |vmware|

--- a/contrib/azure/azure-coreos-cluster
+++ b/contrib/azure/azure-coreos-cluster
@@ -35,8 +35,8 @@ parser.add_argument('--affinity-group', default='',
                    help='optional, overrides location if specified')
 parser.add_argument('--ssh', default=22001, type=int,
                    help='optional, starts with 22001 and +1 for each machine in cluster')
-parser.add_argument('--coreos-image', default='2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-607.0.0',
-                   help='optional, [2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-607.0.0]')
+parser.add_argument('--coreos-image', default='2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-633.1.0',
+                   help='optional, [2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-633.1.0]')
 parser.add_argument('--num-nodes', default=3, type=int,
                    help='optional, number of nodes to create (or add), defaults to 3')
 parser.add_argument('--virtual-network-name',

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -108,15 +108,15 @@
 
   "Mappings" : {
     "CoreOSAMIs" : {
-      "eu-central-1"   : { "PV" : "ami-0c300d11", "HVM" : "ami-0e300d13" },
-      "ap-northeast-1" : { "PV" : "ami-b128dcb1", "HVM" : "ami-af28dcaf" },
-      "sa-east-1"      : { "PV" : "ami-2154ec3c", "HVM" : "ami-2354ec3e" },
-      "ap-southeast-2" : { "PV" : "ami-bbb5c581", "HVM" : "ami-b9b5c583" },
-      "ap-southeast-1" : { "PV" : "ami-fa0b3aa8", "HVM" : "ami-f80b3aaa" },
-      "us-east-1"      : { "PV" : "ami-343b195c", "HVM" : "ami-323b195a" },
-      "us-west-2"      : { "PV" : "ami-0989a439", "HVM" : "ami-0789a437" },
-      "us-west-1"      : { "PV" : "ami-83d533c7", "HVM" : "ami-8dd533c9" },
-      "eu-west-1"      : { "PV" : "ami-57950a20", "HVM" : "ami-55950a22" }
+      "eu-central-1"   : { "PV" : "ami-8c003c91", "HVM" : "ami-92003c8f" },
+      "ap-northeast-1" : { "PV" : "ami-9eb9439e", "HVM" : "ami-9cb9439c" },
+      "sa-east-1"      : { "PV" : "ami-9be66386", "HVM" : "ami-99e66384" },
+      "ap-southeast-2" : { "PV" : "ami-d53845ef", "HVM" : "ami-cb3845f1" },
+      "ap-southeast-1" : { "PV" : "ami-a2cefcf0", "HVM" : "ami-a0cefcf2" },
+      "us-east-1"      : { "PV" : "ami-d6033bbe", "HVM" : "ami-d2033bba" },
+      "us-west-2"      : { "PV" : "ami-39280209", "HVM" : "ami-37280207" },
+      "us-west-1"      : { "PV" : "ami-4df91b09", "HVM" : "ami-43f91b07" },
+      "eu-west-1"      : { "PV" : "ami-2f422358", "HVM" : "ami-21422356" }
 
     },
     "RootDevices" : {

--- a/contrib/rackspace/provision-rackspace-cluster.sh
+++ b/contrib/rackspace/provision-rackspace-cluster.sh
@@ -49,6 +49,7 @@ $CONTRIB_DIR/util/check-user-data.sh
 i=1 ; while [[ $i -le $DEIS_NUM_INSTANCES ]] ; do \
     echo_yellow "Provisioning deis-$i..."
     # This image is CoreOS 607.0.0 in the stable channel
+    # TODO Update to 633.1.0 once it's available in the stable channel
     supernova $ENV boot --image c412af3b-f9a6-4ad1-a9e9-4aabca8073d3 --flavor $FLAVOR --key-name $1 --user-data $CONTRIB_DIR/coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
     ((i = i + 1)) ; \
 done

--- a/docs/installing_deis/baremetal.rst
+++ b/docs/installing_deis/baremetal.rst
@@ -104,8 +104,8 @@ Start the installation
 
 
 This will install the latest `CoreOS`_ stable release to disk. The Deis provision scripts for other
-platforms typically specify a CoreOS version - currently, ``607.0.0``. To specify a CoreOS
-version, append the ``-V`` parameter to the install command, e.g. ``-V 607.0.0``.
+platforms typically specify a CoreOS version - currently, ``633.1.0``. To specify a CoreOS
+version, append the ``-V`` parameter to the install command, e.g. ``-V 633.1.0``.
 
 After the installation has finished, reboot your server. Once your machine is back up, you should
 be able to log in as the `core` user using the `deis` ssh key.

--- a/docs/installing_deis/gce.rst
+++ b/docs/installing_deis/gce.rst
@@ -118,7 +118,7 @@ Launch 3 instances. You can choose another starting CoreOS image from the listin
       --metadata-from-file user-data=gce-user-data sshKeys=~/.ssh/deis.pub \
       --disk name=cored${num} device-name=coredocker \
       --tags deis \
-      --image coreos-stable-607-0-0-v20150317 \
+      --image coreos-stable-633-1-0-v20150414 \
       --image-project coreos-cloud;
     done
 


### PR DESCRIPTION
https://coreos.com/releases/#633.1.0

Note that we really want ~~CoreOS >= 640.0.0 for Linux 3.19 for Ceph
and~~ fleet 0.9.2, but since at least Digital Ocean gets the latest
stable, we should do our best to bump to the latest stable
whenever possible.

replaces #3490