### PR TITLE
feat(controller): Add endpoint to regenerate tokens

### DIFF
--- a/controller/api/__init__.py
+++ b/controller/api/__init__.py
@@ -2,4 +2,4 @@
 The **api** Django app presents a RESTful web API for interacting with the **deis** system.
 """
 
-__version__ = '1.4.0'
+__version__ = '1.5.0'

--- a/controller/api/permissions.py
+++ b/controller/api/permissions.py
@@ -129,3 +129,18 @@ class HasBuilderAuth(permissions.BasePermission):
         if not auth_header:
             return False
         return auth_header == settings.BUILDER_KEY
+
+
+class CanRegenerateToken(permissions.BasePermission):
+    """
+    Checks if a user can regenerate a token
+    """
+
+    def has_permission(self, request, view):
+        """
+        Return `True` if permission is granted, `False` otherwise.
+        """
+        if 'username' in request.data or 'all' in request.data:
+            return request.user.is_superuser
+        else:
+            return True

--- a/controller/api/tests/test_auth.py
+++ b/controller/api/tests/test_auth.py
@@ -278,3 +278,33 @@ class AuthTest(TestCase):
         response = self.client.post(url, json.dumps(submit), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.user1_token))
         self.assertEqual(response.status_code, 200)
+
+    def test_regenerate(self):
+        """ Test that token regeneration works"""
+
+        url = '/v1/auth/tokens/'
+
+        response = self.client.post(url, '{}', content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotEqual(response.data['token'], self.admin_token)
+
+        self.admin_token = Token.objects.get(user=self.admin)
+
+        response = self.client.post(url, '{"username" : "autotest2"}',
+                                    content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotEqual(response.data['token'], self.user1_token)
+
+        response = self.client.post(url, '{"all" : "true"}',
+                                    content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.post(url, '{}', content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
+
+        self.assertEqual(response.status_code, 401)

--- a/controller/api/urls.py
+++ b/controller/api/urls.py
@@ -87,6 +87,8 @@ urlpatterns = patterns(
         views.UserManagementViewSet.as_view({'post': 'passwd'})),
     url(r'^auth/login/',
         'rest_framework.authtoken.views.obtain_auth_token'),
+    url(r'^auth/tokens/',
+        views.TokenManagementViewSet.as_view({'post': 'regenerate'})),
     # admin sharing
     url(r'^admin/perms/(?P<username>[-_\w]+)/?',
         views.AdminPermsViewSet.as_view({'delete': 'destroy'})),

--- a/docs/managing_deis/operational_tasks.rst
+++ b/docs/managing_deis/operational_tasks.rst
@@ -52,28 +52,22 @@ Re-issuing User Authentication Tokens
 The controller API uses a simple token-based HTTP Authentication scheme. Token authentication is
 appropriate for client-server setups, such as native desktop and mobile clients. Each user of the
 platform is issued a token the first time that they sign up on the platform. If this token is
-compromised, you'll need to manually intervene to re-issue a new authentication token for the user.
-To do this, SSH into the node running the controller and drop into a Django shell:
+compromised, it will need to be regenerated.
+
+A user can regenerate their own token like this:
 
 .. code-block:: console
 
-    $ fleetctl ssh deis-controller
-    $ docker exec -it deis-controller python manage.py shell
-    >>>
+    $ deis auth:regenerate
 
-At this point, let's re-issue an auth token for this user. Let's assume that the name for the user
-is Bob (poor Bob):
+An administrator can also regenerate the token of another user like this:
 
 .. code-block:: console
 
-    >>> from django.contrib.auth.models import User
-    >>> from rest_framework.authtoken.models import Token
-    >>> bob = User.objects.get(username='bob')
-    >>> token = Token.objects.get(user=bob)
-    >>> token.delete()
-    >>> exit()
+    $ deis auth:regenerate -u test-user
 
-At this point, Bob will no longer be able to authenticate against the controller with his auth
+
+At this point, the user will no longer be able to authenticate against the controller with his auth
 token:
 
 .. code-block:: console
@@ -83,14 +77,10 @@ token:
     Detail:
     Invalid token
 
-For Bob to be able to use the API again, he will have to authenticate against the controller to be
-re-issued a new token:
+They will need to log back in to use their new auth token.
+
+If there is a cluster wide security breach, an administrator can regenerate everybody's auth token like this:
 
 .. code-block:: console
 
-    $ deis login http://deis.example.com
-    username: bob
-    password:
-    Logged in as bob
-    $ deis apps
-    === Apps
+    $ deis auth:regenerate --all=true

--- a/docs/reference/api-v1.5.rst
+++ b/docs/reference/api-v1.5.rst
@@ -1,21 +1,18 @@
-:title: Controller API v1.4
-:description: The v1.4 REST API for Deis' Controller
+:title: Controller API v1.5
+:description: The v1.5 REST API for Deis' Controller
 
-Controller API v1.4
+.. _controller_api_v1:
+
+Controller API v1.5
 ===================
 
-This is the v1.4 REST API for the :ref:`Controller`.
+This is the v1.5 REST API for the :ref:`Controller`.
 
 
 What's New
 ----------
 
-**New!** optional ``username`` argument for /v1/auth/passwd/
-**New!** Deprecate X prefixed headers
-``X_DEIS_API_VERSION`` ->  ``DEIS_API_VERSION``
-``X_DEIS_PLATFORM_VERSION`` -> ``DEIS_PLATFORM_VERSION``
-``X-Deis-Release`` -> ``Deis-Release``
-
+**New!** ``/auth/tokens/`` endpoint for regenerating tokens.
 
 Authentication
 --------------
@@ -52,7 +49,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -90,7 +87,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -113,9 +110,43 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
 
+Regenerate Token
+````````````````
+
+.. note::
+
+    This command could require administrative privileges
+
+Example Request:
+
+.. code-block:: console
+
+    POST /v1/auth/tokens/ HTTP/1.1
+    Host: deis.example.com
+    Authorization: token abc123
+
+Optional Parameters:
+
+.. code-block:: console
+
+    {
+        "username" : "test"
+        "all" : "true"
+    }
+
+Example Response:
+
+.. code-block:: console
+
+    HTTP/1.1 200 OK
+    X_DEIS_API_VERSION: 1.3
+    X_DEIS_PLATFORM_VERSION: 1.6.1
+    Content-Type: application/json
+
+    {"token": "abc123"}
 
 Change Password
 ```````````````
@@ -148,7 +179,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
 
 
@@ -172,7 +203,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -218,7 +249,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -249,7 +280,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
 
 
@@ -269,7 +300,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -306,7 +337,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: text/plain
 
@@ -330,7 +361,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -357,7 +388,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -390,7 +421,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -435,7 +466,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -465,7 +496,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
 
 
@@ -489,7 +520,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -529,7 +560,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -569,7 +600,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -604,7 +635,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -639,7 +670,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -677,7 +708,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
 
 
@@ -701,7 +732,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -737,7 +768,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
     X-Deis-Release: 3
@@ -780,7 +811,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
     X-Deis-Release: 4
@@ -822,7 +853,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -860,7 +891,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -890,7 +921,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
 
 
@@ -914,7 +945,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -959,7 +990,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
     X-Deis-Release: 4
@@ -997,7 +1028,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -1059,7 +1090,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -1095,7 +1126,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -1122,7 +1153,7 @@ Example Response:
 .. code-block:: console
 
     {
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
         "count": 1,
         "next": null,
@@ -1161,7 +1192,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -1191,7 +1222,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
 
 
@@ -1215,7 +1246,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 
@@ -1242,7 +1273,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
 
 
@@ -1262,7 +1293,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
 
 Grant User Administrative Privileges
@@ -1287,7 +1318,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
 
 Users
@@ -1313,7 +1344,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.4
+    DEIS_API_VERSION: 1.5
     DEIS_PLATFORM_VERSION: 1.7.0
     Content-Type: application/json
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -19,3 +19,4 @@ Reference Guide
     api-v1.2
     api-v1.3
     api-v1.4
+    api-v1.5

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -9,16 +9,21 @@ import (
 )
 
 var (
-	authLoginCmd    = "auth:login http://deis.{{.Domain}} --username={{.UserName}} --password={{.Password}}"
-	authLogoutCmd   = "auth:logout"
-	authRegisterCmd = "auth:register http://deis.{{.Domain}} --username={{.UserName}} --password={{.Password}} --email={{.Email}}"
-	authCancelCmd   = "auth:cancel --username={{.UserName}} --password={{.Password}} --yes"
+	authLoginCmd         = "auth:login http://deis.{{.Domain}} --username={{.UserName}} --password={{.Password}}"
+	authLogoutCmd        = "auth:logout"
+	authRegisterCmd      = "auth:register http://deis.{{.Domain}} --username={{.UserName}} --password={{.Password}} --email={{.Email}}"
+	authCancelCmd        = "auth:cancel --username={{.UserName}} --password={{.Password}} --yes"
+	authRegenerateCmd    = "auth:regenerate"
+	authRegenerateUsrCmd = "auth:regenerate -u {{.UserName}}"
+	authRegenerateAllCmd = "auth:regenerate --all"
+	checkTokenCmd        = "apps:list"
 )
 
 func TestAuth(t *testing.T) {
 	params := authSetup(t)
 	authRegisterTest(t, params)
 	authLogoutTest(t, params)
+	authRegenerateTest(t)
 	authLoginTest(t, params)
 	authWhoamiTest(t, params)
 	authPasswdTest(t, params)
@@ -63,4 +68,19 @@ func authRegisterTest(t *testing.T, params *utils.DeisTestConfig) {
 
 func authWhoamiTest(t *testing.T, params *utils.DeisTestConfig) {
 	utils.Execute(t, "auth:whoami", params, true, params.UserName)
+}
+
+func authRegenerateTest(t *testing.T) {
+	params := utils.GetGlobalConfig()
+	regenCmd := authRegenerateUsrCmd
+	loginCmd := authLoginCmd
+
+	utils.Execute(t, loginCmd, params, false, "")
+	utils.Execute(t, authRegenerateCmd, params, false, "")
+	utils.Execute(t, loginCmd, params, false, "")
+	utils.Execute(t, regenCmd, params, false, "")
+	utils.Execute(t, checkTokenCmd, params, true, "401 UNAUTHORIZED")
+	utils.Execute(t, loginCmd, params, false, "")
+	utils.Execute(t, authRegenerateAllCmd, params, false, "")
+	utils.Execute(t, checkTokenCmd, params, true, "401 UNAUTHORIZED")
 }


### PR DESCRIPTION
If a token was leaked, it could be regenerated with: `deis auth:regenerate`. Admin can regenerate a user's token with `deis auth:regenerate -u user` and could also regenerate everybody's auth token, in the event of a security breach, with `deis auth:regenerate --all=true`