### PR TITLE
feat(platform): support placement options for each plane and router mesh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ dev-cluster: discovery-url
 	ssh-add ~/.vagrant.d/insecure_private_key
 	deisctl config platform set sshPrivateKey=$(HOME)/.vagrant.d/insecure_private_key
 	deisctl config platform set domain=local3.deisapp.com
+	deisctl config platform set enablePlacementOptions=true
 	deisctl install platform
 
 discovery-url:

--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -7,6 +7,7 @@ coreos:
     public-ip: $private_ipv4
     # allow etcd to slow down at times
     etcd_request_timeout: 3.0
+    metadata: controlPlane=true,dataPlane=true,routerMesh=true
   units:
   - name: etcd.service
     command: start

--- a/controller/scheduler/fleet.py
+++ b/controller/scheduler/fleet.py
@@ -150,10 +150,10 @@ class FleetHTTPClient(AbstractSchedulerClient):
             f['value'] = f['value'].format(**l)
         # prepare tags only if one was provided
         tags = kwargs.get('tags', {})
-        if tags:
-            tagset = ' '.join(['"{}={}"'.format(k, v) for k, v in tags.viewitems()])
+        tagset = ' '.join(['"{}={}"'.format(k, v) for k, v in tags.viewitems()])
+        if settings.ENABLE_PLACEMENT_OPTIONS in ['true', 'True', 'TRUE', '1']:
             unit.append({"section": "X-Fleet", "name": "MachineMetadata",
-                         "value": tagset})
+                         "value": tagset + ' "dataPlane=true"'})
         # post unit to fleet
         self._put_unit(name, {"desiredState": "loaded", "options": unit})
 

