### PR TITLE
chore(builder): migrate to heroku's cedar stack

### DIFF
--- a/builder/Makefile
+++ b/builder/Makefile
@@ -74,8 +74,3 @@ test-style:
 	@$(GOFMT) $(GO_PACKAGES) $(GO_FILES) | read; if [ $$? == 0 ]; then echo "gofmt check failed."; exit 1; fi
 	$(GOVET) $(repo_path) $(GO_PACKAGES_REPO_PATH)
 	$(GOLINT) ./...
-
-cedarish/build:
-	mkdir -p build
-	docker pull progrium/cedarish:latest
-	docker save progrium/cedarish:latest | gzip -9 > build/progrium_cedarish_$(shell date "+%Y_%m_%d").tar.gz

--- a/builder/image/Dockerfile
+++ b/builder/image/Dockerfile
@@ -38,11 +38,6 @@ RUN useradd -d $GITHOME $GITUSER
 RUN mkdir -p $GITHOME/.ssh && chown git:git $GITHOME/.ssh
 RUN chown -R $GITUSER:$GITUSER $GITHOME
 
-# HACK: import progrium/cedarish as a tarball
-# see https://github.com/deis/deis/issues/1027
-RUN curl -#SL -o /progrium_cedarish.tar.gz \
-    https://github.com/progrium/cedarish/releases/download/v3/cedarish-cedar14_v3.tar.gz
-
 # define the execution environment
 # use VOLUME to remove /var/lib/docker from copy-on-write for performance
 # we don't want to stack overlay filesystems

--- a/builder/image/bin/boot
+++ b/builder/image/bin/boot
@@ -69,15 +69,6 @@ while [[ ! -e /var/run/docker.sock ]]; do
   sleep 1
 done
 
-# HACK: load progrium/cedarish tarball for faster boot times
-# see https://github.com/deis/deis/issues/1027
-if ! docker history progrium/cedarish >/dev/null 2>/dev/null ; then
-    echo "Loading cedarish..."
-    cat /progrium_cedarish.tar.gz | docker import - progrium/cedarish
-else
-    echo "Cedarish already loaded"
-fi
-
 # build required images
 docker build -t deis/slugbuilder /app/slugbuilder/
 docker build -t deis/slugrunner /app/slugrunner/

--- a/builder/image/slugbuilder/Dockerfile
+++ b/builder/image/slugbuilder/Dockerfile
@@ -1,4 +1,4 @@
-FROM progrium/cedarish:latest
+FROM heroku/cedar:14
 
 RUN mkdir /app
 RUN addgroup --quiet --gid 2000 slug && \

--- a/builder/image/slugbuilder/README.md
+++ b/builder/image/slugbuilder/README.md
@@ -68,6 +68,4 @@ you'd like:
 
 ## Base Environment
 
-The Docker image here is based on [cedarish](https://github.com/progrium/cedarish), an image that
-emulates the Heroku Cedar stack environment. All buildpacks should have everything they need to run
-in this environment, but if something is missing it should be added upstream to cedarish.
+The Docker image is based on Heroku's official [Cedar image](https://registry.hub.docker.com/u/heroku/cedar/).

--- a/builder/image/slugrunner/Dockerfile
+++ b/builder/image/slugrunner/Dockerfile
@@ -1,4 +1,4 @@
-FROM progrium/cedarish:latest
+FROM heroku/cedar:14
 
 RUN mkdir /app
 RUN addgroup --quiet --gid 2000 slug && \

--- a/builder/image/slugrunner/README.md
+++ b/builder/image/slugrunner/README.md
@@ -38,7 +38,7 @@ It is also possible to fully customize the command line for `sdutil` tool using 
 
 ## Base Environment
 
-The Docker image here is based on [cedarish](https://github.com/progrium/cedarish), an image that emulates the Heroku Cedar stack environment. App slugs should include everything they need to run, but if something is missing it should be added upstream to cedarish.
+The Docker image is based on Heroku's official [Cedar image](https://registry.hub.docker.com/u/heroku/cedar/).
 
 ## License
 


### PR DESCRIPTION
Heroku now officially maintains a Docker image for their cedar stack.
The maintainer of cedarish is deprecating it in favour of this image,
so we should migrate over such that we emulate their environment
perfectly.

Since we no longer build a root filesystem and package it into a tarball,
this speeds up development time when compiling builder dramatically
with the tradeoff of having to fetch heroku/cedar:14 on boot, which is
slightly slower than a `docker import`. However, the difference
between relying on your local connection to pull cedarish from S3
vs. relying on a cloud provider's bandwidth to pull the image on boot
is quite significant, so really it's a question of tomato vs. tomatoe.