### PR TITLE
fix(router): Unify timeout values

### DIFF
--- a/docs/customizing_deis/router_settings.rst
+++ b/docs/customizing_deis/router_settings.rst
@@ -39,6 +39,7 @@ setting                                      description
 /deis/domains/*                              domain configuration for applications (set by controller)
 /deis/router/affinityArg                     for requests with the indicated query string variable, hash its contents to perform session affinity (default: undefined)
 /deis/router/bodySize                        nginx body size setting (default: 1m)
+/deis/router/defaultTimeout                  default timeout value in seconds. Should be greater then the frontfacing load balancers timeout value (default: 1300)
 /deis/router/builder/timeout/connect         proxy_connect_timeout for deis-builder (default: 10000). Unit in miliseconds
 /deis/router/builder/timeout/read            proxy_read_timeout for deis-builder (default: 1200000). Unit in miliseconds
 /deis/router/builder/timeout/send            proxy_send_timeout for deis-builder (default: 1200000). Unit in miliseconds

--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -15,7 +15,11 @@ http {
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;
-    keepalive_timeout 65;
+
+    # The Timeout value must be greater than the front facing load balancers timeout value.
+    # Default is the deis recommended timeout value for ELB - 1200 seconds + 100s extra.
+    {{ $defaultTimeout := or (.deis_router_defaultTimeout) "1300" }}
+    keepalive_timeout {{ $defaultTimeout }};
 
     types_hash_max_size 2048;
     server_names_hash_max_size {{ or (.deis_router_serverNameHashMaxSize) "512" }};
@@ -125,8 +129,8 @@ http {
             proxy_set_header            X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_redirect              off;
             proxy_connect_timeout       10s;
-            proxy_send_timeout          1200s;
-            proxy_read_timeout          1200s;
+            proxy_send_timeout          {{ $defaultTimeout }}s;
+            proxy_read_timeout          {{ $defaultTimeout }}s;
 
             proxy_pass                  http://deis-store-gateway;
         }
@@ -194,8 +198,8 @@ http {
             proxy_set_header            X-Forwarded-Ssl   $access_ssl;
             proxy_redirect              off;
             proxy_connect_timeout       30s;
-            proxy_send_timeout          1200s;
-            proxy_read_timeout          1200s;
+            proxy_send_timeout          {{ $defaultTimeout }}s;
+            proxy_read_timeout          {{ $defaultTimeout }}s;
             proxy_http_version          1.1;
             proxy_set_header            Upgrade           $http_upgrade;
             proxy_set_header            Connection        $connection_upgrade;
@@ -244,8 +248,8 @@ http {
             proxy_set_header            X-Forwarded-Ssl   $access_ssl;
             proxy_redirect              off;
             proxy_connect_timeout       30s;
-            proxy_send_timeout          1200s;
-            proxy_read_timeout          1200s;
+            proxy_send_timeout          {{ $defaultTimeout }}s;
+            proxy_read_timeout          {{ $defaultTimeout }}s;
             proxy_http_version          1.1;
             proxy_set_header            Upgrade           $http_upgrade;
             proxy_set_header            Connection        $connection_upgrade;


### PR DESCRIPTION
The router was having different timeout values for keepalive_timeout
and for proxy timeouts.

This can cause issues with front facing load balancers in front of
deis-router (like Amazon ELB), and could be the cause of issue #3448

Timeout values should be greater than the timeout value of the front facing
load balancer. 

**Ref:**

> The keepalive timeout value on your backend server must be higher than that
> of your ELB connection timeout. If it is lower, the ELB will re-use the idle
> connection when your server has already dropped the connection, resulting in
> the client being served up a blank response.

http://engineering.chartbeat.com/2014/02/12/part-2-lessons-learned-tuning-tcp-and-nginx-in-ec2/

> The ELB timeout should be set to less then the backend server idle timeout.

https://forums.aws.amazon.com/thread.jspa?threadID=104688