### PR TITLE
ref(contrib): use merges for changelog summmaries

### DIFF
--- a/contrib/util/generate-changelog.sh
+++ b/contrib/util/generate-changelog.sh
@@ -24,7 +24,7 @@ retrieve() {
         # Echo all this in a way that makes the commit hash and message a link
         # to the commit in markdown
         echo ' -' "[\`$commit\`]($LINK)" "$SUBSYSTEM": "$MESSAGE"
-    done < <(git --no-pager log --oneline --no-merges --oneline --format="%h %H %s" --grep="$1" "$FROM".."$TO")
+    done < <(git --no-pager log --oneline --merges --oneline --format="%h %H %b" --grep="$1" "$FROM".."$TO")
     # Scrape the information from git
 }
 


### PR DESCRIPTION
Instead of using individual commits to generate the changelog, we can use the merged PRs which better reflects the changes in a release. 

*Edit* by @mboersma:
Closes #1416.

refs #3509 

For example, the new output:

```
><> ./contrib/util/generate-changelog.sh v1.5.0
### v1.5.0 -> HEAD

#### Features

 - [`fd3fc8e`](https://github.com/deis/deis/commit/fd3fc8e392e0abc361b77c51d1c5c23ebe4f0f3a) controller: add users:list endpoint
 - [`4070755`](https://github.com/deis/deis/commit/4070755d502729e3a247c80176cb2d6e15908f65) contrib/azure/azure-coreos-cluster: add an https enddpoint on c… …reation
 - [`ef3b89c`](https://github.com/deis/deis/commit/ef3b89c97e7be8fbb6c41f4f2bb4607b9ea3c2de) client: check controller before attempting to register. Fixes #3224

#### Fixes

 - [`8e960ca`](https://github.com/deis/deis/commit/8e960ca203bd5d8c48e129c4172dd2b13cdc4439) (all): use "confd --interval 5" instead of "--watch"
 - [`ce21c3b`](https://github.com/deis/deis/commit/ce21c3bfa1e71a140e9f5e259e37b1a97de5c54d) controller:  fix regex for deis limits
 - [`fa48fd2`](https://github.com/deis/deis/commit/fa48fd21e9aed44f7c50c43211b96dfa4c28f21e) controller:  remove domain
 - [`49d9002`](https://github.com/deis/deis/commit/49d9002e1cd2b1b0cac60c1aa6d3926c994fb3fb) builder: exit 1 when gitreceive captures a build
 - [`bd8b2df`](https://github.com/deis/deis/commit/bd8b2dff4b03efa66d77f22078f6d2ccceceb00f) router: use nginx $host in HTTPS redirects
 - [`def0d96`](https://github.com/deis/deis/commit/def0d9607e58cada0555a99ce86dd1e682954c8d) 'contrib/azure/azure-coreos-cluster': make this not found error more user friendly
 - [`e153834`](https://github.com/deis/deis/commit/e1538349fad1be04d906ecb04ce2f1674b3abfed) database+registry: check for S3 bucket name before creating it

#### Documentation

 - [`54757a0`](https://github.com/deis/deis/commit/54757a08e5f714789c0ead8307736849e2412136) contrib: organize community contributions
 - [`6fe16b1`](https://github.com/deis/deis/commit/6fe16b1f90b6902cd842c8d3567af60d135c7d50) installing_deis/aws: update AWS provisioning example output
 - [`b48ced3`](https://github.com/deis/deis/commit/b48ced3e3ad2c964634fcefd5f8cb56f712677a7) troubleshooting_deis: use private key on ssh -i
 - [`ce4f8c3`](https://github.com/deis/deis/commit/ce4f8c3b97e7f6c6289d80f4010096776c78bf8a) managing_deis: add upgrade Deis clients for in-place upgrade

#### Maintenance

 - [`6702716`](https://github.com/deis/deis/commit/670271697c236743dfcfd3e8d4f85f1fa6922d35) (all): bump confd to v0.9.0
 - [`82cf84c`](https://github.com/deis/deis/commit/82cf84c6c8c7bd6c898d98df41d8b325620106e2) controller: update docker-py to 1.1.0
 - [`1cdf41e`](https://github.com/deis/deis/commit/1cdf41e929d12f8f98c5ac638b1294c0243a9a9b) (all): update pip installer tool to 6.1.1
 - [`d120816`](https://github.com/deis/deis/commit/d1208162f232b1f7309b1dc4f2b98bcb76376233) contrib/ec2: introducing c4 instance types
 - [`da4408b`](https://github.com/deis/deis/commit/da4408b87eafce9c5d00e63bf0b716add1de3080) store: bump Ceph to "hammer" release
 - [`fb081f8`](https://github.com/deis/deis/commit/fb081f86cd1d9b5671bc489d71a64123d8d0fddd) client: update python-dateutil to 2.4.2
 - [`ae7adc1`](https://github.com/deis/deis/commit/ae7adc16f21a0eff5685d86627fdb8fe6c577d79) logspout: switch to busybox
```