### PR TITLE
feat(router): customize error_log level via etcd

### DIFF
--- a/docs/customizing_deis/router_settings.rst
+++ b/docs/customizing_deis/router_settings.rst
@@ -50,6 +50,7 @@ setting                                      description
 /deis/router/enforceHTTPS                    redirect all HTTP traffic to HTTPS (default: false)
 /deis/router/firewall/enabled                nginx naxsi firewall enabled (default: false)
 /deis/router/firewall/errorCode              nginx default firewall error code (default: 400)
+/deis/router/errorLogLevel                   nginx error_log level (default: error) Valid options: debug, info, notice, warn, error, crit, alert, emerg
 /deis/router/gzip                            nginx gzip setting (default: on)
 /deis/router/gzipCompLevel                   nginx gzipCompLevel setting (default: 5)
 /deis/router/gzipDisable                     nginx gzipDisable setting (default: "msie6")

--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -51,7 +51,7 @@ http {
 
     # send logs to STDOUT so they can be seen using 'docker logs'
     access_log /opt/nginx/logs/access.log upstreaminfo;
-    error_log  /opt/nginx/logs/error.log;
+    error_log  /opt/nginx/logs/error.log {{ or (.deis_router_errorLogLevel) "error" }};
 
     map $http_upgrade $connection_upgrade {
         default upgrade;


### PR DESCRIPTION
Add method to customize the nginx error_log level via etcd. This helps when
debugging issues in deis-router.

Fixes #3560

Pretty easy to test:
```
deisctl config router set errorLogLevel=debug
deisctl config router set errorLogLevel=error
```

And check the log.