### PR TITLE
ref(controller): add urls.py docstring and remove unused arg

### DIFF
--- a/controller/api/urls.py
+++ b/controller/api/urls.py
@@ -1,3 +1,7 @@
+"""
+URL routing patterns for the Deis REST API.
+"""
+
 from __future__ import unicode_literals
 
 from django.conf import settings
@@ -13,59 +17,58 @@ urlpatterns = patterns(
     '',
     url(r'^', include(router.urls)),
     # application release components
-    url(r'^apps/(?P<id>{})/config/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/config/?".format(settings.APP_URL_REGEX),
         views.ConfigViewSet.as_view({'get': 'retrieve', 'post': 'create'})),
-    url(r'^apps/(?P<id>{})/builds/(?P<uuid>[-_\w]+)/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/builds/(?P<uuid>[-_\w]+)/?".format(settings.APP_URL_REGEX),
         views.BuildViewSet.as_view({'get': 'retrieve'})),
-    url(r'^apps/(?P<id>{})/builds/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/builds/?".format(settings.APP_URL_REGEX),
         views.BuildViewSet.as_view({'get': 'list', 'post': 'create'})),
-    url(r'^apps/(?P<id>{})/releases/v(?P<version>[0-9]+)/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/releases/v(?P<version>[0-9]+)/?".format(settings.APP_URL_REGEX),
         views.ReleaseViewSet.as_view({'get': 'retrieve'})),
-    url(r'^apps/(?P<id>{})/releases/rollback/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/releases/rollback/?".format(settings.APP_URL_REGEX),
         views.ReleaseViewSet.as_view({'post': 'rollback'})),
-    url(r'^apps/(?P<id>{})/releases/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/releases/?".format(settings.APP_URL_REGEX),
         views.ReleaseViewSet.as_view({'get': 'list'})),
     # application infrastructure
-    url(r'^apps/(?P<id>{})/containers/restart/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/containers/restart/?".format(settings.APP_URL_REGEX),
         views.ContainerViewSet.as_view({'post': 'restart'})),
-    url(r'^apps/(?P<id>{})/containers/(?P<type>[-_\w.]+)/restart/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/containers/(?P<type>[-_\w.]+)/restart/?".format(settings.APP_URL_REGEX),
         views.ContainerViewSet.as_view({'post': 'restart'})),
-    url(r'^apps/(?P<id>{})/containers/(?P<type>[-_\w]+)/(?P<num>[-_\w]+)/restart/?'.format(
+    url(r"^apps/(?P<id>{})/containers/(?P<type>[-_\w]+)/(?P<num>[-_\w]+)/restart/?".format(
         settings.APP_URL_REGEX),
         views.ContainerViewSet.as_view({'post': 'restart'})),
-    url(r'^apps/(?P<id>{})/containers/(?P<type>[-_\w]+)/(?P<num>[-_\w]+)/?'.format(
+    url(r"^apps/(?P<id>{})/containers/(?P<type>[-_\w]+)/(?P<num>[-_\w]+)/?".format(
         settings.APP_URL_REGEX),
         views.ContainerViewSet.as_view({'get': 'retrieve'})),
-    url(r'^apps/(?P<id>{})/containers/(?P<type>[-_\w.]+)/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/containers/(?P<type>[-_\w.]+)/?".format(settings.APP_URL_REGEX),
         views.ContainerViewSet.as_view({'get': 'list'})),
-    url(r'^apps/(?P<id>{})/containers/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/containers/?".format(settings.APP_URL_REGEX),
         views.ContainerViewSet.as_view({'get': 'list'})),
     # application domains
-    url(r'^apps/(?P<id>{})/domains/(?P<domain>[-\._\w]+)/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/domains/(?P<domain>[-\._\w]+)/?".format(settings.APP_URL_REGEX),
         views.DomainViewSet.as_view({'delete': 'destroy'})),
-    url(r'^apps/(?P<id>{})/domains/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/domains/?".format(settings.APP_URL_REGEX),
         views.DomainViewSet.as_view({'post': 'create', 'get': 'list'})),
     # application actions
-    url(r'^apps/(?P<id>{})/scale/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/scale/?".format(settings.APP_URL_REGEX),
         views.AppViewSet.as_view({'post': 'scale'})),
-    url(r'^apps/(?P<id>{})/logs/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/logs/?".format(settings.APP_URL_REGEX),
         views.AppViewSet.as_view({'get': 'logs'})),
-    url(r'^apps/(?P<id>{})/run/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/run/?".format(settings.APP_URL_REGEX),
         views.AppViewSet.as_view({'post': 'run'})),
     # apps sharing
-    url(r'^apps/(?P<id>{})/perms/(?P<username>[-_\w]+)/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/perms/(?P<username>[-_\w]+)/?".format(settings.APP_URL_REGEX),
         views.AppPermsViewSet.as_view({'delete': 'destroy'})),
-    url(r'^apps/(?P<id>{})/perms/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/perms/?".format(settings.APP_URL_REGEX),
         views.AppPermsViewSet.as_view({'get': 'list', 'post': 'create'})),
     # apps base endpoint
-    url(r'^apps/(?P<id>{})/?'.format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/?".format(settings.APP_URL_REGEX),
         views.AppViewSet.as_view({'get': 'retrieve', 'delete': 'destroy'})),
     url(r'^apps/?',
         views.AppViewSet.as_view({'get': 'list', 'post': 'create'})),
     # key
     url(r'^keys/(?P<id>.+)/?',
-        views.KeyViewSet.as_view({
-            'get': 'retrieve', 'delete': 'destroy'})),
+        views.KeyViewSet.as_view({'get': 'retrieve', 'delete': 'destroy'})),
     url(r'^keys/?',
         views.KeyViewSet.as_view({'get': 'list', 'post': 'create'})),
     # hooks
@@ -89,7 +92,7 @@ urlpatterns = patterns(
         views.AdminPermsViewSet.as_view({'delete': 'destroy'})),
     url(r'^admin/perms/?',
         views.AdminPermsViewSet.as_view({'get': 'list', 'post': 'create'})),
-    url(r'^certs/(?P<common_name>[-_*.\w]+)/?'.format(settings.APP_URL_REGEX),
+    url(r'^certs/(?P<common_name>[-_*.\w]+)/?',
         views.CertificateViewSet.as_view({'get': 'retrieve', 'delete': 'destroy'})),
     url(r'^certs/?',
         views.CertificateViewSet.as_view({'get': 'list', 'post': 'create'})),


### PR DESCRIPTION
`pylint` pointed out this module lacked a docstring, and that a certs URL was ignoring a format arg. Also switched single- to double-quotes for format strings to follow an unenforced convention in the codebase.