### PR TITLE
fix(client): use pyOpenSSL for improved security features

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -1,6 +1,6 @@
 
 build: setup-venv
-	venv/bin/pip install docopt==0.6.2 ndg-httpsclient==0.3.3 pyasn1==0.1.7 pyOpenSSL==0.15.1 python-dateutil==2.4.2 PyYAML==3.11 requests==2.5.1 git+https://github.com/pyinstaller/pyinstaller@7413317 tabulate==0.7.4 termcolor==1.1.0 urllib3==1.10.2
+	venv/bin/pip install -r requirements.txt git+https://github.com/pyinstaller/pyinstaller@7413317
 	venv/bin/pyinstaller deis.spec
 	chmod +x dist/deis
 
@@ -16,9 +16,6 @@ uninstall:
 clean:
 	rm -rf build/ dist/ *.egg-info
 
-client:
-	pyinstaller deis.spec
-
 installer: build
 	@if [ ! -d makeself ]; then git clone -b single-binary https://github.com/deis/makeself.git; fi
 	PATH=./makeself:$$PATH BINARY=deis makeself.sh --bzip2 --current --nox11 dist \
@@ -32,9 +29,9 @@ installer: build
 
 setup-venv:
 	@if [ ! -d venv ]; then virtualenv venv; fi
-	venv/bin/pip install -q flake8==2.4.0
 
 test-style: setup-venv
+	venv/bin/pip install -q flake8==2.4.0
 	venv/bin/flake8
 
 test-unit:

--- a/client/Makefile
+++ b/client/Makefile
@@ -1,6 +1,6 @@
 
 build: setup-venv
-	venv/bin/pip install docopt==0.6.2 python-dateutil==2.4.2 PyYAML==3.11 requests==2.5.1 git+https://github.com/pyinstaller/pyinstaller@7413317 tabulate==0.7.4 termcolor==1.1.0
+	venv/bin/pip install docopt==0.6.2 ndg-httpsclient==0.3.3 pyasn1==0.1.7 pyOpenSSL==0.15.1 python-dateutil==2.4.2 PyYAML==3.11 requests==2.5.1 git+https://github.com/pyinstaller/pyinstaller@7413317 tabulate==0.7.4 termcolor==1.1.0 urllib3==1.10.2
 	venv/bin/pyinstaller deis.spec
 	chmod +x dist/deis
 

--- a/client/deis.py
+++ b/client/deis.py
@@ -72,6 +72,7 @@ from docopt import DocoptExit
 import requests
 from tabulate import tabulate
 from termcolor import colored
+import urllib3.contrib.pyopenssl
 
 __version__ = '1.6.0-dev'
 
@@ -80,6 +81,7 @@ __api_version__ = '1.3'
 
 
 locale.setlocale(locale.LC_ALL, '')
+urllib3.contrib.pyopenssl.inject_into_urllib3()
 
 
 class Session(requests.Session):

--- a/client/deis.spec
+++ b/client/deis.spec
@@ -14,4 +14,4 @@ exe = EXE(pyz,
           debug=False,
           strip=None,
           upx=True,
-          console=True )
+          console=True)

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,0 +1,12 @@
+# Deis CLI requirements
+
+docopt==0.6.2
+ndg-httpsclient==0.3.3
+pyasn1==0.1.7
+pyOpenSSL==0.15.1
+python-dateutil==2.4.2
+PyYAML==3.11
+requests==2.5.1
+tabulate==0.7.4
+termcolor==1.1.0
+urllib3==1.10.2

--- a/client/setup.py
+++ b/client/setup.py
@@ -27,6 +27,11 @@ else:
     KWARGS = {'scripts': ['deis']}
 
 
+with open('requirements.txt') as f:
+    required = f.read().splitlines()
+    required = [r for r in required if r.strip() and not r.startswith('#')]
+
+
 setup(name='deis',
       version='1.6.0-dev',
       license=APACHE_LICENSE,
@@ -56,12 +61,6 @@ setup(name='deis',
           ('.', ['README.rst']),
       ],
       long_description=LONG_DESCRIPTION,
-      install_requires=[
-          'docopt==0.6.2', 'ndg-httpsclient==0.3.3',
-          'pyasn1==0.1.7', 'pyOpenSSL==0.15.1',
-          'python-dateutil==2.4.2', 'PyYAML==3.11',
-          'requests==2.5.1', 'tabulate==0.7.4',
-          'termcolor==1.1.0', 'urllib3==1.10.2',
-      ],
+      install_requires=required,
       zip_safe=True,
       **KWARGS)

