### PR TITLE
chore(database): update wal-e to v0.8.0 + busybox fix

### DIFF
--- a/database/build.sh
+++ b/database/build.sh
@@ -38,8 +38,9 @@ curl -sSL https://raw.githubusercontent.com/pypa/pip/6.1.1/contrib/get-pip.py | 
 cd /tmp
 git clone https://github.com/wal-e/wal-e.git
 
+# get a post-v0.8.0 commit which includes a busybox fix
 cd /tmp/wal-e
-git checkout v0.8c2
+git checkout c6dd4b1
 
 pip install .
 


### PR DESCRIPTION
Updates the version of [wal-e](https://github.com/wal-e/wal-e) used by deis-database to v0.8.0, plus a commit by @aledbf that improves compatibility with alpine/busybox.

See https://github.com/wal-e/wal-e/compare/v0.8c2...c6dd4b1