### PR TITLE
docs(configure-dns): drop references to local.deisapp.com

### DIFF
--- a/client/README.rst
+++ b/client/README.rst
@@ -95,7 +95,7 @@ somewhere in your $PATH.
 
 .. code-block:: console
 
-    $ deis register http://deis.local.deisapp.com
+    $ deis register http://deis.local3.deisapp.com
     $ deis keys:add
 
 

--- a/client/deis.py
+++ b/client/deis.py
@@ -728,7 +728,7 @@ Make sure that the Controller URI is correct and the server is running.
 
         Arguments:
           <controller>
-            fully-qualified controller URI, e.g. `http://deis.local.deisapp.com/`
+            fully-qualified controller URI, e.g. `http://deis.local3.deisapp.com/`
 
         Options:
           --username=<username>
@@ -833,7 +833,7 @@ Make sure that the Controller URI is correct and the server is running.
 
         Arguments:
           <controller>
-            a fully-qualified controller URI, e.g. `http://deis.local.deisapp.com/`.
+            a fully-qualified controller URI, e.g. `http://deis.local3.deisapp.com/`.
 
         Options:
           --username=<username>

--- a/docs/managing_deis/configure-dns.rst
+++ b/docs/managing_deis/configure-dns.rst
@@ -6,29 +6,39 @@
 Configure DNS
 =============
 
-For Vagrant clusters, we've created the DNS record ``local.deisapp.com`` which resolves to the IP of the first VM, 172.17.8.100.
-You can use ``local.deisapp.com`` to both log into the controller and to access applications that you've deployed (they will be subdomains of ``local.deisapp.com``, like ``happy-unicorn.local.deisapp.com``). Similarly, you can use ``local3.deisapp.com`` or ``local5.deisapp.com`` for 3- and 5-node clusters, respectively. No DNS configuration is necessary for Vagrant clusters.
+For Deis clusters on EC2, GCE, Azure, DigitalOcean, Rackspace, OpenStack, or bare metal,
+:ref:`DNS records <dns_records>` must be created. The cluster runs multiple routers in
+front of the Deis controller and apps you deploy, so a
+:ref:`load balancer <configure-load-balancers>` is recommended.
 
-For Deis clusters hosted elsewhere (EC2, Rackspace, DigitalOcean, Google Compute Engine, bare metal, etc.), DNS records will need to be created to point to the cluster. For a one-node cluster, we schedule and launch one router, and deis-router and deis-controller will run on the same host. So, the DNS record specified below can be configured to point to this one machine.
+Vagrant
+-------
 
-On a multi-node cluster, however, there are probably multiple routers, and the controller will likely be scheduled on a separate machine. As mentioned in :ref:`configure-load-balancers`, a load balancer is recommended in this scenario.
+For local Vagrant clusters, no DNS configuration is required. The domain
+``local3.deisapp.com`` already resolves to the IPs of the first 3 VMs provisioned
+by Deis' Vagrantfile: 172.17.8.100, 172.17.8.101, 172.17.8.102.
 
-Note that the controller will eventually live behind the routers so that all external traffic will flow through the load balancer - configuring a DNS record which points to a service whose IP could change is less than ideal.
+Use ``deis.local3.deisapp.com`` to log in to the controller on a 3-node Vagrant
+cluster. Apps that you deploy will have their name prefixed to the domain, such
+as "golden-chinbone.local3.deisapp.com".
+
+Similarly, use ``local5.deisapp.com`` for a 5-node Vagrant cluster.
 
 .. _dns_records:
 
 Necessary DNS records
 ---------------------
 
-Deis requires a wildcard DNS record. Assuming ``myapps.com`` is the top-level domain apps will live under:
+Deis requires a wildcard DNS record. Assuming ``myapps.com`` is the top-level domain
+apps will live under:
 
