### PR TITLE
ref(controller/tests): import regex to be tested, don't copy it

### DIFF
--- a/controller/api/tests/test_limits.py
+++ b/controller/api/tests/test_limits.py
@@ -1,14 +1,14 @@
 import unittest
-import re
 
-
-MEMLIMIT = re.compile(r'^(?P<mem>[0-9]+(MB|KB|GB|[BKMG]))$', re.IGNORECASE)
+from api.serializers import MEMLIMIT_MATCH
 
 
 class TestLimits(unittest.TestCase):
+    """Tests the regex for unit format used by "deis limits:set --memory=<limit>".
+    """
 
-    def test_upper(self):
-        self.assertTrue(MEMLIMIT.match("20MB"))
-        self.assertFalse(MEMLIMIT.match("20MK"))
-        self.assertTrue(MEMLIMIT.match("20gb"))
-        self.assertFalse(MEMLIMIT.match("20gK"))
+    def test_memlimit_regex(self):
+        self.assertTrue(MEMLIMIT_MATCH.match("20MB"))
+        self.assertFalse(MEMLIMIT_MATCH.match("20MK"))
+        self.assertTrue(MEMLIMIT_MATCH.match("20gb"))
+        self.assertFalse(MEMLIMIT_MATCH.match("20gK"))


### PR DESCRIPTION
When merging #3484 I missed that the regular expression to be tested was duplicated.