### PR TITLE
feat(controller): add a option to limit the number of log lines

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -633,12 +633,20 @@ Make sure that the Controller URI is correct and the server is running.
         Options:
           -a --app=<app>
             the uniquely identifiable name for the application.
+          -n --lines=<lines>
+            the number of lines to display
         """
         app = args.get('--app')
         if not app:
             app = self._session.app
-        response = self._dispatch('get',
-                                  "/v1/apps/{}/logs".format(app))
+
+        url = "/v1/apps/{}/logs".format(app)
+
+        log_lines = args.get('--lines')
+        if log_lines:
+            url += "?log_lines={}".format(log_lines)
+
+        response = self._dispatch('get', url)
         if response.status_code == requests.codes.ok:
             # strip the last newline character
             for line in response.json().split('\n')[:-1]:

--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -337,12 +337,12 @@ class App(UuidAuditedModel):
 
         self.scale(user, structure)
 
-    def logs(self):
+    def logs(self, log_lines):
         """Return aggregated log data for this application."""
         path = os.path.join(settings.DEIS_LOG_DIR, self.id + '.log')
         if not os.path.exists(path):
             raise EnvironmentError('Could not locate logs')
-        data = subprocess.check_output(['tail', '-n', str(settings.LOG_LINES), path])
+        data = subprocess.check_output(['tail', '-n', log_lines, path])
         return data
 
     def run(self, user, command):

--- a/controller/api/tests/test_app.py
+++ b/controller/api/tests/test_app.py
@@ -121,6 +121,13 @@ class AppTest(TestCase):
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, FAKE_LOG_DATA)
+
+        # test with log_lines
+        response = self.client.get(url + "?log_lines=1",
+                                   HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, FAKE_LOG_DATA.splitlines(True)[4])
+
         os.remove(path)
         # TODO: test run needs an initial build
 

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -150,7 +150,9 @@ class AppViewSet(BaseDeisViewSet):
     def logs(self, request, **kwargs):
         app = self.get_object()
         try:
-            return Response(app.logs(), status=status.HTTP_200_OK, content_type='text/plain')
+            return Response(app.logs(request.query_params.get('log_lines',
+                                     str(settings.LOG_LINES))),
+                            status=status.HTTP_200_OK, content_type='text/plain')
         except EnvironmentError:
             return Response("No logs for {}".format(app.id),
                             status=status.HTTP_204_NO_CONTENT,

--- a/docs/reference/api-v1.3.rst
+++ b/docs/reference/api-v1.3.rst
@@ -13,6 +13,7 @@ What's New
 ----------
 
 **New!** ``/users`` endpoint for listing users
+**New!** ``/logs`` endpoint now has a option for limiting the number of log lines returned
 
 
 Authentication
@@ -257,6 +258,12 @@ Example Request:
     GET /v1/apps/example-go/logs/ HTTP/1.1
     Host: deis.example.com
     Authorization: token abc123
+
+Optional URL Query Parameters:
+
+.. code-block:: console
+
+    ?log_lines=
 
 Example Response:
 

--- a/tests/apps_test.go
+++ b/tests/apps_test.go
@@ -18,6 +18,7 @@ var (
 	appsRunCmd             = "apps:run echo Hello, 世界"
 	appsOpenCmd            = "apps:open --app={{.AppName}}"
 	appsLogsCmd            = "apps:logs --app={{.AppName}}"
+	appsLogsLimitCmd       = "apps:logs --app={{.AppName}} -n 1"
 	appsInfoCmd            = "apps:info --app={{.AppName}}"
 	appsDestroyCmd         = "apps:destroy --app={{.AppName}} --confirm={{.AppName}}"
 	appsDestroyCmdNoApp    = "apps:destroy --confirm={{.AppName}}"
@@ -97,6 +98,9 @@ func appsLogsTest(t *testing.T, params *utils.DeisTestConfig) {
 	utils.CurlApp(t, *params)
 	utils.Execute(t, cmd, params, false, "created initial release")
 	utils.Execute(t, cmd, params, false, "listening on 5000...")
+
+	utils.Execute(t, appsLogsLimitCmd, params, false, "")
+
 	if err := utils.Chdir(".."); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Usage: `deis apps:logs -n <number>`

I used a URL query parameter instead of a JSON body because that is generally considered better practice in a GET request. If you would like me to change to using a JSON body I can.

Do you want a API bump for this, or since 1.3 hasn't been released yet, add to that?

Closes #1264