### PR TITLE
fix(client): add requirements.txt to pypi distribution

### DIFF
--- a/client/MANIFEST.in
+++ b/client/MANIFEST.in
@@ -1,1 +1,1 @@
-include *.rst LICENSE
+include *.rst LICENSE requirements.txt


### PR DESCRIPTION
Tested locally with `python setup.py sdist && pip install dist/deis-1.7.0-dev.zip`: broken before, works now.

Closes #3668.