### PR TITLE
fix(controller): allow "*" wildcard in cert REST URLs

### DIFF
--- a/controller/api/tests/test_certificate.py
+++ b/controller/api/tests/test_certificate.py
@@ -110,3 +110,11 @@ thejiQz0ThCMBw7QMpVOiSvYAlQG0ATsRYwdTDqENIWKlerOLCSuxmbqe8XeDKhq
         url = '/v1/certs/autotest.example.com'
         response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 204)
+        # deleting a wildcard cert should work too (even though they're unsupported right now)
+        # https://github.com/deis/deis/issues/3533
+        Certificate.objects.create(owner=self.user,
+                                   common_name='*.example.com',
+                                   certificate=self.autotest_example_com_cert)
+        url = '/v1/certs/*.example.com'
+        response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.assertEqual(response.status_code, 204)

--- a/controller/api/urls.py
+++ b/controller/api/urls.py
@@ -82,7 +82,7 @@ urlpatterns = patterns(
         views.AdminPermsViewSet.as_view({'delete': 'destroy'})),
     url(r'^admin/perms/?',
         views.AdminPermsViewSet.as_view({'get': 'list', 'post': 'create'})),
-    url(r'^certs/(?P<common_name>[-_.\w]+)/?'.format(settings.APP_URL_REGEX),
+    url(r'^certs/(?P<common_name>[-_*.\w]+)/?'.format(settings.APP_URL_REGEX),
         views.CertificateViewSet.as_view({'get': 'retrieve', 'delete': 'destroy'})),
     url(r'^certs/?',
         views.CertificateViewSet.as_view({'get': 'list', 'post': 'create'})),


### PR DESCRIPTION
One of the regular expressions for `Certificate` endpoints wasn't allowing `*` through, so wildcard certs could be created but not deleted. This relaxes the regex to allow such certs to be deleted. Thanks to @bacongobbler for the test! :green_heart: 

Note that wildcard certificates aren't fully supported yet, but users should still be able to delete them.

Closes #3533.