### PR TITLE
fix(controller): return the correct domain from get_object()

### DIFF
--- a/controller/api/tests/test_domain.py
+++ b/controller/api/tests/test_domain.py
@@ -7,7 +7,6 @@ Run the tests with "./manage.py test api"
 from __future__ import unicode_literals
 
 import json
-import unittest
 
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -102,7 +101,6 @@ class DomainTest(TestCase):
         with self.assertRaises(Domain.DoesNotExist):
             Domain.objects.get(domain=test_domains[0])
 
-    @unittest.skip(".get_object() returns all domains instead of the requested domain")
     def test_delete_domain_does_not_remove_others(self):
         """https://github.com/deis/deis/issues/3475"""
         self.test_delete_domain_does_not_remove_latest()

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -218,7 +218,8 @@ class DomainViewSet(AppResourceViewSet):
     serializer_class = serializers.DomainSerializer
 
     def get_object(self, **kwargs):
-        return self.get_queryset(**kwargs)
+        qs = self.get_queryset(**kwargs)
+        return qs.get(domain=self.kwargs['domain'])
 
 
 class CertificateViewSet(BaseDeisViewSet):


### PR DESCRIPTION
The Django view helper method `get_object` was returning a queryset rather than the `Domain` model instance.

Thanks to @bacongobbler for starting this with a unit test. :green_heart: 

Closes #3475, refs #3499.