### PR TITLE
fix(controller): merge structure with new structure

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -275,7 +275,9 @@ class App(UuidAuditedModel):
         # save new structure to the database
         vals = self.container_set.exclude(type='run').values(
             'type').annotate(Count('pk')).order_by()
-        self.structure = {v['type']: v['pk__count'] for v in vals}
+        new_structure = structure.copy()
+        new_structure.update({v['type']: v['pk__count'] for v in vals})
+        self.structure = new_structure
         self.save()
         return changed
 


### PR DESCRIPTION
If the old structure contained values like {'web': 0}, the container
count would be zero, so the resulting vals structure would be an empty
dictionary. By taking the "requested" structure and updating it with
the actual container queryset, values like {'web': 0} will stay the
same. From that result, the structure will not be considered in an
["initial" state][1], which means that a new deploy will not cause the
containers to be accidentally scaled back up to one.

[1]: https://github.com/deis/deis/blob/ebc3df479a672acb4a81525ba1edd0fb4d70a6a9/controller/api/models.py#L605

closes #3494