### PR TITLE
feat(client): add optional path to config:push

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -1325,7 +1325,7 @@ Make sure that the Controller URI is correct and the server is running.
         The environment is read from <path>. This file can be read by foreman
         to load the local environment for your app.
 
-        Usage: deis config:push [<path>] [options]
+        Usage: deis config:push [options]
 
         Options:
           -a --app=<app>

--- a/client/deis.py
+++ b/client/deis.py
@@ -1342,7 +1342,7 @@ Make sure that the Controller URI is correct and the server is running.
             with open(args.get('--path'), 'r') as f:
                 self._config_set(app, dictify([line.strip() for line in f]))
         except IOError:
-            self._logger.error('could not read env from ' + env_file)
+            self._logger.error('could not read env from ' + args.get('--path'))
             sys.exit(1)
 
     def domains(self, args):

--- a/client/deis.py
+++ b/client/deis.py
@@ -1322,10 +1322,8 @@ Make sure that the Controller URI is correct and the server is running.
         """
         Sets environment variables for an application.
 
-        Your environment is read from the optionally specified path to a
-        .env-formatted file. If no path is specified, your environment is read
-        from a file named .env. This file can be read by foreman to load the
-        local environment for your app.
+        The environment is read from <path>. This file can be read by foreman
+        to load the local environment for your app.
 
         Usage: deis config:push [<path>] [options]
 

--- a/client/deis.py
+++ b/client/deis.py
@@ -1327,24 +1327,19 @@ Make sure that the Controller URI is correct and the server is running.
 
         Usage: deis config:push [<path>] [options]
 
-        Arguments:
-          <path>
-            a path leading to an environment file
-
         Options:
           -a --app=<app>
             the uniquely identifiable name for the application.
+          -p <path>, --path=<path>
+            a path leading to an environment file [default: .env]
         """
-        env_file = '.env'
-        if args.get('<path>'):
-            env_file = args.get('<path>')
         app = args.get('--app')
         if not app:
             app = self._session.app
 
         # read from .env
         try:
-            with open(env_file, 'r') as f:
+            with open(args.get('--path'), 'r') as f:
                 self._config_set(app, dictify([line.strip() for line in f]))
         except IOError:
             self._logger.error('could not read env from ' + env_file)

--- a/client/deis.py
+++ b/client/deis.py
@@ -1176,6 +1176,7 @@ Make sure that the Controller URI is correct and the server is running.
         app = args.get('--app')
         if not app:
             app = self._session.app
+
         values = dictify(args['<var>=<value>'])
         if values.get('SSH_KEY'):
             if os.path.isfile(values.get('SSH_KEY')):
@@ -1321,24 +1322,34 @@ Make sure that the Controller URI is correct and the server is running.
         """
         Sets environment variables for an application.
 
-        Your environment is read from a file named .env. This file can be
-        read by foreman to load the local environment for your app.
+        Your environment is read from the optionally specified path to a
+        .env-formatted file. If no path is specified, your environment is read
+        from a file named .env. This file can be read by foreman to load the
+        local environment for your app.
 
-        Usage: deis config:push [options]
+        Usage: deis config:push [<path>] [options]
+
+        Arguments:
+          <path>
+            a path leading to an environment file
 
         Options:
           -a --app=<app>
             the uniquely identifiable name for the application.
         """
+        env_file = '.env'
+        if args.get('<path>'):
+            env_file = args.get('<path>')
         app = args.get('--app')
         if not app:
             app = self._session.app
+
         # read from .env
         try:
-            with open('.env', 'r') as f:
+            with open(env_file, 'r') as f:
                 self._config_set(app, dictify([line.strip() for line in f]))
         except IOError:
-            self._logger.error('could not read from local env')
+            self._logger.error('could not read env from ' + env_file)
             sys.exit(1)
 
     def domains(self, args):


### PR DESCRIPTION
Implement #3423 allowing users to optionally specify a path to an environment file for config:push.

*edit carmstrong*
closes #3423