### PR TITLE
fix(store): change template to return ip address instead of :6789

### DIFF
--- a/store/base/templates/ceph.conf
+++ b/store/base/templates/ceph.conf
@@ -2,7 +2,7 @@
 fsid = {{ getv "/deis/store/fsid" }}
 mon initial members = {{ getv "/deis/store/monSetupLock" }}
 mon host = {{ join (getvs "/deis/store/hosts/*") "," }}
-mon addr = {{ join (ls "/deis/store/hosts/*") ":6789 ," }}:6789
+mon addr = {{ range $index, $element := (gets "/deis/store/hosts/*") }}{{if $index}},{{end}}{{ base $element.Key }}:6789{{ end }}
 auth cluster required = cephx
 auth service required = cephx
 auth client required = cephx


### PR DESCRIPTION
The current template generates `mon addr = :6789` instead of a list of ip:port of each ceph node.