### PR TITLE
feat(logger): expose config as flags

### DIFF
--- a/logger/README.md
+++ b/logger/README.md
@@ -10,19 +10,9 @@ the [Deis Project](https://github.com/deis/deis).
 
 ## Usage
 
-Please consult the [Makefile](Makefile) for current instructions on how to build, test, push,
-install, and start **deis/logger**.
-
-## Environment Variables
-
-* **DEBUG** enables verbose output if set
-* **ETCD_PORT** sets the TCP port on which to connect to the local etcd
-  daemon (default: *4001*)
-* **ETCD_PATH** sets the etcd directory where the logger announces
-  its configuration (default: */deis/logs*)
-* **ETCD_TTL** sets the time-to-live before etcd purges a configuration
-  value, in seconds (default: *10*)
-* **PORT** sets the TCP port on which the logger listens (default: *514*)
+```bash
+$ docker run deis/logger --help
+```
 
 ## License
 

--- a/logger/image/Dockerfile
+++ b/logger/image/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu-debootstrap:14.04
 
-CMD ["/bin/logger --publish"]
+ENTRYPOINT ["/bin/logger"]
+CMD ["--publish"]
 EXPOSE 514
 
 ADD . /

--- a/logger/image/Dockerfile
+++ b/logger/image/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu-debootstrap:14.04
 
 ENTRYPOINT ["/bin/logger"]
-CMD ["--publish"]
+CMD ["--enable-publish"]
 EXPOSE 514
 
 ADD . /

--- a/logger/image/Dockerfile
+++ b/logger/image/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu-debootstrap:14.04
 
-CMD ["/bin/logger"]
+CMD ["/bin/logger --publish"]
 EXPOSE 514
 
 ADD . /

--- a/logger/main.go
+++ b/logger/main.go
@@ -28,6 +28,7 @@ var (
 func init() {
 	flag.StringVar(&logAddr, "log-addr", "0.0.0.0", "bind address for the logger")
 	flag.IntVar(&logPort, "log-port", 514, "bind port for the logger")
+	flag.StringVar(&syslogd.LogRoot, "log-root", "/data/logs", "log path to store logs")
 	flag.BoolVar(&enablePublish, "publish", false, "enable publishing to service discovery")
 	flag.StringVar(&publishHost, "publish-host", getopt("HOST", "127.0.0.1"), "service discovery hostname")
 	flag.IntVar(&publishInterval, "publish-interval", 10, "publish interval in seconds")

--- a/logger/main.go
+++ b/logger/main.go
@@ -29,7 +29,7 @@ func init() {
 	flag.StringVar(&logAddr, "log-addr", "0.0.0.0", "bind address for the logger")
 	flag.IntVar(&logPort, "log-port", 514, "bind port for the logger")
 	flag.StringVar(&syslogd.LogRoot, "log-root", "/data/logs", "log path to store logs")
-	flag.BoolVar(&enablePublish, "publish", false, "enable publishing to service discovery")
+	flag.BoolVar(&enablePublish, "enable-publish", false, "enable publishing to service discovery")
 	flag.StringVar(&publishHost, "publish-host", getopt("HOST", "127.0.0.1"), "service discovery hostname")
 	flag.IntVar(&publishInterval, "publish-interval", 10, "publish interval in seconds")
 	flag.StringVar(&publishPath, "publish-path", getopt("ETCD_PATH", "/deis/logs"), "path to publish host/port information")

--- a/logger/main.go
+++ b/logger/main.go
@@ -13,6 +13,7 @@ import (
 )
 
 var (
+	enablePublish bool
 	publishHost   string
 	publishPath   string
 	publishPort   string
@@ -21,6 +22,7 @@ var (
 )
 
 func init() {
+	flag.BoolVar(&enablePublish, "publish", false, "enable publishing to service discovery")
 	flag.IntVar(&publishInterval, "publish-interval", 10, "publish interval in seconds")
 	flag.StringVar(&publishHost, "publish-host", getopt("HOST", "127.0.0.1"), "service discovery hostname")
 	flag.StringVar(&publishPath, "publish-path", getopt("ETCD_PATH", "/deis/logs"), "path to publish host/port information")
@@ -42,7 +44,9 @@ func main() {
 
 	go syslogd.Listen(exitChan, cleanupChan)
 
-	go publishService(client, publishHost, publishPath, externalPort, uint64(time.Duration(publishTTL).Seconds()))
+	if enablePublish {
+		go publishService(client, publishHost, publishPath, externalPort, uint64(time.Duration(publishTTL).Seconds()))
+	}
 
 	// Wait for the proper shutdown of the syslog server before exit
 	<-cleanupChan

--- a/logger/syslogd/syslogd.go
+++ b/logger/syslogd/syslogd.go
@@ -97,7 +97,7 @@ func (h *handler) mainLoop() {
 }
 
 // Listen starts a new syslog server which runs until it receives a signal.
-func Listen(signalChan chan os.Signal, cleanupDone chan bool) {
+func Listen(signalChan chan os.Signal, cleanupDone chan bool, bindAddr string) {
 	fmt.Println("Starting syslog...")
 	// If logRoot doesn't exist, create it
 	// equivalent to Python's `if not os.path.exists(filename)`
@@ -109,7 +109,7 @@ func Listen(signalChan chan os.Signal, cleanupDone chan bool) {
 	// Create a server with one handler and run one listen gorutine
 	s := syslog.NewServer()
 	s.AddHandler(newHandler())
-	s.Listen("0.0.0.0:514")
+	s.Listen(bindAddr)
 	fmt.Println("Syslog server started...")
 	fmt.Println("deis-logger running")
 

--- a/logger/syslogd/syslogd.go
+++ b/logger/syslogd/syslogd.go
@@ -13,7 +13,7 @@ import (
 	"github.com/deis/deis/logger/drain"
 )
 
-const logRoot = "/data/logs"
+var LogRoot string
 
 type handler struct {
 	// To simplify implementation of our handler we embed helper
@@ -51,7 +51,7 @@ func getLogFile(message string) (io.Writer, error) {
 		return nil, fmt.Errorf("Could not find app name in message: %s", message)
 	}
 	appName := match[1]
-	filePath := path.Join(logRoot, appName+".log")
+	filePath := path.Join(LogRoot, appName+".log")
 	// check if file exists
 	exists, err := fileExists(filePath)
 	if err != nil {
@@ -99,11 +99,11 @@ func (h *handler) mainLoop() {
 // Listen starts a new syslog server which runs until it receives a signal.
 func Listen(signalChan chan os.Signal, cleanupDone chan bool, bindAddr string) {
 	fmt.Println("Starting syslog...")
-	// If logRoot doesn't exist, create it
+	// If LogRoot doesn't exist, create it
 	// equivalent to Python's `if not os.path.exists(filename)`
-	if _, err := os.Stat(logRoot); os.IsNotExist(err) {
-		if err = os.MkdirAll(logRoot, 0777); err != nil {
-			log.Fatalf("unable to create logRoot at %s", logRoot)
+	if _, err := os.Stat(LogRoot); os.IsNotExist(err) {
+		if err = os.MkdirAll(LogRoot, 0777); err != nil {
+			log.Fatalf("unable to create LogRoot at %s: %v", LogRoot, err)
 		}
 	}
 	// Create a server with one handler and run one listen gorutine

--- a/logger/tests/logger_test.go
+++ b/logger/tests/logger_test.go
@@ -32,7 +32,7 @@ func TestLogger(t *testing.T) {
 			"--rm",
 			"-p", port+":514/udp",
 			imageName,
-			"--publish",
+			"--enable-publish",
 			"--log-port="+port,
 			"--publish-host="+host,
 			"--publish-port="+etcdPort)

--- a/logger/tests/logger_test.go
+++ b/logger/tests/logger_test.go
@@ -31,10 +31,11 @@ func TestLogger(t *testing.T) {
 			"--name", name,
 			"--rm",
 			"-p", port+":514/udp",
-			"-e", "EXTERNAL_PORT="+port,
-			"-e", "HOST="+host,
-			"-e", "ETCD_PORT="+etcdPort,
-			imageName)
+			imageName,
+			"--publish",
+			"--log-port="+port,
+			"--publish-host="+host,
+			"--publish-port="+etcdPort)
 	}()
 	dockercli.PrintToStdout(t, stdout, stdoutPipe, "deis-logger running")
 	if err != nil {


### PR DESCRIPTION
So I was trying to look around for a syslog server to store logs on some of my remote machines so I can test the Docker 1.6 changes and I thought to myself... "Hey, deis built one of those!" So this PR is a general enhancement to the logger itself. These enhancements are a no-op to the existing logger, but exposes flags to the end-user such that it's possible to extend the logger to the user's content.

Along with exposing common configuration as feature flags, this PR includes a feature flag for enabling/disabling publishing to service discovery (etcd). In some cases where you are running the logger in a local environment, you don't require the need to publish the logger to etcd. By default this is set to false, but I've enabled it in the Dockerfile so it's a no-op for Deis.

This doesn't need to be merged as it does not really affect Deis, but it does increase the value of the logger to be adopted by non-Deis platforms. Woo open source! :fireworks: 