### PR TITLE
fix(deisctl): prefix unit name with "deis-" before expanding

### DIFF
--- a/deisctl/backend/fleet/utils.go
+++ b/deisctl/backend/fleet/utils.go
@@ -88,6 +88,10 @@ func splitTarget(target string) (component string, num int, err error) {
 // expand a target to all installed units
 func expandTargets(c *FleetClient, targets []string) (expandedTargets []string, err error) {
 	for _, t := range targets {
+		// ensure unit name starts with "deis-"
+		if !strings.HasPrefix(t, "deis-") {
+			t = "deis-" + t
+		}
 		if strings.HasSuffix(t, "@*") {
 			var targets []string
 			targets, err = expandTarget(c, strings.TrimSuffix(t, "@*"))

--- a/deisctl/backend/fleet/utils_test.go
+++ b/deisctl/backend/fleet/utils_test.go
@@ -137,12 +137,21 @@ func TestExpandTargets(t *testing.T) {
 			Name: "deis-store-gateway@1.service",
 		},
 		&schema.Unit{
+			Name: "deis-store-gateway@2.service",
+		},
+		&schema.Unit{
 			Name: "deis-controller.service",
+		},
+		&schema.Unit{
+			Name: "deis-registry@1.service",
+		},
+		&schema.Unit{
+			Name: "registry_v2.cmd.1.service",
 		},
 	}
 	c := &FleetClient{Fleet: fc}
 
-	targets := []string{"deis-router@*", "deis-store-gateway@1", "deis-controller"}
+	targets := []string{"router@*", "deis-store-gateway@1", "deis-controller", "registry@*"}
 	expandedTargets, err := expandTargets(c, targets)
 	if err != nil {
 		t.Fatal(err)
@@ -152,6 +161,7 @@ func TestExpandTargets(t *testing.T) {
 		"deis-router@2.service",
 		"deis-store-gateway@1",
 		"deis-controller",
+		"deis-registry@1.service",
 	}
 	if !reflect.DeepEqual(expandedTargets, expectedTargets) {
 		t.Fatal(expandedTargets)


### PR DESCRIPTION
Commands such as `deisctl stop platform` were doing wildcard searches for the short names of units, effectively telling fleet to find all `*registry*` units, for example. This changes that wildcard to `*deis-registry*` and adds a test to ensure `deisctl` won't find a random app unit with "registry" in its name in that case.

Closes #3497.