### PR TITLE
fix(builder): remove warning when docker uses the aufs driver

### DIFF
--- a/builder/image/bin/auplink
+++ b/builder/image/bin/auplink
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 0;

--- a/builder/image/bin/boot
+++ b/builder/image/bin/boot
@@ -62,6 +62,7 @@ fi
 
 # cheat
 cp /app/bin/apparmor_parser /sbin/apparmor_parser
+cp /app/bin/auplink /sbin/auplink
 
 # spawn a docker daemon to run builds
 docker -d --bip=172.19.42.1/16 $DRIVER_OVERRIDE --insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 --insecure-registry 100.64.0.0/10 &


### PR DESCRIPTION
alpine do not provides support for aufs tools.
This is the removed warning:
```
Step 1 : RUN mkdir /app
time="2015-05-11T11:47:40Z" level="error" msg="[warning]: couldn't run auplink before unmount: exec: \"auplink\": executable file not found in $PATH" 
time="2015-05-11T11:47:40Z" level="error" msg="[warning]: couldn't run auplink before unmount: exec: \"auplink\": executable file not found in $PATH" 
```