### PR TITLE
fix(router): check if there is certificates to generate

### DIFF
--- a/router/image/templates/generate-certs
+++ b/router/image/templates/generate-certs
@@ -18,6 +18,7 @@ rm -rf $KEY_PATH
 mkdir -p $CERT_PATH
 mkdir -p $KEY_PATH
 
+{{ if gt (len (lsdir "/deis/certs")) 0 }}
 while read etcd_path; do
   {{ range $cert := ls "/deis/certs" }}
   if [[ "$etcd_path" == "{{ $cert }}" ]]; then
@@ -29,4 +30,7 @@ EOF
 EOF
   fi{{ end }}
 done < /etc/ssl/deis_certs
+{{ else }}
+# there is no certificates to generate
+{{ end }}
 


### PR DESCRIPTION
Debugging an error I found this output from the router:
```
/bin/generate-certs: line 21: syntax error near unexpected token `done'
/bin/generate-certs: line 21: `done < /etc/ssl/deis_certs'
```
