### PR TITLE
ref(logger+publisher): use busybox as Docker base image

### DIFF
--- a/logger/image/Dockerfile
+++ b/logger/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-debootstrap:14.04
+FROM busybox
 
 ENTRYPOINT ["/bin/logger"]
 CMD ["--enable-publish"]
@@ -7,4 +7,3 @@ EXPOSE 514
 ADD . /
 
 ENV DEIS_RELEASE 1.7.0-dev
-

--- a/publisher/image/Dockerfile
+++ b/publisher/image/Dockerfile
@@ -1,7 +1,6 @@
-FROM ubuntu-debootstrap:14.04
+FROM busybox
 
 ADD bin/publisher /usr/local/bin/publisher
 ENTRYPOINT ["/usr/local/bin/publisher"]
 
 ENV DEIS_RELEASE 1.7.0-dev
-


### PR DESCRIPTION
Deis already uses the official Docker `busybox` image for logspout and swarm. This moves logger and publisher over to `busybox` from `ubuntu-debootstrap:14.04` as well, which may reduce `docker pull` times a bit:
```console
$ docker images
REPOSITORY            TAG          IMAGE ID            CREATED              VIRTUAL SIZE
deis/publisher        busybox      a25fcb101021        38 seconds ago       7.456 MB
deis/publisher        ubuntu       5c2426283d34        2 hours ago          92.06 MB
deis/logger           busybox      2dc3bd7e2d5e        About a minute ago   7.288 MB
deis/logger           ubuntu       2308c400b8c9        2 hours ago          91.9 MB
```
(It should be a trivial change from `busybox` to `alpine:3.1` if and when we get there.)