### PR TITLE
fix(router): write out only if cert matches the path

### DIFF
--- a/router/image/templates/generate-certs
+++ b/router/image/templates/generate-certs
@@ -27,13 +27,17 @@ while read etcd_path; do
     {{ range $cert := .deis_certs }}{{ if $cert.Nodes }}
     {{ range $certFields := $cert.Nodes }}
     {{ if eq (Base $certFields.Key) "cert" }}
+    if [[ "$(basename $etcd_path)" == "{{ Base $cert.Key }}" ]]; then
     cat << EOF > "$CERT_PATH/$(basename $etcd_path).cert"
 {{ $certFields.Value }}
 EOF
+    fi
     {{ else if eq (Base $certFields.Key) "key" }}
+    if [[ "$(basename $etcd_path)" == "{{ Base $cert.Key }}" ]]; then
     cat << EOF > "$KEY_PATH/$(basename $etcd_path).key"
 {{ $certFields.Value }}
 EOF
+    fi
     {{ end }}
     {{ end }}
     {{ end }}{{ end }}


### PR DESCRIPTION
closes #3483 
closes #3507

What's happening is that we are iterating through each cert twice. This is necessary to work around some boot issues with confd. However with the current logic, we're writing the last cert in each iteration to every file. By checking the domain with the etcd key, only the correct one will be written to the cert/key path.