--- a/client/setup.py
+++ b/client/setup.py
@@ -57,9 +57,11 @@ setup(name='deis',
       ],
       long_description=LONG_DESCRIPTION,
       install_requires=[
-          'docopt==0.6.2', 'python-dateutil==2.4.2',
-          'PyYAML==3.11', 'requests==2.5.1',
-          'tabulate==0.7.4', 'termcolor==1.1.0'
+          'docopt==0.6.2', 'ndg-httpsclient==0.3.3',
+          'pyasn1==0.1.7', 'pyOpenSSL==0.15.1',
+          'python-dateutil==2.4.2', 'PyYAML==3.11',
+          'requests==2.5.1', 'tabulate==0.7.4',
+          'termcolor==1.1.0', 'urllib3==1.10.2',
       ],
       zip_safe=True,
       **KWARGS)

--- a/controller/dev_requirements.txt
+++ b/controller/dev_requirements.txt
@@ -1,28 +1,5 @@
-# Deis client requirements
-docopt==0.6.2
-ndg-httpsclient==0.3.3
-pyasn1==0.1.7
-pyOpenSSL==0.15.1
-python-dateutil==2.4.2
-PyYAML==3.11
-requests==2.5.1
-tabulate==0.7.4
-termcolor==1.1.0
-urllib3==1.10.2
-
-# PyInstaller builds client binaries
-git+https://github.com/pyinstaller/pyinstaller@7413317
-
-# Deis documentation requirements
-Sphinx==1.3.1
-smartypants==1.8.6
-sphinxcontrib-httpdomain==1.3.0
-
-# Run "make coverage" for the % of code exercised during tests
+# Run "make coverage" or "make test-unit" for the % of code exercised during tests
 coverage>=3.7.1
-
-# Generates template documentation in the Django admin
-docutils>=0.12
 
 # Run "make flake8" to check python syntax and style
 flake8==2.4.0

--- a/controller/dev_requirements.txt
+++ b/controller/dev_requirements.txt
@@ -1,8 +1,14 @@
 # Deis client requirements
 docopt==0.6.2
+ndg-httpsclient==0.3.3
+pyasn1==0.1.7
+pyOpenSSL==0.15.1
 python-dateutil==2.4.2
+PyYAML==3.11
 requests==2.5.1
+tabulate==0.7.4
 termcolor==1.1.0
+urllib3==1.10.2
 
 # PyInstaller builds client binaries
 git+https://github.com/pyinstaller/pyinstaller@7413317

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -25,10 +25,15 @@ python-ldap==2.4.19
 
 # Deis client requirements
 docopt==0.6.2
+ndg-httpsclient==0.3.3
+pyasn1==0.1.7
+pyOpenSSL==0.15.1
 python-dateutil==2.4.2
+#PyYAML==3.11
 requests==2.5.1
 tabulate==0.7.4
 termcolor==1.1.0
+urllib3==1.10.2
 
 # Deis documentation requirements
 Sphinx==1.3.1

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -23,7 +23,7 @@ PyYAML==3.11
 South==1.0.2
 python-ldap==2.4.19
 
-# Deis client requirements
+# Deis client requirements, copied from client/requirements.txt
 docopt==0.6.2
 ndg-httpsclient==0.3.3
 pyasn1==0.1.7

--- a/tests/bin/build-deis-cli.sh
+++ b/tests/bin/build-deis-cli.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-#
-# Creates a python virtual environment and builds the `deis` client binary with it.
-
-virtualenv --system-site-packages venv
-. venv/bin/activate
-pip install docopt==0.6.2 python-dateutil==2.4.1 PyYAML==3.11 requests==2.5.1 git+https://github.com/pyinstaller/pyinstaller@7413317 termcolor==1.1.0
-make -C client/ client


### PR DESCRIPTION
Recently urllib3 began [emitting these warnings](https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning) pointing to limitations in python's `ssl` that could create vulnerabilities. It's not easy to require Python 2.7.9 for all dev users and our build environment, so [using `pyOpenSSL`](https://urllib3.readthedocs.org/en/latest/security.html#pyopenssl) is the other recommended fix, which is what this PR does. 

This also moves `deis` CLI libraries to `client/requirements.txt` and cleans up a dead Makefile target and test script.

Closes #3253, refs #3512.