### PR TITLE
fix(client): pin cryptography library at 0.8.2

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,5 +1,6 @@
 # Deis CLI requirements
 
+cryptography==0.8.2
 docopt==0.6.2
 ndg-httpsclient==0.3.3
 pyasn1==0.1.7

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -24,6 +24,7 @@ South==1.0.2
 python-ldap==2.4.19
 
 # Deis client requirements, copied from client/requirements.txt
+cryptography==0.8.2
 docopt==0.6.2
 ndg-httpsclient==0.3.3
 pyasn1==0.1.7


### PR DESCRIPTION
pyOpenSSL only specifies `cryptography>=0.7`, but last night's release of cryptography 0.9 with [osrandom.h refactoring](https://github.com/pyca/cryptography/pull/1774) breaks our PyInstaller packaging for the `deis` CLI:
```
 File "/var/lib/jenkins/jobs/test-ec2/workspace@2/src/github.com/deis/deis/client/build/deis/out00-PYZ.pyz/cryptography.hazmat.bindings.openssl.osrandom_engine", line 10, in <module>
IOError: [Errno 2] No such file or directory: '/tmp/_MEIfxEnRz/cryptography/hazmat/bindings/openssl/src/osrandom_engine.h'
error at command wait
--- FAIL: TestGlobal (1.02s)
```
Note that this error shows up when running the packaged/compiled `deis` CLI, not during its build. All CI builds have been broken since cryptography made their 0.9 release.

Pinning the sub-requirement to the last known working version of cryptography should fix this issue.