### PR TITLE
fix(router): include deis.conf if no match with an SSL cert

### DIFF
--- a/router/image/Dockerfile
+++ b/router/image/Dockerfile
@@ -5,8 +5,8 @@ ENV DEBIAN_FRONTEND noninteractive
 # install common packages
 RUN apt-get update && apt-get install -y curl net-tools sudo
 
-# install confd
-RUN curl -sSL -o /usr/local/bin/confd https://s3-us-west-2.amazonaws.com/opdemand/confd-git-b8e693c \
+# install confd from https://github.com/deis/confd/tree/deis
+RUN curl -sSL -o /usr/local/bin/confd https://s3-us-west-2.amazonaws.com/opdemand/confd-git-4c50136 \
     && chmod +x /usr/local/bin/confd
 
 # install common packages

--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -157,9 +157,11 @@ http {
     server {
         server_name {{ Base $domain.Key }};
         {{/* if a SSL certificate is installed for this domain, use SSL */}}
-        {{/* Note (bacongobbler): domains are separate from the default platform domain, */}}
+        {{/* NOTE (bacongobbler): domains are separate from the default platform domain, */}}
         {{/* so we can't rely on deis.conf as each domain is an island */}}
-        {{ if index $root (printf "deis_certs_%s_cert" (Base $domain.Key)) }}
+        {{/* FIXME (bacongobbler): confd turns hyphens to dashes, so we need to account */}}
+        {{/* for that in domains */}}
+        {{ if index $root (printf "deis_certs_%s_cert" (Replace (Base $domain.Key) "-" "_" -1)) }}
         server_name_in_redirect off;
         port_in_redirect off;
         listen 80;

--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -142,6 +142,7 @@ http {
     {{ $affinityArg := .deis_router_affinityArg }}
     {{ $certs := .deis_certs }}
     {{ $domains := .deis_domains }}
+    {{ $root := . }}
     {{ range $service := .deis_services }}{{ if $service.Nodes }}
     upstream {{ Base $service.Key }} {
         {{ if $affinityArg }}hash $arg_{{ $affinityArg }} consistent;
@@ -155,18 +156,24 @@ http {
     {{ range $domain := $domains }}{{ if eq (Base $service.Key) $domain.Value }}
     server {
         server_name {{ Base $domain.Key }};
-        server_name_in_redirect off;
-        port_in_redirect off;
-        listen 80;
         {{/* if a SSL certificate is installed for this domain, use SSL */}}
         {{/* Note (bacongobbler): domains are separate from the default platform domain, */}}
         {{/* so we can't rely on deis.conf as each domain is an island */}}
-        {{ range $cert := $certs }}{{ if eq (Base $domain.Key) (Base $cert.Key) }}
+        {{ if index $root (printf "deis_certs_%s_cert" (Base $domain.Key)) }}
+        server_name_in_redirect off;
+        port_in_redirect off;
+        listen 80;
         listen 443 ssl spdy;
         ssl_certificate /etc/ssl/deis/certs/{{ Base $domain.Key }}.cert;
         ssl_certificate_key /etc/ssl/deis/keys/{{ Base $domain.Key }}.key;
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-        {{ end }}{{ end }}
+        {{/* if there's no app SSL cert but we have a router SSL cert, enable that instead */}}
+        {{/* TODO (bacongobbler): wait for https://github.com/kelseyhightower/confd/issues/270 */}}
+        {{/* so we can apply this config to just subdomains of the platform domain. */}}
+        {{/* ref: https://github.com/deis/deis/pull/3519 */}}
+        {{ else }}
+        include deis.conf;
+        {{ end }}
 
         {{ if $service.Nodes }}
         location / {


### PR DESCRIPTION
The idea behind not including deis.conf was so that custom domains which
are different from the platform domain would not attach the platform SSL
certificate when it was enabled. However, this has the side effect of
not attaching domains which are subdomains of the platform domain, which
is intentional.

A better fix would be to check if the domain is a subdomain of the platform domain but text/template or confd doesn't have `strings.Contains` included as a function.

closes #3470