### PR TITLE
fix(store): install lsb-release package

### DIFF
--- a/store/base/build.sh
+++ b/store/base/build.sh
@@ -27,7 +27,7 @@ curl -sSL -o /usr/local/bin/confd https://github.com/kelseyhightower/confd/relea
 curl -sSL 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc' | apt-key add -
 echo "deb http://ceph.com/debian-hammer trusty main" > /etc/apt/sources.list.d/ceph.list
 
-apt-get update && apt-get install -yq ceph
+apt-get update && apt-get install -yq ceph lsb-release
 
 apt-get clean -y
 


### PR DESCRIPTION
Install missing `lsb-package` to remote error in `deis-store-daemon`

```
Apr 25 20:07:14 nodo-2 sh[16765]: store-daemon: starting daemon on nodo-2...
Apr 25 20:07:14 nodo-2 sh[16765]: 2015-04-25 20:07:14.488531 7f152a06e900  0 ceph version 0.94.1 (e4bfad3a3c51054df7e537a724c8d0bf9be972ff), process ceph-osd, pid 1
Apr 25 20:07:14 nodo-2 sh[16765]: starting osd.2 at :/0 osd_data /var/lib/ceph/osd/ceph-2 /var/lib/ceph/osd/ceph-2/journal
Apr 25 20:07:14 nodo-2 sh[16765]: 2015-04-25 20:07:14.502673 7f152a06e900  0 filestore(/var/lib/ceph/osd/ceph-2) backend btrfs (magic 0x9123683e)
Apr 25 20:07:14 nodo-2 sh[16765]: 2015-04-25 20:07:14.508672 7f152a06e900  0 genericfilestorebackend(/var/lib/ceph/osd/ceph-2) detect_features: FIEMAP ioctl is supported and appears to work
Apr 25 20:07:14 nodo-2 sh[16765]: 2015-04-25 20:07:14.508687 7f152a06e900  0 genericfilestorebackend(/var/lib/ceph/osd/ceph-2) detect_features: FIEMAP ioctl is disabled via 'filestore fiemap' config option
Apr 25 20:07:14 nodo-2 sh[16765]: 2015-04-25 20:07:14.525754 7f152a06e900  0 genericfilestorebackend(/var/lib/ceph/osd/ceph-2) detect_features: syncfs(2) syscall fully supported (by glibc and kernel)
Apr 25 20:07:14 nodo-2 sh[16765]: 2015-04-25 20:07:14.526674 7f152a06e900  0 btrfsfilestorebackend(/var/lib/ceph/osd/ceph-2) detect_feature: CLONE_RANGE ioctl is supported
Apr 25 20:07:14 nodo-2 sh[16765]: 2015-04-25 20:07:14.582982 7f152a06e900  0 btrfsfilestorebackend(/var/lib/ceph/osd/ceph-2) detect_feature: SNAP_CREATE is supported
Apr 25 20:07:14 nodo-2 sh[16765]: 2015-04-25 20:07:14.583768 7f152a06e900  0 btrfsfilestorebackend(/var/lib/ceph/osd/ceph-2) detect_feature: SNAP_DESTROY is supported
Apr 25 20:07:14 nodo-2 sh[16765]: 2015-04-25 20:07:14.584069 7f152a06e900  0 btrfsfilestorebackend(/var/lib/ceph/osd/ceph-2) detect_feature: START_SYNC is supported (transid 69992)
Apr 25 20:07:14 nodo-2 sh[16765]: 2015-04-25 20:07:14.628367 7f152a06e900  0 btrfsfilestorebackend(/var/lib/ceph/osd/ceph-2) detect_feature: WAIT_SYNC is supported
Apr 25 20:07:14 nodo-2 sh[16765]: 2015-04-25 20:07:14.645910 7f152a06e900  0 btrfsfilestorebackend(/var/lib/ceph/osd/ceph-2) detect_feature: SNAP_CREATE_V2 is supported
Apr 25 20:07:14 nodo-2 sh[16765]: 2015-04-25 20:07:14.836163 7f152a06e900  0 filestore(/var/lib/ceph/osd/ceph-2) mount: enabling PARALLEL journal mode: fs, checkpoint is enabled
Apr 25 20:07:14 nodo-2 sh[16765]: 2015-04-25 20:07:14.854439 7f152a06e900 -1 journal FileJournal::_open: disabling aio for non-block journal.  Use journal_force_aio to force use of aio anyway
Apr 25 20:07:14 nodo-2 sh[16765]: 2015-04-25 20:07:14.854468 7f152a06e900  1 journal _open /var/lib/ceph/osd/ceph-2/journal fd 18: 5368709120 bytes, block size 4096 bytes, directio = 1, aio = 0
Apr 25 20:07:15 nodo-2 sh[16765]: 2015-04-25 20:07:14.984710 7f152a06e900  1 journal _open /var/lib/ceph/osd/ceph-2/journal fd 18: 5368709120 bytes, block size 4096 bytes, directio = 1, aio = 0
Apr 25 20:07:15 nodo-2 sh[16765]: 2015-04-25 20:07:14.985025 7f152a06e900  0 <cls> cls/hello/cls_hello.cc:271: loading cls_hello
Apr 25 20:07:15 nodo-2 sh[16765]: 2015-04-25 20:07:14.998027 7f152a06e900  0 osd.2 56 crush map has features 1107558400, adjusting msgr requires for clients
Apr 25 20:07:15 nodo-2 sh[16765]: 2015-04-25 20:07:14.998048 7f152a06e900  0 osd.2 56 crush map has features 1107558400 was 8705, adjusting msgr requires for mons
Apr 25 20:07:15 nodo-2 sh[16765]: 2015-04-25 20:07:14.998056 7f152a06e900  0 osd.2 56 crush map has features 1107558400, adjusting msgr requires for osds
Apr 25 20:07:15 nodo-2 sh[16765]: 2015-04-25 20:07:14.998067 7f152a06e900  0 osd.2 56 load_pgs
Apr 25 20:07:15 nodo-2 sh[16765]: 2015-04-25 20:07:15.696827 7f152a06e900  0 osd.2 56 load_pgs opened 1408 pgs
Apr 25 20:07:15 nodo-2 sh[16765]: 2015-04-25 20:07:15.698217 7f152a06e900 -1 osd.2 56 log_to_monitors {default=true}
Apr 25 20:07:15 nodo-2 sh[16765]: 2015-04-25 20:07:15.701931 7f15174ab700  0 osd.2 56 ignoring osdmap until we have initialized
Apr 25 20:07:16 nodo-2 sh[16765]: 2015-04-25 20:07:16.168920 7f152a06e900  0 osd.2 56 done with init, starting boot process
Apr 25 20:07:16 nodo-2 sh[16765]: sh: 1: lsb_release: not found
Apr 25 20:07:16 nodo-2 sh[16765]: 2015-04-25 20:07:16.176004 7f150ec9a700 -1 osd.2 56 lsb_release_parse - pclose failed: (0)
````

`Apr 25 20:07:16 nodo-2 sh[16765]: sh: 1: lsb_release: not found`
