### PR TITLE
fix(client): let requests read env vars

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -91,7 +91,6 @@ class Session(requests.Session):
 
     def __init__(self):
         super(Session, self).__init__()
-        self.trust_env = False
         config_dir = os.path.expanduser('~/.deis')
         self.proxies = {
             "http": os.getenv("http_proxy"),


### PR DESCRIPTION
This fix lets the `requests` library read configuration from environment
variables.

This is intended to fix a problem I had with being unable to
authenticate with deis when using a self-signed cert from a debian
system. By default, requests does not trust the system cert bundle on
debian systems and requires either `verify=/path/to/bundle` (as a config
value of requests.Session) or `REQUESTS_CA_BUNDLE=/path/to/bundle`. But,
in order for that environment variable to get read,
`requests.Session.trust_env` must be `True`.