### PR TITLE
[WIP] ref(publisher): tech debt removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ logspout/build/
 logspout/image/logspout
 logspout/Godeps/
 publisher/Godeps/
-publisher/image/bin/publisher
+publisher/rootfs/bin/publisher
 router/Godeps/
 swarm/image/bin/
 

--- a/deisctl/units/deis-publisher.service
+++ b/deisctl/units/deis-publisher.service
@@ -8,7 +8,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-publisher >/dev/null 2>&1 && docker rm -f deis-publisher || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker run --name deis-publisher --rm -v /var/run/docker.sock:/var/run/docker.sock $IMAGE --host=$COREOS_PRIVATE_IPV4 --etcd-host=$COREOS_PRIVATE_IPV4"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker run --name deis-publisher --rm -v /var/run/docker.sock:/var/run/docker.sock $IMAGE --host=$COREOS_PRIVATE_IPV4 --etcd-addr=$COREOS_PRIVATE_IPV4:4001"
 ExecStopPost=-/usr/bin/docker rm -f deis-publisher
 Restart=on-failure
 RestartSec=5

--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -11,12 +11,12 @@ COMPONENT = $(notdir $(repo_path))
 DOCKER_IMAGE := $(IMAGE_PREFIX)$(COMPONENT)
 RELEASE_IMAGE := $(DOCKER_IMAGE):$(BUILD_TAG)
 REMOTE_IMAGE := $(REGISTRY)/$(RELEASE_IMAGE)
-BINARY_DEST_DIR = image/bin
+BINARY_DEST_DIR = rootfs/bin
 
 build: check-docker
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix cgo -ldflags '-s' -o $(BINARY_DEST_DIR)/publisher github.com/deis/deis/publisher || exit 1
 	$(call check-static-binary,$(BINARY_DEST_DIR)/publisher)
-	docker build -t $(RELEASE_IMAGE) image
+	docker build -t $(RELEASE_IMAGE) rootfs
 
 clean: check-docker check-registry
 	rm -rf $(BINARY_DEST_DIR)

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -48,15 +48,15 @@ func main() {
 		}
 	}()
 
-	server, err := server.New(dockerAddr, etcdAddr, host)
+	server, err := server.New(dockerAddr, etcdAddr, host, publishTTL)
 	if err != nil {
 		log.Fatalf("failed to start (%s)", err)
 	}
 
