### PR TITLE
feat(controller): restore coverage.py report for unit tests

### DIFF
--- a/controller/Makefile
+++ b/controller/Makefile
@@ -67,7 +67,8 @@ test-style: setup-venv
 	venv/bin/flake8
 
 test-unit: setup-venv test-style
-	venv/bin/python manage.py test --noinput api
+	venv/bin/coverage run manage.py test --noinput api
+	venv/bin/coverage report -m
 
 test-functional:
 	@docker history deis/test-etcd >/dev/null 2>&1 || docker pull deis/test-etcd:latest


### PR DESCRIPTION
Deis used to summarize test code coverage for the controller, but this was lost in a project shuffle. This restores the summary table to `make -C controller/ test-unit`.
```
$ venv/bin/coverage report -m
Name                 Stmts   Miss  Cover   Missing
--------------------------------------------------
api/admin               47      0   100%   
api/authentication       5      0   100%   
api/fields              29      4    86%   29, 39, 43-47
api/middleware          17      0   100%   
api/models             662     90    86%   104-105, 111-112, 118-119, 196-197, 461-464, 478-484, 491-494, 499, 544, 632-633, 636-637, 706-719, 732, 754-756, 788, 817, 821, 856-857, 933-934, 939-944, 948-954, 958-960, 964-968, 972-975, 979-984, 988-990, 994-999, 1027-1035
api/permissions         43      9    79%   39-42, 51-56, 92
api/routers              5      0   100%   
api/serializers        186     11    94%   148, 150, 157, 159, 162, 166-167, 169, 244, 246, 260
api/urls                 6      0   100%   
api/utils               22      3    86%   113-116
api/views              253      8    97%   80, 127, 167, 266-268, 301, 324
api/viewsets            12      0   100%   
deis/__init__            2      0   100%   
deis/middleware          5      0   100%   
deis/settings          104      4    96%   206, 208, 356-357
deis/urls                8      1    88%   24
manage                   3      0   100%   
registry/__init__        4      0   100%   
registry/mock            2      0   100%   
--------------------------------------------------
TOTAL                 1415    130    91%   
```