--- a/controller/templates/confd_settings.py
+++ b/controller/templates/confd_settings.py
@@ -24,6 +24,8 @@ SSH_PRIVATE_KEY = """{{ if exists "/deis/platform/sshPrivateKey" }}{{ getv "/dei
 # platform domain must be provided
 DEIS_DOMAIN = '{{ getv "/deis/platform/domain" }}'
 
+ENABLE_PLACEMENT_OPTIONS = """{{ if exists "/deis/platform/enablePlacementOptions" }}{{ getv "/deis/platform/enablePlacementOptions" }}{{ else }}false{{end}}"""
+
 # use the private registry module
 REGISTRY_MODULE = 'registry.private'
 REGISTRY_URL = '{{ getv "/deis/registry/protocol" }}://{{ getv "/deis/registry/host" }}:{{ getv "/deis/registry/port" }}'  # noqa

--- a/deisctl/backend/fleet/create.go
+++ b/deisctl/backend/fleet/create.go
@@ -3,6 +3,7 @@ package fleet
 import (
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -96,7 +97,15 @@ func (c *FleetClient) createServiceUnit(component string, num int) (name string,
 	if err != nil {
 		return "", nil, err
 	}
-	uf, err = NewUnit(component, c.templatePaths)
+	decorateStr, err := c.configBackend.GetWithDefault("/deis/platform/enablePlacementOptions", "false")
+	if err != nil {
+		return "", nil, err
+	}
+	decorate, err := strconv.ParseBool(decorateStr)
+	if err != nil {
+		return "", nil, err
+	}
+	uf, err = NewUnit(component, c.templatePaths, decorate)
 	if err != nil {
 		return
 	}

--- a/deisctl/backend/fleet/create_test.go
+++ b/deisctl/backend/fleet/create_test.go
@@ -6,6 +6,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/deis/deis/deisctl/config/model"
+	"github.com/deis/deis/deisctl/test/mock"
+
 	"github.com/coreos/fleet/schema"
 )
 
@@ -30,7 +33,9 @@ func TestCreate(t *testing.T) {
 	testFleetClient := stubFleetClient{testUnits: []*schema.Unit{}, unitsMutex: &sync.Mutex{},
 		unitStatesMutex: &sync.Mutex{}}
 
-	c := &FleetClient{templatePaths: []string{name}, Fleet: &testFleetClient}
+	testConfigBackend := mock.ConfigBackend{Expected: []*model.ConfigNode{{Key: "/deis/platform/enablePlacementOptions", Value: "true"}}}
+
+	c := &FleetClient{templatePaths: []string{name}, Fleet: &testFleetClient, configBackend: testConfigBackend}
 
 	var errOutput string
 	var wg sync.WaitGroup

--- a/deisctl/backend/fleet/fleet.go
+++ b/deisctl/backend/fleet/fleet.go
@@ -6,13 +6,16 @@ import (
 	"path"
 	"text/tabwriter"
 
+	"github.com/deis/deis/deisctl/config"
+
 	"github.com/coreos/fleet/client"
 	"github.com/coreos/fleet/machine"
 )
 
 // FleetClient used to wrap Fleet API calls
 type FleetClient struct {
-	Fleet client.API
+	Fleet         client.API
+	configBackend config.Backend
 
 	// used to cache MachineStates
 	machineStates map[string]*machine.MachineState
@@ -25,7 +28,7 @@ type FleetClient struct {
 
 // NewClient returns a client used to communicate with Fleet
 // using the Registry API
-func NewClient() (*FleetClient, error) {
+func NewClient(cb config.Backend) (*FleetClient, error) {
 	client, err := getRegistryClient()
 	if err != nil {
 		return nil, err
@@ -41,6 +44,6 @@ func NewClient() (*FleetClient, error) {
 	out := new(tabwriter.Writer)
 	out.Init(os.Stdout, 0, 8, 1, '\t', 0)
 
-	return &FleetClient{Fleet: client, templatePaths: templatePaths, runner: sshCommandRunner{},
+	return &FleetClient{Fleet: client, configBackend: cb, templatePaths: templatePaths, runner: sshCommandRunner{},
 		out: out, errWriter: os.Stderr}, nil
 }

--- a/deisctl/backend/fleet/fleet_test.go
+++ b/deisctl/backend/fleet/fleet_test.go
@@ -6,6 +6,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/deis/deis/deisctl/config/model"
+	"github.com/deis/deis/deisctl/test/mock"
+
 	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/schema"
 )
@@ -176,8 +179,10 @@ func TestNewClient(t *testing.T) {
 	// set required flags
 	Flags.Endpoint = "http://127.0.0.1:4001"
 
+	testConfigBackend := mock.ConfigBackend{Expected: []*model.ConfigNode{}}
+
 	// instantiate client
-	_, err := NewClient()
+	_, err := NewClient(testConfigBackend)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/deisctl/backend/fleet/scale_test.go
+++ b/deisctl/backend/fleet/scale_test.go
@@ -7,6 +7,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/deis/deis/deisctl/config/model"
+	"github.com/deis/deis/deisctl/test/mock"
+
 	"github.com/coreos/fleet/schema"
 )
 
@@ -30,7 +33,9 @@ func TestScaleUp(t *testing.T) {
 
 	testFleetClient := stubFleetClient{testUnits: testUnits, testUnitStates: []*schema.UnitState{}, unitsMutex: &sync.Mutex{}, unitStatesMutex: &sync.Mutex{}}
 
-	c := &FleetClient{templatePaths: []string{name}, Fleet: &testFleetClient}
+	testConfigBackend := mock.ConfigBackend{Expected: []*model.ConfigNode{{Key: "/deis/platform/enablePlacementOptions", Value: "true"}}}
+
+	c := &FleetClient{templatePaths: []string{name}, Fleet: &testFleetClient, configBackend: testConfigBackend}
 
 	var errOutput string
 	var wg sync.WaitGroup

--- a/deisctl/backend/fleet/unit.go
+++ b/deisctl/backend/fleet/unit.go
@@ -11,6 +11,21 @@ import (
 	"github.com/coreos/fleet/unit"
 )
 
+// path hierarchy for finding systemd service templates
+var templatePaths = []string{
+	os.Getenv("DEISCTL_UNITS"),
+	path.Join(os.Getenv("HOME"), ".deis", "units"),
+	"/var/lib/deis/units",
+}
+
+// and the same for systemd service "decorators" for optionally isolating
+// control plane, data plane, and router mesh
+var decoratorPaths = []string{
+	path.Join(os.Getenv("DEISCTL_UNITS"), "decorators"),
+	path.Join(os.Getenv("HOME"), ".deis", "units", "decorators"),
+	"/var/lib/deis/units/decorators",
+}
+
 // Units returns a list of units filtered by target
 func (c *FleetClient) Units(target string) (units []string, err error) {
 	allUnits, err := c.Fleet.Units()
@@ -56,14 +71,19 @@ func (c *FleetClient) lastUnit(component string) (num int, err error) {
 
 // NewUnit takes a component type and returns a Fleet unit
 // that includes the relevant systemd service template
-func NewUnit(component string, templatePaths []string) (uf *unit.UnitFile, err error) {
+func NewUnit(component string, templatePaths []string, decorate bool) (uf *unit.UnitFile, err error) {
 	template, err := readTemplate(component, templatePaths)
 	if err != nil {
 		return
 	}
-	uf, err = unit.NewUnitFile(string(template))
-	if err != nil {
-		return
+	if decorate {
+		decorator, err := readDecorator(component)
+		if err != nil {
+			return nil, err
+		}
+		uf, err = unit.NewUnitFile(string(template) + "\n" + string(decorator))
+	} else {
+		uf, err = unit.NewUnitFile(string(template))
 	}
 	return
 }
@@ -102,5 +122,28 @@ func readTemplate(component string, templatePaths []string) (out []byte, err err
 	if err != nil {
 		return
 	}
+	return
+}
+
+// readDecorator returns the contents of a file containing a snippet that can
+// optionally be grafted on to the end of a corresponding systemd unit to
+// achieve isolation of the control plane, data plane, and router mesh
+func readDecorator(component string) (out []byte, err error) {
+	decoratorName := "deis-" + component + ".service.decorator"
+	var decoratorFile string
+
+	// look in $DEISCTL_UNITS env var, then the local and global root paths
+	for _, p := range decoratorPaths {
+		filename := path.Join(p, decoratorName)
+		if _, err := os.Stat(filename); err == nil {
+			decoratorFile = filename
+			break
+		}
+	}
+
+	if decoratorFile == "" {
+		return
+	}
+	out, err = ioutil.ReadFile(decoratorFile)
 	return
 }

--- a/deisctl/backend/fleet/unit_test.go
+++ b/deisctl/backend/fleet/unit_test.go
@@ -119,7 +119,7 @@ Description=deis-controller`
 
 	ioutil.WriteFile(path.Join(name, unit+".service"), []byte(unitFile), 777)
 
-	uf, err := NewUnit(unit[5:], []string{name})
+	uf, err := NewUnit(unit[5:], []string{name}, false)
 
 	if err != nil {
 		t.Fatal(err)

--- a/deisctl/client/client.go
+++ b/deisctl/client/client.go
@@ -46,24 +46,24 @@ type Client struct {
 func NewClient(requestedBackend string) (*Client, error) {
 	var backend backend.Backend
 
+	cb, err := etcd.NewConfigBackend()
+	if err != nil {
+		return nil, err
+	}
+
 	if requestedBackend == "" {
 		requestedBackend = "fleet"
 	}
 
 	switch requestedBackend {
 	case "fleet":
-		b, err := fleet.NewClient()
+		b, err := fleet.NewClient(cb)
 		if err != nil {
 			return nil, err
 		}
 		backend = b
 	default:
 		return nil, errors.New("invalid backend")
-	}
-
-	cb, err := etcd.NewConfigBackend()
-	if err != nil {
-		return nil, err
 	}
 
 	return &Client{Backend: backend, configBackend: cb}, nil

--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -2,11 +2,8 @@ package cmd
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -18,6 +15,7 @@ import (
 	"github.com/deis/deis/deisctl/config"
 	"github.com/deis/deis/deisctl/units"
 	"github.com/deis/deis/deisctl/utils"
+	"github.com/deis/deis/deisctl/utils/net"
 )
 
 const (
@@ -462,19 +460,7 @@ func RefreshUnits(dir, tag, url string) error {
 	for _, unit := range units.Names {
 		src := fmt.Sprintf(url, tag, unit)
 		dest := filepath.Join(dir, unit+".service")
-		res, err := http.Get(src)
-		if err != nil {
-			return err
-		}
-		if res.StatusCode != 200 {
-			return errors.New(res.Status)
-		}
-		defer res.Body.Close()
-		data, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-		if err = ioutil.WriteFile(dest, data, 0644); err != nil {
+		if err := net.Download(src, dest); err != nil {
 			return err
 		}
 		fmt.Printf("Refreshed %s from %s\n", unit, tag)

--- a/deisctl/cmd/cmd_test.go
+++ b/deisctl/cmd/cmd_test.go
@@ -115,7 +115,7 @@ func TestRefreshUnits(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	err = RefreshUnits(name, "v1.7.2", server.URL+"/%s/%s.service")
+	err = RefreshUnits(name, "v1.7.2", server.URL+"/")
 
 	if err != nil {
 		t.Error(err)
@@ -123,8 +123,12 @@ func TestRefreshUnits(t *testing.T) {
 
 	files, err := ioutil.ReadDir(name)
 
-	if len(units.Names) != len(files) {
-		t.Error(fmt.Errorf("Expected %d units, Got %d", len(units.Names), len(files)))
+	// There will be a "decorators" subdirectory and that shouldn't be
+	// counted as a unit when making the upcoming assertion.
+	numFiles := len(files) - 1
+
+	if len(units.Names) != numFiles {
+		t.Error(fmt.Errorf("Expected %d units, Got %d", len(units.Names), numFiles))
 	}
 
 	for _, unit := range units.Names {
@@ -155,7 +159,7 @@ func TestRefreshUnitsError(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	err = RefreshUnits(name, "foo", server.URL+"/%s/%s.service")
+	err = RefreshUnits(name, "foo", server.URL+"/")
 	result := err.Error()
 	expected := "404 Not Found"
 

--- a/deisctl/config/backend.go
+++ b/deisctl/config/backend.go
@@ -5,6 +5,7 @@ import "github.com/deis/deis/deisctl/config/model"
 // Backend is an interface for any sort of underlying key/value config store
 type Backend interface {
 	Get(string) (string, error)
+	GetWithDefault(string, string) (string, error)
 	Set(string, string) (string, error)
 	SetWithTTL(string, string, uint64) (string, error)
 	Delete(string) error

--- a/deisctl/config/etcd/etcd.go
+++ b/deisctl/config/etcd/etcd.go
@@ -45,6 +45,21 @@ func (cb *ConfigBackend) Get(key string) (string, error) {
 	return resp.Node.Value, nil
 }
 
+// GetWithDefault gets a value by key from etcd and return a default value if
+// not found
+func (cb *ConfigBackend) GetWithDefault(key string, defaultValue string) (string, error) {
+	sort, recursive := true, false
+	resp, err := cb.etcdlib.Get(key, sort, recursive)
+	if err != nil {
+		etcdErr, ok := err.(*etcdlib.EtcdError)
+		if ok && etcdErr.ErrorCode == 100 {
+			return defaultValue, nil
+		}
+		return "", err
+	}
+	return resp.Node.Value, nil
+}
+
 func singleNodeToConfigNode(node *etcdlib.Node) *model.ConfigNode {
 	key := model.ConfigNode{
 		Key:        node.Key,

--- a/deisctl/test/mock/config.go
+++ b/deisctl/test/mock/config.go
@@ -25,6 +25,17 @@ func (cb ConfigBackend) Get(key string) (value string, err error) {
 	return "", fmt.Errorf("%s does not exist", cb.Expected)
 }
 
+// GetWithDefault gets a value by key from an in memory config backend and
+// return a default value if not found
+func (cb ConfigBackend) GetWithDefault(key string, defaultValue string) (string, error) {
+	for _, expect := range cb.Expected {
+		if expect.Key == key {
+			return expect.Value, nil
+		}
+	}
+	return defaultValue, nil
+}
+
 // Set a value for the specified key in an in memory config backend
 func (cb ConfigBackend) Set(key, value string) (returnedValue string, err error) {
 	for _, expect := range cb.Expected {

--- a/deisctl/units/decorators/deis-builder.service.decorator
+++ b/deisctl/units/decorators/deis-builder.service.decorator
@@ -1,0 +1,3 @@
+
+[X-Fleet]
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-cache.service.decorator
+++ b/deisctl/units/decorators/deis-cache.service.decorator
@@ -1,0 +1,3 @@
+
+[X-Fleet]
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-controller.service.decorator
+++ b/deisctl/units/decorators/deis-controller.service.decorator
@@ -1,0 +1,3 @@
+
+[X-Fleet]
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-database.service.decorator
+++ b/deisctl/units/decorators/deis-database.service.decorator
@@ -1,0 +1,3 @@
+
+[X-Fleet]
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-kube-apiserver.service.decorator
+++ b/deisctl/units/decorators/deis-kube-apiserver.service.decorator
@@ -1,0 +1,3 @@
+
+[X-Fleet]
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-kube-controller-manager.service.decorator
+++ b/deisctl/units/decorators/deis-kube-controller-manager.service.decorator
@@ -1,0 +1,3 @@
+
+[X-Fleet]
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-kube-kubelet.service.decorator
+++ b/deisctl/units/decorators/deis-kube-kubelet.service.decorator
@@ -1,0 +1,1 @@
+MachineMetadata="dataPlane=true"

--- a/deisctl/units/decorators/deis-kube-proxy.service.decorator
+++ b/deisctl/units/decorators/deis-kube-proxy.service.decorator
@@ -1,0 +1,1 @@
+MachineMetadata="routerMesh=true"

--- a/deisctl/units/decorators/deis-kube-scheduler.service.decorator
+++ b/deisctl/units/decorators/deis-kube-scheduler.service.decorator
@@ -1,0 +1,3 @@
+
+[X-Fleet]
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-logger.service.decorator
+++ b/deisctl/units/decorators/deis-logger.service.decorator
@@ -1,0 +1,3 @@
+
+[X-Fleet]
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-mesos-marathon.service.decorator
+++ b/deisctl/units/decorators/deis-mesos-marathon.service.decorator
@@ -1,0 +1,2 @@
+
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-mesos-master.service.decorator
+++ b/deisctl/units/decorators/deis-mesos-master.service.decorator
@@ -1,0 +1,3 @@
+
+[X-Fleet]
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-mesos-slave.service.decorator
+++ b/deisctl/units/decorators/deis-mesos-slave.service.decorator
@@ -1,0 +1,2 @@
+
+MachineMetadata="dataPlane=true"

--- a/deisctl/units/decorators/deis-publisher.service.decorator
+++ b/deisctl/units/decorators/deis-publisher.service.decorator
@@ -1,0 +1,1 @@
+MachineMetadata="dataPlane=true"

--- a/deisctl/units/decorators/deis-registry.service.decorator
+++ b/deisctl/units/decorators/deis-registry.service.decorator
@@ -1,0 +1,1 @@
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-router.service.decorator
+++ b/deisctl/units/decorators/deis-router.service.decorator
@@ -1,0 +1,1 @@
+MachineMetadata="routerMesh=true"

--- a/deisctl/units/decorators/deis-store-admin.service.decorator
+++ b/deisctl/units/decorators/deis-store-admin.service.decorator
@@ -1,0 +1,1 @@
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-store-daemon.service.decorator
+++ b/deisctl/units/decorators/deis-store-daemon.service.decorator
@@ -1,0 +1,1 @@
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-store-gateway.service.decorator
+++ b/deisctl/units/decorators/deis-store-gateway.service.decorator
@@ -1,0 +1,1 @@
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-store-metadata.service.decorator
+++ b/deisctl/units/decorators/deis-store-metadata.service.decorator
@@ -1,0 +1,1 @@
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-store-monitor.service.decorator
+++ b/deisctl/units/decorators/deis-store-monitor.service.decorator
@@ -1,0 +1,1 @@
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-store-volume.service.decorator
+++ b/deisctl/units/decorators/deis-store-volume.service.decorator
@@ -1,0 +1,1 @@
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-swarm-manager.service.decorator
+++ b/deisctl/units/decorators/deis-swarm-manager.service.decorator
@@ -1,0 +1,3 @@
+
+[X-Fleet]
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/decorators/deis-swarm-node.service.decorator
+++ b/deisctl/units/decorators/deis-swarm-node.service.decorator
@@ -1,0 +1,1 @@
+MachineMetadata="dataPlane=true"

--- a/deisctl/units/decorators/deis-zookeeper.service.decorator
+++ b/deisctl/units/decorators/deis-zookeeper.service.decorator
@@ -1,0 +1,2 @@
+
+MachineMetadata="controlPlane=true"

--- a/deisctl/units/units.go
+++ b/deisctl/units/units.go
@@ -31,4 +31,4 @@ var Names = []string{
 }
 
 // URL is the GitHub url where these units can be refreshed from
-var URL = "https://raw.githubusercontent.com/deis/deis/%s/deisctl/units/%s.service"
+var URL = "https://raw.githubusercontent.com/deis/deis/"

--- a/deisctl/utils/net/net.go
+++ b/deisctl/utils/net/net.go
@@ -1,0 +1,29 @@
+// Package net contains commonly useful network functions
+package net
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+)
+
+// Download downloads a resource from a specified
+// source (URL) to the specified destination
+func Download(src string, dest string) error {
+	res, err := http.Get(src)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 200 {
+		return errors.New(res.Status)
+	}
+	defer res.Body.Close()
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	if err = ioutil.WriteFile(dest, data, 0644); err != nil {
+		return err
+	}
+	return nil
+}

--- a/docs/_includes/_isolating-planes-description.rst
+++ b/docs/_includes/_isolating-planes-description.rst
@@ -1,0 +1,17 @@
+Whether built for evaluation or to host production applications, when managing a
+small Deis cluster (three to five nodes), it is reasonable to accept the
+platform's default behavior wherein the Control Plane, Data Plane, and Router
+Mesh are not isolated from one another. (See :ref:`architecture`.) This means
+Control Plane components such as the :ref:`controller` or :ref:`database` will
+be eligible to run on any node, as will the Router Mesh and the Data Plane
+components such as :ref:`logspout`, :ref:`publisher`, and deployed applications.
+
+In larger clusters however, nodes are more easily thought of as a commodity.
+Operators may scale clusters out to meet demand or in to conserve resources. In
+such cases, it is beneficial to isolate the Control Plane, which has no
+significant need to scale (and optionally, the Router Mesh) to a small, fixed
+number of nodes that are exempt from such scaling events.  This eliminates the
+possibility that Control Plane components running on a decommissioned node will
+experience downtime as they are rescheduled.  Additionally, this reserves the
+resources of a large (and possibly dynamic) pool of nodes for the workloads that
+are most likely to scale-- applications.

--- a/docs/managing_deis/index.rst
+++ b/docs/managing_deis/index.rst
@@ -20,6 +20,7 @@ Managing Deis
     platform_logging
     platform_monitoring
     production_deployments
+    isolating-planes
     isolating-etcd
     recovering-ceph-quorum
     running-deis-without-ceph

--- a/docs/managing_deis/isolating-planes.rst
+++ b/docs/managing_deis/isolating-planes.rst
@@ -1,0 +1,119 @@
+:title: Isolating the Planes
+:description: Configuring the cluster to isolate the control plane, data plane, and router mesh.
+
+.. _isolating-planes:
+
+Isolating the Planes
+====================
+
+.. include:: ../_includes/_isolating-planes-description.rst
+
+Understanding Fleet metadata
+----------------------------
+
+The key to isolating the Control Plane, Data Plane, and Router Mesh is Fleet
+metadata.  Although Deis supports alternate schedulers, Deis components
+themselves are all scheduled via Fleet.
+
+Deis configures the Fleet daemon executing on each node at the time of
+provisioning via cloud-config.  Within that configuration, it is possible to tag
+nodes with metadata in the form of key/value pairs to arbitrarily describe
+attributes of the node.  For instance, an operator may tag a node with
+``ssd=true`` to indicate that a node's volumes use solid state disk.
+
+.. code-block:: yaml
+
+    #cloud-config
+    ---
+    coreos:
+      fleet:
+        metadata: ssd=true
+    # ...
+
+When scheduling a unit of work via Fleet, it is also possible to annotate that
+unit with metadata that is required to be present on any node in order to be
+considered eligible to host that work.  In keeping with our previous example,
+to restrict a unit of work to only those nodes equipped with SSD, the unit may
+be annotated thusly:
+
+.. code-block:: yaml
+
+    # ...
+    [X-Fleet]
+    MachineMetadata="ssd=true"
+
+Deis takes advantage of this very mechanism to establish which nodes are
+eligible to host each of the Control Plane, Data Plane, and Router Mesh.
+
+`More details on Fleet metadata`_
+
+cloud-config
+------------
+
+To configure a Fleet node as eligible to host Control Plane components, the
+following cloud-config may be used:
+
+.. code-block:: yaml
+
+    #cloud-config
+    ---
+    coreos:
+      fleet:
+        metadata: controlPlane=true
+
+Similarly, ``dataPlane=true`` and ``routerMesh=true`` may be used to establish
+eligibility to host components of the Data Plane (including applications) and
+Router Mesh, respectively.
+
+It is also possible to configure nodes as eligible to host two or even all
+three of the Control Plane, Data Plane, and Router Mesh.  In fact, this is
+the default behavior described by Deis' included cloud-config.
+
+.. code-block:: yaml
+
+    #cloud-config
+    ---
+    coreos:
+      fleet:
+        metadata: controlPlane=true,dataPlane=true,routerMesh=true
+
+It should be obvious that isolating the planes as described here requires
+subsets of a cluster's nodes to be configured differently from one another (with
+different metadata). Deis provisioning scripts do not currently account for
+this, so managing separate cloud-config for each subset of nodes in the cluster
+is left as an exercise for the advanced operator.
+
+Decorating units
+----------------
+
+To complement the cloud-config described above, Deis 1.9.0 and later are capable
+of seamlessly "decorating" the Fleet units for each Deis platform component with
+the metadata that describes where each unit may be hosted.
+
+.. note::
+
+    For the purposes of backwards compatibility with Deis clusters provisioned
+    using versions of Deis older than 1.9.0, decorating the platform's units
+    with metadata is an opt-in.  Nodes in older clusters are guaranteed to be
+    lacking the metadata that indicates what components they are eligible to
+    host.  As such, decorated units would be ineligible to run anywhere within
+    such a cluster.
+
+    To opt in, use the following:
+
+    .. code-block:: console
+
+        $ deisctl config platform set enablePlacementOptions=true
+
+Alternate schedulers
+--------------------
+
+Recent versions of Deis ship with
+:ref:`technology previews <choosing_a_scheduler>` that permit the use of
+alternate schedulers such as Swarm or Mesos with Marathon.
+
+If opting into both isolated planes and an alternate scheduler, units for the
+alternate scheduler's agents (a Mesos slave process, for instance) will be
+decorated appropriately to isolate them to the Data Plane.
+
+.. _`More details on Fleet metadata`: https://coreos.com/fleet/docs/latest/unit-files-and-scheduling.html#fleet-specific-options

--- a/docs/managing_deis/production_deployments.rst
+++ b/docs/managing_deis/production_deployments.rst
@@ -9,6 +9,13 @@ Production deployments
 Many Deis users are running Deis quite successfully in production. When readying a Deis deployment
 for production workloads, there are some additional (but optional) recommendations.
 
+Isolating the Planes
+--------------------
+
+.. include:: ../_includes/_isolating-planes-description.rst
+
+See :ref:`isolating-planes` for further details.
+
 Isolating etcd
 --------------
 

--- a/docs/understanding_deis/architecture.rst
+++ b/docs/understanding_deis/architecture.rst
@@ -70,8 +70,11 @@ Topologies
 
 For small deployments you can run the entire platform
 -- Control Plane, Data Plane and Router Mesh -- on just 3 servers.
-For larger deployments, you'll want to isolate the Control Plane and Router Mesh,
-then scale your data plane out to as many servers as you need.
+
+For larger deployments, you'll want to isolate the Control Plane and Router
+Mesh, then scale your Data Plane out to as many servers as you need.
+
+See :ref:`isolating-planes` for further details.
 
 The Deis Control Plane, Data Plane, and Router Mesh components all depend on an
 etcd cluster for service discovery and configuration. For larger deployments,


### PR DESCRIPTION
Addresses #3023 

Documentation to follow if the approach is satisfactory.

This updates units (and code that generates units) such that Deis platform
components belonging to the control plane can be scheduled only where
machine metadata includes controlPlane=true.  Similarly, data plane components
(including applications) can be scheduled only where machine metadata includes
dataPlane=true and router mesh components can be scheduled only whrere machine
metadata includes routerMesh=true.

user-data.example is modified such that machines configured from that
cloud-config are eligible to host both planes and the router mesh.  This
permits small clusters composed entirely of general purpose nodes to be
constructed as easily as ever before and permits the platform to be installed
to such a cluster without complication, but it additionally creates the
the ability for advanced operators using custom cloud-config to easily partition
the nodes of a larger cluster by role without needing to modify/customize unit
files.  This is especially useful for anyone wishing to implement CoreOS' own
recommended large / production-worthy cluster architecture documented here:

https://coreos.com/docs/cluster-management/setup/cluster-architectures/#production-cluster-with-central-services

~~BREAKING CHANGE: Requires that all machines hosting Deis components
be assigned one or more of controlPlane=true, dataPlane=true, or
routerMesh=true via cloud-config.  This represents a breaking
change for anyone upgrading an existing clutser.~~