### PR TITLE
feat(controller): support SAN certificates

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -1043,18 +1043,35 @@ Make sure that the Controller URI is correct and the server is running.
         """
         Binds a certificate/key pair to an application.
 
-        Usage: deis certs:add <cert> <key>
+        Usage: deis certs:add <cert> <key> [--subject-alt-name=<san>...] [options]
 
         Arguments:
           <cert>
             The public key of the SSL certificate.
           <key>
             The private key of the SSL certificate.
+
+        Options:
+          --common-name=<cname>
+            The common name of the certificate. If none is provided, the controller will
+            interpret the common name from the certificate.
+          --subject-alt-name=<san>...
+            The subject alternate names (SAN) of the certificate. This will create multiple
+            Certificate objects in the controller, one for each SAN.
         """
         cert = args.get('<cert>')
         key = args.get('<key>')
+        self._certs_add(cert, key, args.get('--common-name'))
+        for san in args.get('--subject-alt-name'):
+            self._certs_add(cert, key, san)
+
+    def _certs_add(self, cert, key, common_name=None):
         body = {'certificate': file(cert).read().strip(), 'key': file(key).read().strip()}
-        sys.stdout.write("Adding SSL endpoint... ")
+        if common_name:
+            body['common_name'] = common_name
+            sys.stdout.write("Adding SSL endpoint {}...".format(common_name))
+        else:
+            sys.stdout.write("Adding SSL endpoint... ")
         sys.stdout.flush()
         try:
             progress = TextProgress()
@@ -1066,7 +1083,8 @@ Make sure that the Controller URI is correct and the server is running.
         if response.status_code == requests.codes.created:
             self._logger.info("done")
             data = response.json()
-            self._logger.info("{common_name}".format(**data))
+            if not common_name:
+                self._logger.info("{common_name}".format(**data))
         else:
             raise ResponseError(response)
 

--- a/client/deis.py
+++ b/client/deis.py
@@ -1043,7 +1043,7 @@ Make sure that the Controller URI is correct and the server is running.
         """
         Binds a certificate/key pair to an application.
 
-        Usage: deis certs:add <cert> <key> [--subject-alt-name=<san>...] [options]
+        Usage: deis certs:add <cert> <key> [options]
 
         Arguments:
           <cert>
@@ -1055,15 +1055,16 @@ Make sure that the Controller URI is correct and the server is running.
           --common-name=<cname>
             The common name of the certificate. If none is provided, the controller will
             interpret the common name from the certificate.
-          --subject-alt-name=<san>...
-            The subject alternate names (SAN) of the certificate. This will create multiple
-            Certificate objects in the controller, one for each SAN.
+          --subject-alt-names=<sans>
+            The subject alternate names (SAN) of the certificate, separated by commas. This will
+            create multiple Certificate objects in the controller, one for each SAN.
         """
         cert = args.get('<cert>')
         key = args.get('<key>')
         self._certs_add(cert, key, args.get('--common-name'))
-        for san in args.get('--subject-alt-name'):
-            self._certs_add(cert, key, san)
+        sans = args.get('--subject-alt-names')
+        if sans:
+            [self._certs_add(cert, key, san) for san in sans.split(',')]
 
     def _certs_add(self, cert, key, common_name=None):
         body = {'certificate': file(cert).read().strip(), 'key': file(key).read().strip()}

--- a/controller/api/serializers.py
+++ b/controller/api/serializers.py
@@ -275,8 +275,9 @@ class CertificateSerializer(ModelSerializer):
         """Metadata options for a DomainCertSerializer."""
         model = models.Certificate
         extra_kwargs = {'certificate': {'write_only': True},
-                        'key': {'write_only': True}}
-        read_only_fields = ['common_name', 'expires', 'created', 'updated']
+                        'key': {'write_only': True},
+                        'common_name': {'required': False}}
+        read_only_fields = ['expires', 'created', 'updated']
 
 
 class PushSerializer(ModelSerializer):

--- a/controller/api/tests/test_certificate.py
+++ b/controller/api/tests/test_certificate.py
@@ -80,6 +80,20 @@ thejiQz0ThCMBw7QMpVOiSvYAlQG0ATsRYwdTDqENIWKlerOLCSuxmbqe8XeDKhq
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
 
+    def test_create_certificate_with_different_common_name(self):
+        """
+        In some cases such as with SAN certificates, the certificate can cover more
+        than a single domain. In that case, we want to be able to specify the common
+        name for the certificate/key.
+        """
+        body = {'certificate': self.autotest_example_com_cert,
+                'key': self.key,
+                'common_name': 'foo.example.com'}
+        response = self.client.post(self.url, json.dumps(body), content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data['common_name'], 'foo.example.com')
+
     def test_get_certificate_screens_data(self):
         """
         When a user retrieves a certificate, only the common name and expiry date should be

--- a/docs/reference/api-v1.3.rst
+++ b/docs/reference/api-v1.3.rst
@@ -14,6 +14,7 @@ What's New
 
 **New!** ``/users`` endpoint for listing users
 **New!** ``/logs`` endpoint now has a option for limiting the number of log lines returned
+**New!** ``/certs`` endpoint now has an optional parameter to set the common name for a certificate
 
 
 Authentication
@@ -383,6 +384,14 @@ Example Request:
     {
         "certificate": "-----BEGIN CERTIFICATE-----",
         "key": "-----BEGIN RSA PRIVATE KEY-----"
+    }
+
+Optional Parameters:
+
+.. code-block:: console
+
+    {
+        "common_name": "test.example.com"
     }
 
 


### PR DESCRIPTION
This feature allows a user to specify a list of SubjectAltNames (SANs)
for a specified certificate. This has the effect of creating multiple
certificate entries in the database (one for each SAN), but it gives the
user the benefit to revoke the certficate for each custom domain.

By default, SANs are **not** added as new entries with `certs:add`. The
user will need to explicitly give each subject alt name they wish to add
as a certificate.

Usage:

```
$ deis certs:add ~/.openssl/star.fishworks.io.cert ~/.openssl/private.key.nopass --subject-alt-name foo.fishworks.io --subject-alt-name bar.fishworks.io
Adding SSL endpoint... done
*.fishworks.io
Adding SSL endpoint foo.fishworks.io...done
Adding SSL endpoint bar.fishworks.io...done
$ deis certs
Common Name       Expires
----------------  ----------------------
*.fishworks.io    2015-08-29T08:17:48UTC
foo.fishworks.io  2015-08-29T08:17:48UTC
bar.fishworks.io  2015-08-29T08:17:48UTC
```

In order for users to update their certificate, they will need to run
`deis certs:remove` for each entry, then re-run `deis certs:add`.

Docopt does not respect ellipsis when '[options]' is present, so I had
to explicitly write out the option in the usage in order for the flag to
work.

Additionally, a new --common-name flag has also been introduced. This is
a temporary workaround for users to add their wildcard certificates to
their custom domain endpoints. This acts the same way where a database
entry is created for each call to `certs:add`. If users want to update
their wildcard certificate, they'll have to update each entry they've
added. This is not the optimal solution, but it provides a way for us to
support wildcard certificates for custom domains.

Usage:

```
$ deis certs:add ~/.openssl/star.fishworks.io.cert ~/.openssl/private.key.nopass --common-name foo.fishworks.io
Adding SSL endpoint foo.fishworks.io...done
$ deis certs
Common Name       Expires
----------------  ----------------------
foo.fishworks.io  2015-08-29T08:17:48UTC
```

closes #3441