### PR TITLE
fix(registry): bump etcd ttl to 20 seconds

### DIFF
--- a/builder/image/bin/boot
+++ b/builder/image/bin/boot
@@ -17,7 +17,7 @@ fi
 export ETCD_PORT=${ETCD_PORT:-4001}
 export ETCD="$HOST:$ETCD_PORT"
 export ETCD_PATH=${ETCD_PATH:-/deis/builder}
-export ETCD_TTL=${ETCD_TTL:-10}
+export ETCD_TTL=${ETCD_TTL:-20}
 
 # wait for etcd to be available
 until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do

--- a/cache/README.md
+++ b/cache/README.md
@@ -20,8 +20,6 @@ install, and start **deis/cache**.
   daemon (default: *4001*)
 * **ETCD_PATH** sets the etcd directory where the cache announces its
   configuration (default: */deis/cache*)
-* **ETCD_TTL** sets the time-to-live before etcd purges a configuration
-  value, in seconds (default: *10*)
 * **PORT** sets the TCP port on which the cache listens (default: *6379*)
 
 ## License

--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -13,7 +13,7 @@ set -eo pipefail
 export ETCD_PORT=${ETCD_PORT:-4001}
 export ETCD="$HOST:$ETCD_PORT"
 export ETCD_PATH=${ETCD_PATH:-/deis/controller}
-export ETCD_TTL=${ETCD_TTL:-10}
+export ETCD_TTL=${ETCD_TTL:-20}
 
 # wait for etcd to be available
 until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do

--- a/database/bin/boot
+++ b/database/bin/boot
@@ -13,7 +13,7 @@ set -eo pipefail
 export ETCD_PORT=${ETCD_PORT:-4001}
 export ETCD="$HOST:$ETCD_PORT"
 export ETCD_PATH=${ETCD_PATH:-/deis/database}
-export ETCD_TTL=${ETCD_TTL:-10}
+export ETCD_TTL=${ETCD_TTL:-20}
 
 export BUCKET_NAME=${BUCKET_NAME:-db_wal}
 export BACKUPS_TO_RETAIN=${BACKUPS_TO_RETAIN:-5}

--- a/registry/bin/boot
+++ b/registry/bin/boot
@@ -14,7 +14,7 @@ export ETCD_PORT=${ETCD_PORT:-4001}
 export ETCD="$HOST:$ETCD_PORT"
 export ETCD_PATH=${ETCD_PATH:-/deis/registry}
 export HOST_ETCD_PATH=${HOST_ETCD_PATH:-/deis/registry/hosts/$HOST}
-export ETCD_TTL=${ETCD_TTL:-10}
+export ETCD_TTL=${ETCD_TTL:-20}
 
 # run.sh requires $REGISTRY_PORT
 export REGISTRY_PORT=${PORT:-5000}

--- a/store/gateway/bin/boot
+++ b/store/gateway/bin/boot
@@ -14,7 +14,7 @@ export ETCD_PORT=${ETCD_PORT:-4001}
 export ETCD="$HOST:$ETCD_PORT"
 export ETCD_PATH=${ETCD_PATH:-/deis/store/gateway}
 export HOST_ETCD_PATH=${HOST_ETCD_PATH:-/deis/store/gateway/hosts/$HOST}
-export ETCD_TTL=${ETCD_TTL:-10}
+export ETCD_TTL=${ETCD_TTL:-20}
 
 # wait for etcd to be available
 until etcdctl --no-sync -C $ETCD ls >/dev/null 2>&1; do

--- a/tests/fixtures/mock-store/bin/boot
+++ b/tests/fixtures/mock-store/bin/boot
@@ -13,7 +13,7 @@ set -eo pipefail
 export ETCD_PORT=${ETCD_PORT:-4001}
 export ETCD="$HOST:$ETCD_PORT"
 export ETCD_PATH=${ETCD_PATH:-/deis/store/gateway}
-export ETCD_TTL=${ETCD_TTL:-10}
+export ETCD_TTL=${ETCD_TTL:-20}
 
 export EXTERNAL_PORT=${EXTERNAL_PORT:-8888}
 export STORAGE_DIRECTORY=${STORAGE_DIRECTORY:-/app/storage}


### PR DESCRIPTION
The registry and gateway's boot relies on etcdctl for determining who has the master lock. Bumping to 20 seconds should prevent users from having their TTLs expire from latency issues.

closes #3563 
