### PR TITLE
feat(contrib/azure/azure-coreos-cluster): automatically create discovery url

### DIFF
--- a/contrib/azure/azure-coreos-cluster
+++ b/contrib/azure/azure-coreos-cluster
@@ -55,6 +55,9 @@ parser.add_argument('--data-disk', action='store_true',
                    help='optional, attaches a data disk to each VM')
 parser.add_argument('--nohttps', action='store_true',
                    help='optional, disables the creation of the https load balanced endpoint')
+parser.add_argument('--no-discovery-url', action='store_true',
+                   help='optional, disables the creation of a new coreos discovery url')
+
 cloud_init_template = """#cloud-config
 
 coreos:
@@ -84,6 +87,11 @@ if not args.ssh_cert and not args.ssh_thumb:
       args.ssh_thumb = thumbprint.split('=')[1].replace('\n', '')
       args.ssh_cert = './ssh-cert.cer'
   print 'Generated SSH certificate with thumbprint ' + args.ssh_thumb
+
+# generate coreos discovery url
+if not args.no_discovery_url:
+  print 'Generating new CoreOS discovery URL for the cluster'
+  subprocess.call(['bash', '-c', 'python ./create-azure-user-data $(curl -s https://discovery.etcd.io/new)'])
 
 # Setup custom data
 if args.custom_data:
@@ -163,8 +171,7 @@ def network_config(subnet_name=None, port='59913', public_ip_name=None):
         if not args.nohttps:
           network.input_endpoints.input_endpoints.append(lb_endpoint_config('https', '443', load_balancer_probe(None, '443', 'tcp')))
         # create builder endpoint TCP probe check and extended timeout
-        network.input_endpoints.input_endpoints.append(lb_endpoint_config('builder', '2222',
-load_balancer_probe(None, '2222', 'tcp',), 20))
+        network.input_endpoints.input_endpoints.append(lb_endpoint_config('builder', '2222', load_balancer_probe(None, '2222', 'tcp',), 20))
     return network
 
 def data_hd(target_container_url, target_blob_name, target_lun, target_disk_size_in_gb):

--- a/docs/installing_deis/azure.rst
+++ b/docs/installing_deis/azure.rst
@@ -47,20 +47,6 @@ Azure portal's Settings.
 
 Also copy the Azure subscription id from this table and save it for the cluster creation script below.
 
-Create Cluster Cloud Config
----------------------------
-
-Before we can create a cluster, we need to create a cloud config for it. The script
-``create-azure-user-data`` does this for you. This script takes the stock cluster instance config
-in ``../coreos/user-data.example``, customizes it for Azure, and inserts a unique cluster discovery
-endpoint:
-
-.. code-block:: console
-
-    $ ./create-azure-user-data $(curl -s https://discovery.etcd.io/new)
-
-This will create a azure-user-data cloud config file. We'll use this with the script in the next
-section during cluster creation.
 
 Create CoreOS Cluster
 ---------------------
@@ -70,6 +56,9 @@ With the management certificate and cloud config in place, we are ready to creat
 * Create a container called ``vhds`` within a storage account in the same region as your cluster using the Azure portal. Note the URL of the container for the cluster creation script below.
 * Choose a cloud service name for your Deis cluster for the script below. The script will automatically create this cloud service for you.
 * Create an `affinity group`_ if you already don't have one. Supply it in quotes with the ``--affinity-group`` parameter. Although *using an affinity group is not mandatory*, it is **highly recommended** since it tells the Azure fabric to place all VMs in the cluster physically close to each other, reducing inter-node latency by a great deal. If you don't want ot use affinity groups, specify a `region`_ for Azure to use with a ``--location`` parameter. The default is ``"West US"``. If you specify both parameters, ``location`` will be ignored. Please note that the script *will not* create an affinity group by itself; it expects the affinity group exists.
+
+This script calls the ``./create-azure-user-data`` script which takes the stock cluster instance config in ``../coreos/user-data.example``, customizes it for Azure, and inserts a unique cluster discovery
+endpoint. It will then use the newly created CoreOS config on the newly provisioned cluster.
 
 With that, let's run the azure-coreos-cluster script which will create the CoreOS cluster. Fill in the bracketed values with the values for your deployment you created above.
 


### PR DESCRIPTION
Added a the convenience of recreating azure-user-data for coreos with a new discovery
url. This prevents accidental cluster provisioning without creating a new url which
the user will only realize they did after the coreos has been provisioned and
attempts to connect with deisctl.