-	go server.Listen(publishTTL)
+	go server.Listen()
 
 	for {
-		go server.Poll(publishTTL)
+		go server.Poll()
 		time.Sleep(interval)
 	}
 }

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -25,13 +25,13 @@ var (
 )
 
 func init() {
-	flag.StringVar(&bindAddr, "bind-addr", "localhost:6060", "The IP address and port to bind to")
-	flag.DurationVar(&refreshDuration, "refresh-duration", 10 * time.Second, "The time to wait between etcd refreshes")
-	flag.DurationVar(&etcdTTL, "etcd-ttl", refreshDuration * 2, "The TTL for all of the keys in etcd")
-	flag.StringVar(&host, "host", "127.0.0.1", "The host where the publisher is running")
-	flag.StringVar(&dockerAddr, "docker-addr", "unix:///var/run/docker.sock", "The bind address to the docker API")
-	flag.StringVar(&etcdAddr, "etcd-addr", "http://127.0.0.1:4001", "The bind address to the etcd host")
-	flag.StringVar(&logLevel, "log-level", "error", "Acceptable values: error, debug")
+	flag.StringVar(&bindAddr, "bind-addr", "localhost:6060", "address to listen for incoming HTTP requests")
+	flag.DurationVar(&refreshDuration, "interval", 10 * time.Second, "backend polling interval")
+	flag.DurationVar(&etcdTTL, "publish-ttl", refreshDuration * 2, "backend TTL when publishing keys")
+	flag.StringVar(&host, "host", "127.0.0.1", "host address of the machine")
+	flag.StringVar(&dockerAddr, "docker-addr", "unix:///var/run/docker.sock", "address to a docker API")
+	flag.StringVar(&etcdAddr, "etcd-addr", "http://127.0.0.1:4001", "address to the etcd host")
+	flag.StringVar(&logLevel, "log-level", "error", "level which publisher should log messages (Accepted levels: error, debug)")
 }
 
 func main() {

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -59,8 +59,8 @@ func main() {
 		log.Fatalf("failed to start (%s)", err)
 	}
 
-	// run Poll() once at boot to publish existing containers
-	go sever.Poll()
+	// run Publish() once at boot to publish existing containers
+	go server.Publish()
 	go server.Listen(stopChan)
 
 	t := time.NewTicker(interval)
@@ -68,7 +68,8 @@ func main() {
 	for {
 		select {
 		case <-t.C:
-			go server.Poll()
+			// we need to re-publish containers every interval so the TTL doesn't expire
+			go server.Publish()
 		case <-signalChan:
 			log.Info("shutting down publisher...")
 			stopChan <- true

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -14,53 +14,51 @@ import (
 	"github.com/deis/deis/publisher/server"
 )
 
-const (
-	defaultBindAddr    				 = "localhost:6060"
-	defaultRefreshTime time.Duration = 10 * time.Second
-	defaultEtcdTTL     time.Duration = defaultRefreshTime * 2
-	defaultHost                      = "127.0.0.1"
-	defaultDockerHost                = "unix:///var/run/docker.sock"
-	defaultEtcdHost                  = "127.0.0.1"
-	defaultEtcdPort                  = "4001"
-	defaultLogLevel                  = "error"
+var (
+	bindAddr        string
+	refreshDuration time.Duration
+	etcdTTL         time.Duration
+	host            string
+	dockerAddr      string
+	etcdAddr        string
+	logLevel        string
 )
 
-var (
-	bindAddr        = flag.String("bind-addr", defaultBindAddr, "The IP address and port to bind to")
-	refreshDuration = flag.Duration("refresh-duration", defaultRefreshTime, "The time to wait between etcd refreshes.")
-	etcdTTL         = flag.Duration("etcd-ttl", defaultEtcdTTL, "The TTL for all of the keys in etcd.")
-	host            = flag.String("host", defaultHost, "The host where the publisher is running.")
-	dockerHost      = flag.String("docker-host", defaultDockerHost, "The host where to find docker.")
-	etcdHost        = flag.String("etcd-host", defaultEtcdHost, "The etcd host.")
-	etcdPort        = flag.String("etcd-port", defaultEtcdPort, "The etcd port.")
-	logLevel        = flag.String("log-level", defaultLogLevel, "Acceptable values: error, debug")
-)
+func init() {
+	flag.StringVar(&bindAddr, "bind-addr", "localhost:6060", "The IP address and port to bind to")
+	flag.DurationVar(&refreshDuration, "refresh-duration", 10 * time.Second, "The time to wait between etcd refreshes")
+	flag.DurationVar(&etcdTTL, "etcd-ttl", refreshDuration * 2, "The TTL for all of the keys in etcd")
+	flag.StringVar(&host, "host", "127.0.0.1", "The host where the publisher is running")
+	flag.StringVar(&dockerAddr, "docker-addr", "unix:///var/run/docker.sock", "The bind address to the docker API")
+	flag.StringVar(&etcdAddr, "etcd-addr", "http://127.0.0.1:4001", "The bind address to the etcd host")
+	flag.StringVar(&logLevel, "log-level", "error", "Acceptable values: error, debug")
+}
 
 func main() {
 	flag.Parse()
 
 	log.Println("booting publisher...")
 
-	dockerClient, err := docker.NewClient(*dockerHost)
+	dockerClient, err := docker.NewClient(dockerAddr)
 	if err != nil {
 		log.Fatal(err)
 	}
-	etcdClient := etcd.NewClient([]string{"http://" + *etcdHost + ":" + *etcdPort})
+	etcdClient := etcd.NewClient([]string{etcdAddr})
 
-	server := server.New(dockerClient, etcdClient, *host, *logLevel)
+	server := server.New(dockerClient, etcdClient, host, logLevel)
 
-	go server.Listen(*etcdTTL)
+	go server.Listen(etcdTTL)
 
 	go func() {
 		msg := fmt.Sprintf("profiler listening on %s", bindAddr)
-		if err := http.ListenAndServe(*bindAddr, nil); err != nil {
+		if err := http.ListenAndServe(bindAddr, nil); err != nil {
 			msg = err.Error()
 		}
 		log.Println(msg)
 	}()
 
 	for {
-		go server.Poll(*etcdTTL)
-		time.Sleep(*refreshDuration)
+		go server.Poll(etcdTTL)
+		time.Sleep(refreshDuration)
 	}
 }

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -15,20 +15,20 @@ import (
 )
 
 var (
-	bindAddr        string
-	refreshDuration time.Duration
-	etcdTTL         time.Duration
-	host            string
-	dockerAddr      string
-	etcdAddr        string
-	log             = logrus.New()
-	logLevel        string
+	bindAddr   string
+	interval   time.Duration
+	etcdTTL    time.Duration
+	host       string
+	dockerAddr string
+	etcdAddr   string
+	log        = logrus.New()
+	logLevel   string
 )
 
 func init() {
 	flag.StringVar(&bindAddr, "bind-addr", "localhost:6060", "address to listen for incoming HTTP requests")
-	flag.DurationVar(&refreshDuration, "interval", 10 * time.Second, "backend polling interval")
-	flag.DurationVar(&etcdTTL, "publish-ttl", refreshDuration * 2, "backend TTL when publishing keys")
+	flag.DurationVar(&interval, "interval", 10*time.Second, "backend polling interval")
+	flag.DurationVar(&etcdTTL, "publish-ttl", interval*2, "backend TTL when publishing keys")
 	flag.StringVar(&host, "host", "127.0.0.1", "host address of the machine")
 	flag.StringVar(&dockerAddr, "docker-addr", "unix:///var/run/docker.sock", "address to a docker API")
 	flag.StringVar(&etcdAddr, "etcd-addr", "http://127.0.0.1:4001", "address to the etcd host")
@@ -62,7 +62,7 @@ func main() {
 
 	for {
 		go server.Poll(etcdTTL)
-		time.Sleep(refreshDuration)
+		time.Sleep(interval)
 	}
 }
 

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -15,7 +15,7 @@ import (
 var (
 	bindAddr   string
 	interval   time.Duration
-	etcdTTL    time.Duration
+	publishTTL time.Duration
 	host       string
 	dockerAddr string
 	etcdAddr   string
@@ -26,7 +26,7 @@ var (
 func init() {
 	flag.StringVar(&bindAddr, "bind-addr", "localhost:6060", "address to listen for incoming HTTP requests")
 	flag.DurationVar(&interval, "interval", 10*time.Second, "backend polling interval")
-	flag.DurationVar(&etcdTTL, "publish-ttl", interval*2, "backend TTL when publishing keys")
+	flag.DurationVar(&publishTTL, "publish-ttl", interval*2, "backend TTL when publishing keys")
 	flag.StringVar(&host, "host", "127.0.0.1", "host address of the machine")
 	flag.StringVar(&dockerAddr, "docker-addr", "unix:///var/run/docker.sock", "address to a docker API")
 	flag.StringVar(&etcdAddr, "etcd-addr", "http://127.0.0.1:4001", "address to the etcd host")
@@ -53,10 +53,10 @@ func main() {
 		log.Fatalf("failed to start (%s)", err)
 	}
 
-	go server.Listen(etcdTTL)
+	go server.Listen(publishTTL)
 
 	for {
-		go server.Poll(etcdTTL)
+		go server.Poll(publishTTL)
 		time.Sleep(interval)
 	}
 }

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/coreos/go-etcd/etcd"
-	"github.com/fsouza/go-dockerclient"
 
 	"github.com/deis/deis/publisher/server"
 )
@@ -50,13 +48,10 @@ func main() {
 		}
 	}()
 
-	dockerClient, err := docker.NewClient(dockerAddr)
+	server, err := server.New(dockerAddr, etcdAddr, host)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("failed to start (%s)", err)
 	}
-	etcdClient := etcd.NewClient([]string{etcdAddr})
-
-	server := server.New(dockerClient, etcdClient, host)
 
 	go server.Listen(etcdTTL)
 

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -39,6 +39,15 @@ func main() {
 
 	log.Println("booting publisher...")
 
+	// run a profiler
+	go func() {
+		msg := fmt.Sprintf("profiler listening on %s", bindAddr)
+		if err := http.ListenAndServe(bindAddr, nil); err != nil {
+			msg = err.Error()
+		}
+		log.Println(msg)
+	}()
+
 	dockerClient, err := docker.NewClient(dockerAddr)
 	if err != nil {
 		log.Fatal(err)
@@ -48,14 +57,6 @@ func main() {
 	server := server.New(dockerClient, etcdClient, host, logLevel)
 
 	go server.Listen(etcdTTL)
-
-	go func() {
-		msg := fmt.Sprintf("profiler listening on %s", bindAddr)
-		if err := http.ListenAndServe(bindAddr, nil); err != nil {
-			msg = err.Error()
-		}
-		log.Println(msg)
-	}()
 
 	for {
 		go server.Poll(etcdTTL)

--- a/publisher/rootfs/Dockerfile
+++ b/publisher/rootfs/Dockerfile
@@ -4,7 +4,8 @@ FROM alpine:3.1
 # profiling information without any additional package installation.
 RUN apk add --update-cache curl && rm -rf /var/cache/apk/*
 
-ADD bin/publisher /usr/local/bin/publisher
-ENTRYPOINT ["/usr/local/bin/publisher"]
+COPY . /
+
+ENTRYPOINT ["/bin/publisher"]
 
 ENV DEIS_RELEASE 1.7.0-dev

--- a/publisher/server/publisher.go
+++ b/publisher/server/publisher.go
@@ -31,12 +31,18 @@ var safeMap = struct {
 }{data: make(map[string]string)}
 
 // New returns a new instance of Server.
-func New(dockerClient *docker.Client, etcdClient *etcd.Client, host string) *Server {
+func New(dockerAddr, etcdAddr, host string) (*Server, error) {
+	dockerClient, err := docker.NewClient(dockerAddr)
+	if err != nil {
+		return nil, err
+	}
+	etcdClient := etcd.NewClient([]string{etcdAddr})
+
 	return &Server{
 		DockerClient: dockerClient,
 		EtcdClient:   etcdClient,
 		host:         host,
-	}
+	}, nil
 }
 
 // Listen adds an event listener to the docker client and publishes containers that were started.

--- a/publisher/server/publisher.go
+++ b/publisher/server/publisher.go
@@ -80,8 +80,8 @@ func (s *Server) Listen(stopChan chan bool) {
 	}
 }
 
-// Poll lists all containers from the docker client every time the TTL comes up and publishes them to etcd
-func (s *Server) Poll() {
+// Publish lists all containers from the docker client every time the TTL comes up and publishes them to etcd
+func (s *Server) Publish() {
 	containers, err := s.DockerClient.ListContainers(docker.ListContainersOptions{})
 	if err != nil {
 		log.Error(err)

--- a/publisher/server/publisher.go
+++ b/publisher/server/publisher.go
@@ -22,7 +22,7 @@ const (
 type Server struct {
 	DockerClient *docker.Client
 	EtcdClient   *etcd.Client
-	host         string
+	Host         string
 }
 
 var safeMap = struct {
@@ -41,7 +41,7 @@ func New(dockerAddr, etcdAddr, host string) (*Server, error) {
 	return &Server{
 		DockerClient: dockerClient,
 		EtcdClient:   etcdClient,
-		host:         host,
+		Host:         host,
 	}, nil
 }
 
@@ -117,7 +117,7 @@ func (s *Server) publishContainer(container *docker.APIContainers, ttl time.Dura
 			// lowest port wins (docker sorts the ports)
 			// TODO (bacongobbler): support multiple exposed ports
 			port := strconv.Itoa(int(p.PublicPort))
-			hostAndPort := s.host + ":" + port
+			hostAndPort := s.Host + ":" + port
 			if s.IsPublishableApp(containerName) && s.IsPortOpen(hostAndPort) {
 				s.setEtcd(keyPath, hostAndPort, uint64(ttl.Seconds()))
 				s.updateDir(dirPath, uint64(ttl.Seconds()))


### PR DESCRIPTION
A few changes in this PR which are fairly minor but are QoL improvements for maintainers as well as operators:

 - switch to logrus for logging, allowing users to set --log-level to more than just 2 levels
 - updated flag docstrings for more clarity on their impact and usage in publisher
 - log output when publisher is booting (before, publisher would not log anything on stdout)
 - gracefully kill the server on SIGINT/SIGTERM, same as logger
 - log errors on ERROR rather than INFO

I'd be happy to pull out certain pieces for easier reviewing to get it merged/rejected; just say the word! The commits stand alone for the most part, so I just kept it as one PR to prevent having to rebase 3-4 separate PRs, but if it makes life easier then please feel free. Nitpick away!

No milestone has been attached to this as it's doesn't fix anything other than cleanup so no rush on this one