### PR TITLE
fix(database): remove postgres pid error from log

### DIFF
--- a/database/build.sh
+++ b/database/build.sh
@@ -46,9 +46,9 @@ pip install .
 # python port of daemontools
 pip install envdir
 
-mkdir -p /etc/wal-e.d/env /etc/postgresql/main /var/run/postgresql /var/lib/postgresql
+mkdir -p /etc/wal-e.d/env /etc/postgresql/main /var/lib/postgresql
 
-chown -R root:postgres /etc/wal-e.d /etc/postgresql/main /var/run/postgresql /var/lib/postgresql
+chown -R root:postgres /etc/wal-e.d /etc/postgresql/main /var/lib/postgresql
 
 # cleanup.
 apk del --purge \

--- a/database/templates/postgresql.conf
+++ b/database/templates/postgresql.conf
@@ -46,7 +46,7 @@ ident_file = '/etc/postgresql/main/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
-external_pid_file = '/var/run/postgresql/daemon.pid'			# write an extra PID file
+external_pid_file = '/var/lib/postgresql/9.3/main/daemon.pid'			# write an extra PID file
 					# (change requires restart)
 
 


### PR DESCRIPTION
This is the error in jenkins:
```
...
database: expecting initialization id: none
database: no existing database found or it is outdated.
database: no backups found. Initializing a new database...
postgres: could not write external PID file "/var/run/postgresql/daemon.pid": Permission denied
2015-05-11 11:51:14 UTC LOG:  could not open usermap file "/etc/postgresql/main/pg_ident.conf": No such file or directory
2015-05-11 11:51:14 UTC LOG:  database system was shut down at 2015-05-11 11:51:13 UTC
...
```