### PR TITLE
ref(controller): simplify thread and set comparison code

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -14,7 +14,7 @@ import os
 import re
 import subprocess
 import time
-import threading
+from threading import Thread
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -84,9 +84,8 @@ def validate_id_is_docker_compatible(value):
 def validate_app_structure(value):
     """Error if the dict values aren't ints >= 0."""
     try:
-        for k, v in value.iteritems():
-            if int(v) < 0:
-                raise ValueError("Must be greater than or equal to zero")
+        if any(int(v) < 0 for v in value.itervalues()):
+            raise ValueError("Must be greater than or equal to zero")
     except ValueError, err:
         raise ValidationError(err)
 
@@ -271,17 +270,13 @@ class App(UuidAuditedModel):
 
     def _start_containers(self, to_add):
         """Creates and starts containers via the scheduler"""
-        create_threads = []
-        start_threads = []
         if not to_add:
-            # do nothing if we didn't request any containers
             return
-        for c in to_add:
-            create_threads.append(threading.Thread(target=c.create))
-            start_threads.append(threading.Thread(target=c.start))
+        create_threads = [Thread(target=c.create) for c in to_add]
+        start_threads = [Thread(target=c.start) for c in to_add]
         [t.start() for t in create_threads]
         [t.join() for t in create_threads]
-        if set([c.state for c in to_add]) != set(['created']):
+        if any(c.state != 'created' for c in to_add):
             err = 'aborting, failed to create some containers'
             log_event(self, err, logging.ERROR)
             raise RuntimeError(err)
@@ -293,37 +288,30 @@ class App(UuidAuditedModel):
 
     def _restart_containers(self, to_restart):
         """Restarts containers via the scheduler"""
-        stop_threads = []
-        start_threads = []
         if not to_restart:
-            # do nothing if we didn't request any containers
             return
-        for c in to_restart:
-            stop_threads.append(threading.Thread(target=c.stop))
-            start_threads.append(threading.Thread(target=c.start))
+        stop_threads = [Thread(target=c.stop) for c in to_restart]
+        start_threads = [Thread(target=c.start) for c in to_restart]
         [t.start() for t in stop_threads]
         [t.join() for t in stop_threads]
-        if set([c.state for c in to_restart]) != set(['created']):
+        if any(c.state != 'created' for c in to_restart):
             err = 'warning, some containers failed to stop'
             log_event(self, err, logging.WARNING)
         [t.start() for t in start_threads]
         [t.join() for t in start_threads]
-        if set([c.state for c in to_restart]) != set(['up']):
+        if any(c.state != 'up' for c in to_restart):
             err = 'warning, some containers failed to start'
             log_event(self, err, logging.WARNING)
 
     def _destroy_containers(self, to_destroy):
         """Destroys containers via the scheduler"""
-        destroy_threads = []
         if not to_destroy:
-            # do nothing if we didn't request any containers
             return
-        for c in to_destroy:
-            destroy_threads.append(threading.Thread(target=c.destroy))
+        destroy_threads = [Thread(target=c.destroy) for c in to_destroy]
         [t.start() for t in destroy_threads]
         [t.join() for t in destroy_threads]
         [c.delete() for c in to_destroy if c.state == 'destroyed']
-        if set([c.state for c in to_destroy]) != set(['destroyed']):
+        if any(c.state != 'destroyed' for c in to_destroy):
             err = 'aborting, failed to destroy some containers'
             log_event(self, err, logging.ERROR)
             raise RuntimeError(err)


### PR DESCRIPTION
This change makes some scheduler-related code shorter and easier to read. Certain parts are also marginally more efficient since Python's [`any()`](https://docs.python.org/2/library/functions.html#any) will return on the first match, whereas the `set() != set()` comparisons iterated through all elements.