### PR TITLE
fix(contrib): remove message to exporting DEISCTL_TUNNEL

### DIFF
--- a/contrib/ec2/provision-ec2-cluster.sh
+++ b/contrib/ec2/provision-ec2-cluster.sh
@@ -132,7 +132,6 @@ FIRST_INSTANCE=$(aws ec2 describe-instances \
     --filters Name=tag:aws:cloudformation:stack-name,Values=$STACK_NAME Name=instance-state-name,Values=running \
     --query 'Reservations[].Instances[].[PublicIpAddress]' \
     --output text | head -1)
-echo_green "Setting DEISCTL_TUNNEL=$FIRST_INSTANCE"
 export DEISCTL_TUNNEL=$FIRST_INSTANCE
 echo_green "Enabling proxy protocol"
 


### PR DESCRIPTION
This envvar does not persist after the script is executed unless you
`source` it.

closes #3628