### PR TITLE
feat(publisher): add pprof to enable profiling

### DIFF
--- a/publisher/image/Dockerfile
+++ b/publisher/image/Dockerfile
@@ -1,5 +1,9 @@
 FROM alpine:3.1
 
+# install curl in the image so it is possible to get the runtime
+# profiling information without any additional package installation.
+RUN apk add --update-cache curl && rm -rf /var/cache/apk/*
+
 ADD bin/publisher /usr/local/bin/publisher
 ENTRYPOINT ["/usr/local/bin/publisher"]
 

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"flag"
 	"log"
+	"net/http"
+	_ "net/http/pprof"
 	"time"
 
 	"github.com/coreos/go-etcd/etcd"
@@ -43,6 +45,10 @@ func main() {
 	server := server.New(dockerClient, etcdClient, *host, *logLevel)
 
 	go server.Listen(*etcdTTL)
+
+	go func() {
+		log.Println(http.ListenAndServe("localhost:6060", nil))
+	}()
 
 	for {
 		go server.Poll(*etcdTTL)


### PR DESCRIPTION
This enables the golang [pprof](https://golang.org/pkg/net/http/pprof/) tool to get runtime profiling from the go publisher application

```
core@nodo-1 ~ $ docker exec -it deis-publisher /bin/sh
/ # curl http://localhost:6060/debug/pprof/goroutine?debug=2
goroutine 186 [running]:
runtime/pprof.writeGoroutineStacks(0x7f3c9ab15c40, 0xc208060000, 0x0, 0x0)
	/usr/local/go/src/runtime/pprof/pprof.go:511 +0x8d
runtime/pprof.writeGoroutine(0x7f3c9ab15c40, 0xc208060000, 0x2, 0x0, 0x0)
	/usr/local/go/src/runtime/pprof/pprof.go:500 +0x4f
runtime/pprof.(*Profile).WriteTo(0x9b6b20, 0x7f3c9ab15c40, 0xc208060000, 0x2, 0x0, 0x0)
	/usr/local/go/src/runtime/pprof/pprof.go:229 +0xd5
net/http/pprof.handler.ServeHTTP(0xc2080cc071, 0x9, 0x7f3c9ab15b90, 0xc208060000, 0xc20803c1a0)
	/usr/local/go/src/net/http/pprof/pprof.go:169 +0x35f
net/http/pprof.Index(0x7f3c9ab15b90, 0xc208060000, 0xc20803c1a0)
	/usr/local/go/src/net/http/pprof/pprof.go:181 +0x15e
net/http.HandlerFunc.ServeHTTP(0x8946e8, 0x7f3c9ab15b90, 0xc208060000, 0xc20803c1a0)
	/usr/local/go/src/net/http/server.go:1265 +0x41
net/http.(*ServeMux).ServeHTTP(0xc20803a750, 0x7f3c9ab15b90, 0xc208060000, 0xc20803c1a0)
	/usr/local/go/src/net/http/server.go:1541 +0x17d
net/http.serverHandler.ServeHTTP(0xc20800c300, 0x7f3c9ab15b90, 0xc208060000, 0xc20803c1a0)
	/usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc208061680)
	/usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 1 [sleep]:
main.main()
	/Users/aledbf/go/src/github.com/deis/deis/publisher/main.go:55 +0x3fb

goroutine 10 [select]:
github.com/fsouza/go-dockerclient.(*eventMonitoringState).monitorEvents(0xc208010230, 0xc20808a100)
	/Users/aledbf/go/src/github.com/deis/deis/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/event.go:159 +0x40b
created by github.com/fsouza/go-dockerclient.(*eventMonitoringState).enableEventMonitoring
	/Users/aledbf/go/src/github.com/deis/deis/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/event.go:132 +0x16f

goroutine 6 [chan receive]:
github.com/deis/deis/publisher/server.(*Server).Listen(0xc20803b410, 0x4a817c800)
	/Users/aledbf/go/src/github.com/deis/deis/publisher/server/publisher.go:56 +0x1d9
created by main.main
	/Users/aledbf/go/src/github.com/deis/deis/publisher/main.go:47 +0x3ac

goroutine 7 [IO wait]:
net.(*pollDesc).Wait(0xc208010300, 0x72, 0x0, 0x0)
	/usr/local/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc208010300, 0x0, 0x0)
	/usr/local/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).accept(0xc2080102a0, 0x0, 0x7f3c9ab13d08, 0xc2080e0010)
	/usr/local/go/src/net/fd_unix.go:419 +0x40b
net.(*TCPListener).AcceptTCP(0xc208040068, 0x45e17e, 0x0, 0x0)
	/usr/local/go/src/net/tcpsock_posix.go:234 +0x4e
net/http.tcpKeepAliveListener.Accept(0xc208040068, 0x0, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/server.go:1976 +0x4c
net/http.(*Server).Serve(0xc20800c300, 0x7f3c9ab15340, 0xc208040068, 0x0, 0x0)
	/usr/local/go/src/net/http/server.go:1728 +0x92
net/http.(*Server).ListenAndServe(0xc20800c300, 0x0, 0x0)
	/usr/local/go/src/net/http/server.go:1718 +0x154
net/http.ListenAndServe(0x7f8930, 0xe, 0x0, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/server.go:1808 +0xba
main.func·001()
	/Users/aledbf/go/src/github.com/deis/deis/publisher/main.go:50 +0x48
created by main.main
	/Users/aledbf/go/src/github.com/deis/deis/publisher/main.go:51 +0x3bd

goroutine 11 [IO wait]:
net.(*pollDesc).Wait(0xc20809bfe0, 0x72, 0x0, 0x0)
	/usr/local/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc20809bfe0, 0x0, 0x0)
	/usr/local/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).Read(0xc20809bf80, 0xc20809c000, 0x1000, 0x1000, 0x0, 0x7f3c9ab13d08, 0xc2080e1728)
	/usr/local/go/src/net/fd_unix.go:242 +0x40f
net.(*conn).Read(0xc208040148, 0xc20809c000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/net.go:121 +0xdc
bufio.(*Reader).fill(0xc20800c5a0)
	/usr/local/go/src/bufio/bufio.go:97 +0x1ce
bufio.(*Reader).ReadSlice(0xc20800c5a0, 0x7f3c9ab0fa0a, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/local/go/src/bufio/bufio.go:295 +0x257
net/http/internal.readLine(0xc20800c5a0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/internal/chunked.go:110 +0x5a
net/http/internal.(*chunkedReader).beginChunk(0xc20803bda0)
	/usr/local/go/src/net/http/internal/chunked.go:47 +0x46
net/http/internal.(*chunkedReader).Read(0xc20803bda0, 0xc2080c2200, 0x200, 0x200, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/internal/chunked.go:77 +0xbb
net/http.(*body).readLocked(0xc20804ac80, 0xc2080c2200, 0x200, 0x200, 0x5, 0x0, 0x0)
	/usr/local/go/src/net/http/transfer.go:584 +0x7a
net/http.(*body).Read(0xc20804ac80, 0xc2080c2200, 0x200, 0x200, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/transfer.go:579 +0x115
encoding/json.(*Decoder).readValue(0xc2080a0000, 0xc207ffb55f, 0x0, 0x0)
	/usr/local/go/src/encoding/json/stream.go:124 +0x5e1
encoding/json.(*Decoder).Decode(0xc2080a0000, 0x6a5f40, 0xc20804aa00, 0x0, 0x0)
	/usr/local/go/src/encoding/json/stream.go:44 +0x7b
github.com/fsouza/go-dockerclient.func·004(0xc20805c360, 0xc20807c8f0)
	/Users/aledbf/go/src/github.com/deis/deis/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/event.go:262 +0x1ab
created by github.com/fsouza/go-dockerclient.(*Client).eventHijack
	/Users/aledbf/go/src/github.com/deis/deis/Godeps/_workspace/src/github.com/fsouza/go-dockerclient/event.go:276 +0x57f
```