### PR TITLE
ref(controller): move mkdir to bin/boot

### DIFF
--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -52,9 +52,10 @@ etcd_set_default webEnabled 0
 etcd_set_default unitHostname default
 
 # safely create required keyspaces
-etcd_safe_mkdir /deis/services
 etcd_safe_mkdir /deis/domains
 etcd_safe_mkdir /deis/platform
+etcd_safe_mkdir /deis/scheduler
+etcd_safe_mkdir /deis/services
 
 # run etcd data migrations
 echo "controller: running etcd data migrations..."

--- a/deisctl/units/deis-controller.service
+++ b/deisctl/units/deis-controller.service
@@ -6,7 +6,6 @@ After=deis-store-volume.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=-/usr/bin/etcdctl mkdir /deis/scheduler >/dev/null 2>&1
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-controller >/dev/null 2>&1 && docker rm -f deis-controller || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker run --name deis-controller --rm -p 8000:8000 -e EXTERNAL_PORT=8000 -e HOST=$COREOS_PRIVATE_IPV4 -v /var/run/fleet.sock:/var/run/fleet.sock -v /var/lib/deis/store:/data $IMAGE"


### PR DESCRIPTION
This is a mini optimization. We have a function and a place which we
set up directories which components rely upon. Since the controller now
relies on /deis/scheduler, this moves it over there.

I found this because I wasn't following the upgrade docs to a tee, but it made more sense to put it where all the rest are initialized anyways :)