### PR TITLE
feat(controller): allow user to scale gunicorn worker processes

### DIFF
--- a/controller/conf.d/gconf.toml
+++ b/controller/conf.d/gconf.toml
@@ -1,0 +1,10 @@
+[template]
+src   = "gconf.py"
+dest  = "/app/deis/gconf.py"
+uid = 1000
+gid = 1000
+mode  = "0640"
+keys = [
+  "/deis/controller",
+]
+reload_cmd = "/app/bin/reload"

--- a/controller/deis/gconf.py
+++ b/controller/deis/gconf.py
@@ -1,5 +1,7 @@
+import multiprocessing
+
 bind = '0.0.0.0'
-workers = 8
+workers = multiprocessing.cpu_count() * 2 + 1
 proc_name = 'deis-controller'
 timeout = 1200
 pidfile = '/tmp/gunicorn.pid'

--- a/controller/templates/gconf.py
+++ b/controller/templates/gconf.py
@@ -1,7 +1,12 @@
-import multiprocessing
-
 bind = '0.0.0.0'
-workers = multiprocessing.cpu_count() * 2 + 1
+try:
+    workers = int({{ if exists "/deis/controller/workers" }}{{ getv "/deis/controller/workers" }}{{ else }}"not set"{{end}})
+except (NameError, ValueError):
+    import multiprocessing
+    try:
+        workers = multiprocessing.cpu_count() * 2 + 1
+    except NotImplementedError:
+        workers = 8
 proc_name = 'deis-controller'
 timeout = 1200
 pidfile = '/tmp/gunicorn.pid'

--- a/docs/customizing_deis/controller_settings.rst
+++ b/docs/customizing_deis/controller_settings.rst
@@ -41,6 +41,7 @@ setting                                   description
 ====================================      ======================================================
 /deis/controller/registrationMode         set registration to "enabled", "disabled", or "admin_only" (default: "enabled")
 /deis/controller/webEnabled               enable controller web UI (default: false)
+/deis/controller/workers                  number of web worker processes (default: CPU cores * 2 + 1)
 /deis/cache/host                          host of the cache component (set by cache)
 /deis/cache/port                          port of the cache component (set by cache)
 /deis/database/host                       host of the database component (set by database)


### PR DESCRIPTION
The hard-coded default of 8 python worker processes was a stab in the dark, and may use more resources than required in general. This change uses gunicorn's recommended default of (CPUs * 2 + 1), and allows a user to override that with `deisctl config controller set workers=N`.