### PR TITLE
fix(controller): Roll back scale on failure

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -292,6 +292,7 @@ class App(UuidAuditedModel):
         if any(c.state != 'created' for c in to_add):
             err = 'aborting, failed to create some containers'
             log_event(self, err, logging.ERROR)
+            self._destroy_containers(to_add)
             raise RuntimeError(err)
         [t.start() for t in start_threads]
         [t.join() for t in start_threads]

--- a/controller/api/tests/test_scheduler.py
+++ b/controller/api/tests/test_scheduler.py
@@ -75,10 +75,7 @@ class SchedulerTest(TransactionTestCase):
         url = "/v1/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data['results']), 20)
-        # make sure some failed
-        states = set([c['state'] for c in response.data['results']])
-        self.assertEqual(states, set(['error', 'created']))
+        self.assertEqual(len(response.data['results']), 0)
 
     def test_start_chaos(self):
         url = '/v1/apps'
@@ -304,7 +301,6 @@ class SchedulerTest(TransactionTestCase):
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 20)
-
         # make sure all old containers are still up
         states = set([c['state'] for c in response.data['results']])
         self.assertEqual(states, set(['up']))

--- a/controller/scheduler/swarm.py
+++ b/controller/scheduler/swarm.py
@@ -33,7 +33,8 @@ class SwarmClient(object):
                 mem = mem[:-1]
         cpu = kwargs.get('cpu', {}).get(l['c_type'])
         self.docker_cli.create_container(image=cimage, name=name,
-                                         command=command.encode('utf-8'), mem_limit=mem,
+                                         command=command.encode('utf-8'),
+                                         mem_limit=mem,
                                          cpu_shares=cpu,
                                          environment=[affinity],
                                          host_config={'PublishAllPorts': True})


### PR DESCRIPTION
fix(controller): roll back if scale fails
fixes #3605 

Log_event method was implemented in scheduler and app.id is passed to scheduler record logs to app logs. Rollback happens if any of the container state is not in created.  
```
$ deis scale cmd=7
Scaling processes... but first, coffee!
503 Service Unavailable
Detail:
aborting, failed to create some containers rolling back
reshut2-82-75-dhcp:example-dockerfile-http smothiki$ deis logs
2015-05-14T23:13:45UTC deis[api]: smothiki created initial release
2015-05-14T23:14:34UTC deis[api]: smothiki deployed 6578692
2015-05-14T23:14:35UTC deis[api]: smothiki scaled containers cmd=1
2015-05-14T23:15:54UTC deis[api]: smothiki changed limits for memory
2015-05-14T23:45:46UTC deis[api]: smothiki scaled containers cmd=5
2015-05-14T23:46:38UTC deis[api]: smothiki scaled containers cmd=6
2015-05-14T23:46:47UTC deis[api]: smothiki scaled containers cmd=7
2015-05-14T23:46:47UTC deis[api]: 500 Server Error: Internal Server Error  no resources available to schedule container
2015-05-14T23:46:47UTC deis[api]: aborting, failed to create some containers rolling back
2015-05-14T23:46:47UTC deis[api]: smothiki scaled containers cmd=7
2015-05-14T23:46:47UTC deis[api]: 500 Server Error: Internal Server Error  no resources available to schedule container
2015-05-14T23:46:47UTC deis[api]: aborting, failed to create some containers rolling back
2015-05-14T23:46:47UTC deis[api]: smothiki scaled containers cmd=7
2015-05-14T23:46:47UTC deis[api]: 500 Server Error: Internal Server Error  no resources available to schedule container
2015-05-14T23:46:47UTC deis[api]: aborting, failed to create some containers rolling back
reshut2-82-75-dhcp:example-dockerfile-http smothiki$ deis info
=== luxury-neckwear Application
{
  "updated": "2015-05-14T23:46:38UTC", 
  "uuid": "a77c23e2-da7c-4077-b201-ef4bf7032097", 
  "created": "2015-05-14T23:13:45UTC", 
  "url": "luxury-neckwear.smothiki.io", 
  "owner": "smothiki", 
  "id": "luxury-neckwear", 
  "structure": {
    "cmd": 6
  }
}

=== luxury-neckwear Processes

--- cmd: 
cmd.1 up (v3)
cmd.2 up (v3)
cmd.3 up (v3)
cmd.4 up (v3)
cmd.5 up (v3)
cmd.6 up (v3)

=== luxury-neckwear Domains
No domains
```