### PR TITLE
feat(Makefile): Add a command to start a local postgresql container for running unit tests

### DIFF
--- a/controller/Makefile
+++ b/controller/Makefile
@@ -50,6 +50,14 @@ deploy: build dev-release restart
 runserver:
 	python manage.py runserver
 
+postgres:
+	docker start postgres || docker run --restart="always" -d -p 5432:5432 --name postgres postgres:9.4.1
+	docker exec postgres createdb -U postgres deis 2>/dev/null || true
+	@echo "To use postgres for local development:"
+	@echo "    export PGHOST=`boot2docker ip 2>/dev/null || echo 127.0.0.1`"
+	@echo "    export PGPORT=5432"
+	@echo "    export PGUSER=postgres"
+
 db:
 	python manage.py syncdb --migrate --noinput
 


### PR DESCRIPTION
`make -C controller postgres` will start up a PostgreSQL container you can use to run unit tests. Useful for people without PostgreSQL installed or who don't want to mess with their local database. Exporting the variables printed by the command will allow the controller to connect to the specified database.