### PR TITLE
Suggest checking out a tag when getting the source

### DIFF
--- a/docs/_includes/_get-the-source.rst
+++ b/docs/_includes/_get-the-source.rst
@@ -6,6 +6,9 @@ this documentation. Download an archive file from the `releases page`_, or use
 
     $ git clone https://github.com/deis/deis.git
     $ cd deis
+    $ git checkout v1.6.0
+
+Check out the latest Deis release, rather than using the default (master).
 
 If you contribute to Deis or build components locally, use ``go get`` instead to
 clone the source code into your `$GOPATH`_:

--- a/docs/contributing/releases.rst
+++ b/docs/contributing/releases.rst
@@ -43,6 +43,7 @@ Patch Release
         database/Dockerfile \
         deisctl/cmd/cmd.go \
         deisctl/deis-version \
+        docs/_includes/_get-the-source.rst \
         docs/installing_deis/install-deisctl.rst \
         docs/installing_deis/install-platform.rst \
         docs/managing_deis/upgrading-deis.rst \
@@ -93,6 +94,7 @@ Major or Minor Release
     $ ./contrib/bumpver/bumpver -f A.B.C A.B.D \
         README.md \
         contrib/coreos/user-data.example \
+        docs/_includes/_get-the-source.rst \
         docs/installing_deis/install-deisctl.rst \
         docs/installing_deis/install-platform.rst \
         docs/managing_deis/upgrading-deis.rst \
@@ -173,6 +175,7 @@ Patch Release
     ./contrib/bumpver/bumpver -f A.B.C A.B.D \
       README.md \
       contrib/coreos/user-data.example \
+      docs/_includes/_get-the-source.rst \
       docs/installing_deis/install-deisctl.rst \
       docs/installing_deis/install-platform.rst \
       docs/managing_deis/upgrading-deis.rst \


### PR DESCRIPTION
This would have saved me a bit of heartache; the issue was finally identified by @bacongobbler .

As it stands, this tag name will very soon be out of date, leaving people blithely copy/pasting (I would *never* do that, right?) running an old version of Deis.  But I don't see an easy fix for that..

It looks like `|release|` is always the release from which the docs are built, which will not correspond to the most recently released tag.  I don't know if there's any other automated way to generate the correct tag name.