-* ``*.myapps.com`` should have "A" record entries for each of the load balancer IP addresses
+* ``*.myapps.com`` should have "A" record entries for each of the load balancer's IP addresses
 
 Apps can then be accessed by browsers at ``appname.myapps.com``, and the controller will be available to the Deis client at ``deis.myapps.com``.
 
 `EC2 recommends`_ against creating "A" record entries; instead, create a wildcard "CNAME" record entry for the load balancer's DNS name, or use Amazon `Route 53`_.
 
-These records are necessary for all deployments of Deis (EC2, Rackspace, DigitalOcean, Google Compute Engine, bare metal, etc.). Vagrant clusters can use the domain ``local.deisapp.com``, ``local3.deisapp.com``, or ``local5.deiaspp.com``.
+These records are necessary for all deployments of Deis other than Vagrant clusters.
 
 .. _xip_io:
 

--- a/docs/using_deis/manage-application.rst
+++ b/docs/using_deis/manage-application.rst
@@ -80,7 +80,7 @@ When working with an application that has been shared with you, clone the origin
   $ git clone https://github.com/deis/example-java-jetty.git
   Cloning into 'example-java-jetty'... done
   $ cd example-java-jetty
-  $ git remote add -f deis ssh://git@local.deisapp.com:2222/peachy-waxworks.git
+  $ git remote add -f deis ssh://git@local3.deisapp.com:2222/peachy-waxworks.git
   Updating deis
   From deis-controller.local:peachy-waxworks
    * [new branch]      master     -> deis/master

--- a/docs/using_deis/using-buildpacks.rst
+++ b/docs/using_deis/using-buildpacks.rst
@@ -82,14 +82,14 @@ Use ``git push deis master`` to deploy your application.
            Launching... done, v2
 
     -----> unisex-huntress deployed to Deis
-           http://unisex-huntress.local.deisapp.com
+           http://unisex-huntress.local3.deisapp.com
 
            To learn more, use `deis help` or visit http://deis.io
 
-    To ssh://git@local.deisapp.com:2222/unisex-huntress.git
+    To ssh://git@local3.deisapp.com:2222/unisex-huntress.git
      * [new branch]      master -> master
 
-    $ curl -s http://unisex-huntress.local.deisapp.com
+    $ curl -s http://unisex-huntress.local3.deisapp.com
     Powered by Deis!
 
 Because a Heroku-style application is detected, the ``web`` process type is automatically scaled to 1 on first deploy.

--- a/docs/using_deis/using-dockerfiles.rst
+++ b/docs/using_deis/using-dockerfiles.rst
@@ -97,14 +97,14 @@ Use ``git push deis master`` to deploy your application.
            Launching... done, v2
 
     -----> folksy-offshoot deployed to Deis
-           http://folksy-offshoot.local.deisapp.com
+           http://folksy-offshoot.local3.deisapp.com
 
            To learn more, use `deis help` or visit http://deis.io
 
-    To ssh://git@local.deisapp.com:2222/folksy-offshoot.git
+    To ssh://git@local3.deisapp.com:2222/folksy-offshoot.git
      * [new branch]      master -> master
 
-    $ curl -s http://folksy-offshoot.local.deisapp.com
+    $ curl -s http://folksy-offshoot.local3.deisapp.com
     Welcome to Deis!
     See the documentation at http://docs.deis.io/ for more information.
 

--- a/tests/utils/itutils.go
+++ b/tests/utils/itutils.go
@@ -59,7 +59,7 @@ func GetGlobalConfig() *DeisTestConfig {
 	}
 	domain := os.Getenv("DEIS_TEST_DOMAIN")
 	if domain == "" {
-		domain = "local.deisapp.com"
+		domain = "local3.deisapp.com"
 	}
 	sshKey := os.Getenv("DEIS_TEST_SSH_KEY")
 	if sshKey == "" {


### PR DESCRIPTION
1-node clusters are not supported, but the "Configure DNS" docs still referred to them, and several places in the codebase still referred to "local.deisapp.com" instead of "local3".