### PR TITLE
feat(contrib/digitalocean): enable ams2 and sfo1 datacenters

### DIFF
--- a/contrib/digitalocean/provision-do-cluster.sh
+++ b/contrib/digitalocean/provision-do-cluster.sh
@@ -41,7 +41,7 @@ if [ -z "$DEIS_NUM_INSTANCES" ]; then
     DEIS_NUM_INSTANCES=3
 fi
 
-regions_without_private_networking_or_metadata="nyc1 nyc2 ams1 ams2 sfo1"
+regions_without_private_networking_or_metadata="nyc1 nyc2 ams1"
 if listcontains "$regions_without_private_networking_or_metadata" "$REGION_SLUG";
 then
     echo_red "Invalid region. Please supply a region with private networking & metadata support."


### PR DESCRIPTION
ams2 and sfo1 now do have metadata and private-networking support.

Replaces #3603.