### PR TITLE
chore(contrib/rackspace): bump CoreOS to 633.1.0

### DIFF
--- a/contrib/rackspace/provision-rackspace-cluster.sh
+++ b/contrib/rackspace/provision-rackspace-cluster.sh
@@ -48,9 +48,8 @@ $CONTRIB_DIR/util/check-user-data.sh
 
 i=1 ; while [[ $i -le $DEIS_NUM_INSTANCES ]] ; do \
     echo_yellow "Provisioning deis-$i..."
-    # This image is CoreOS 607.0.0 in the stable channel
-    # TODO Update to 633.1.0 once it's available in the stable channel
-    supernova $ENV boot --image c412af3b-f9a6-4ad1-a9e9-4aabca8073d3 --flavor $FLAVOR --key-name $1 --user-data $CONTRIB_DIR/coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
+    # This image is CoreOS 633.1.0 in the stable channel
+    supernova $ENV boot --image a41d8b7c-d41b-4369-a180-0734f3b1cd8c --flavor $FLAVOR --key-name $1 --user-data $CONTRIB_DIR/coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
     ((i = i + 1)) ; \
 done
 


### PR DESCRIPTION
Manually verified:
```console
core@deis-1 ~ $ cat /etc/os-release
NAME=CoreOS
ID=coreos
VERSION=633.1.0
VERSION_ID=633.1.0
BUILD_ID=
PRETTY_NAME="CoreOS 633.1.0"
ANSI_COLOR="1;32"
HOME_URL="https://coreos.com/"
BUG_REPORT_URL="https://github.com/coreos/bugs/issues"
```