### PR TITLE
chore(controller): remove $PORT logic from fleet

### DIFF
--- a/controller/scheduler/fleet.py
+++ b/controller/scheduler/fleet.py
@@ -379,7 +379,7 @@ CONTAINER_TEMPLATE = [
     {"section": "Unit", "name": "Description", "value": "{name}"},
     {"section": "Service", "name": "ExecStartPre", "value": '''/bin/sh -c "IMAGE=$(etcdctl get /deis/registry/host 2>&1):$(etcdctl get /deis/registry/port 2>&1)/{image}; docker pull $IMAGE"'''},  # noqa
     {"section": "Service", "name": "ExecStartPre", "value": '''/bin/sh -c "docker inspect {name} >/dev/null 2>&1 && docker rm -f {name} || true"'''},  # noqa
-    {"section": "Service", "name": "ExecStart", "value": '''/bin/sh -c "IMAGE=$(etcdctl get /deis/registry/host 2>&1):$(etcdctl get /deis/registry/port 2>&1)/{image}; port=$(docker inspect -f '{{{{range $k, $v := .ContainerConfig.ExposedPorts }}}}{{{{$k}}}}{{{{end}}}}' $IMAGE | cut -d/ -f1) ; docker run --name {name} {memory} {cpu} {hostname} -P -e PORT=$port $IMAGE {command}"'''},  # noqa
+    {"section": "Service", "name": "ExecStart", "value": '''/bin/sh -c "IMAGE=$(etcdctl get /deis/registry/host 2>&1):$(etcdctl get /deis/registry/port 2>&1)/{image}; docker run --name {name} {memory} {cpu} {hostname} -P $IMAGE {command}"'''},  # noqa
     {"section": "Service", "name": "ExecStop", "value": '''/usr/bin/docker stop {name}'''},
     {"section": "Service", "name": "ExecStop", "value": '''/usr/bin/docker rm -f {name}'''},
     {"section": "Service", "name": "TimeoutStartSec", "value": "20m"},

--- a/docs/using_deis/using-docker-images.rst
+++ b/docs/using_deis/using-docker-images.rst
@@ -31,7 +31,7 @@ Docker Image Requirements
 In order to deploy Docker images, they must conform to the following requirements:
 
  * The Docker image must EXPOSE only one port
- * The exposed port must be an HTTP service that can be connected to an HTTP router
+ * The port must be listening for a HTTP connection
  * A default CMD must be specified for running the container
 
 .. note::

--- a/docs/using_deis/using-dockerfiles.rst
+++ b/docs/using_deis/using-dockerfiles.rst
@@ -22,7 +22,7 @@ Dockerfile Requirements
 In order to deploy Dockerfile applications, they must conform to the following requirements:
 
  * The Dockerfile must EXPOSE only one port
- * The exposed port must be an HTTP service that can be connected to an HTTP router
+ * The port must be listening for a HTTP connection
  * A default CMD must be specified for running the container
 
 .. note::

--- a/publisher/server/publisher.go
+++ b/publisher/server/publisher.go
@@ -100,6 +100,8 @@ func (s *Server) publishContainer(container *docker.APIContainers, ttl time.Dura
 		keyPath := fmt.Sprintf("/deis/services/%s", appPath)
 		dirPath := fmt.Sprintf("/deis/services/%s", appName)
 		for _, p := range container.Ports {
+			// lowest port wins (docker sorts the ports)
+			// TODO (bacongobbler): support multiple exposed ports
 			port := strconv.Itoa(int(p.PublicPort))
 			hostAndPort := host + ":" + port
 			if s.IsPublishableApp(containerName) && s.IsPortOpen(hostAndPort) {
@@ -109,7 +111,6 @@ func (s *Server) publishContainer(container *docker.APIContainers, ttl time.Dura
 				safeMap.data[container.ID] = appPath
 				safeMap.Unlock()
 			}
-			// TODO: support multiple exposed ports
 			break
 		}
 	}


### PR DESCRIPTION
For buildpack apps, [$PORT is exposed][1] as part of slugrunner's job. For Dockerfile/Docker images, the internal port numbers are already known to the developer, so if they want to follow 12-factor best practices then they will have set up $PORT in their own image. I tried seeing if there was a way to work around the docker API's limitations but didn't find one, and then it dawned on me that this is only relevant for users which *do not have control over the exposed ports*. For Dockerfiles/Docker images, this is managed by them so this logic was over-engineered.

deis/publisher exposes the port with the lowest numerical value to the router (docker sorts the internal ports before exposing them in the API), which is why the documentation is reflected to show this.

[1]: https://github.com/deis/deis/blob/e6a078b4119887b4de73e8a6d04291b7cdeb823b/builder/image/slugrunner/Dockerfile#L10-L12

closes #1156. We've been able to run multi-port containers for a while, it's just not what users would expect. This bug was (apparently) gone a long time ago. This is just updating the docs to reflect how to use it in today's world.

Official multi-port support is still untouched: #2095 #3069