### PR TITLE
fix(nonstring-default) numeric default for webEnabled

### DIFF
--- a/docs/customizing_deis/controller_settings.rst
+++ b/docs/customizing_deis/controller_settings.rst
@@ -41,7 +41,7 @@ setting                                   description
 ====================================      ======================================================
 /deis/controller/registrationMode         set registration to "enabled", "disabled", or "admin_only" (default: "enabled")
 /deis/controller/schedulerModule          scheduler backend (default: "fleet")
-/deis/controller/webEnabled               enable controller web UI (default: false)
+/deis/controller/webEnabled               enable controller web UI (default: 0)
 /deis/controller/workers                  number of web worker processes (default: CPU cores * 2 + 1)
 /deis/cache/host                          host of the cache component (set by cache)
 /deis/cache/port                          port of the cache component (set by cache)


### PR DESCRIPTION
`/deis/controller/webEnabled` uses Python's `bool` to parse this
configuration value; `0` and `1` are handled correctly, but `false` and
`true` lead to NameError.