### PR TITLE
docs(contrib): add link to Docker S3 Cleaner

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -31,6 +31,7 @@ Please add to this list by opening a pull request!
 ### CoreOS Unit Files
 * [CoreOS unit files](https://github.com/ianblenke/coreos-vagrant-kitchen-sink/tree/master/cloud-init) by [@ianblenke](https://github.com/ianblenke) - Unit files to launch various services on CoreOS hosts
 * [deis-backup-service](https://github.com/mozilla/deis-backup-service) by [@glogiotatidis](https://github.com/glogiotatidis) - Unit Files to automatically backup to S3 database and registry data.
+* [Docker S3 Cleaner](https://github.com/myriadmobile/docker-s3-cleaner) by [@croemmich](https://github.com/croemmich) - Unit file to remove orphaned image layers from S3 backed private docker registries
 * [New Relic unit for CoreOS](https://github.com/lorieri/coreos-newrelic) by [@lorieri](https://github.com/lorieri) - A global unit to launch New Relic sysmond
 
 ### Example Applications


### PR DESCRIPTION
Docker S3 cleaner removes orphaned image layers from S3 backed private docker registries. Packaged with Deis-specific unit file in [contrib/deis](https://github.com/myriadmobile/docker-s3-cleaner/tree/master/contrib/deis).