### PR TITLE
feat(router): allow sticky or persistent sessions in nginx

### DIFF
--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -144,6 +144,7 @@ http {
     {{ $domains := .deis_domains }}
     {{ range $service := .deis_services }}{{ if $service.Nodes }}
     upstream {{ Base $service.Key }} {
+	ip_hash;
         {{ if $affinityArg }}hash $arg_{{ $affinityArg }} consistent;
         {{ end }}
         {{ range $upstream := $service.Nodes }}server {{ $upstream.Value }};


### PR DESCRIPTION
This allows clients to be tied to the same application server and allow
sessions to be maintained

Noticed that the apps that were scaled to more than one container were asking for login upon every requests.
This is just a modest attempt.
Thanks