### PR TITLE
feat(deisctl): add config rm

### DIFF
--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -511,11 +511,13 @@ to a private key.
 Usage:
   deisctl config <target> get [<key>...]
   deisctl config <target> set <key=val>...
+  deisctl config <target> rm [<key>...]
 
 Examples:
   deisctl config platform set domain=mydomain.com
   deisctl config platform set sshPrivateKey=$HOME/.ssh/deis
   deisctl config controller get webEnabled
+  deisctl config controller rm webEnabled
 `
 	// parse command-line arguments
 	args, err := docopt.Parse(usage, argv, true, "", false)

--- a/deisctl/config/config.go
+++ b/deisctl/config/config.go
@@ -51,6 +51,8 @@ func doConfig(args map[string]interface{}) error {
 	var vals []string
 	if args["set"] == true {
 		vals, err = doConfigSet(client, rootPath, args["<key=val>"].([]string))
+	} else if args["rm"] == true {
+		vals, err = doConfigRm(client, rootPath, args["<key>"].([]string))
 	} else {
 		vals, err = doConfigGet(client, rootPath, args["<key>"].([]string))
 	}
@@ -100,6 +102,18 @@ func doConfigGet(client *etcdClient, root string, keys []string) ([]string, erro
 			return result, err
 		}
 		result = append(result, val)
+	}
+	return result, nil
+}
+
+func doConfigRm(client *etcdClient, root string, keys []string) ([]string, error) {
+	var result []string
+	for _, k := range keys {
+		err := client.Delete(root + k)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, k)
 	}
 	return result, nil
 }

--- a/deisctl/config/etcd.go
+++ b/deisctl/config/etcd.go
@@ -42,6 +42,11 @@ func (c *etcdClient) Get(key string) (string, error) {
 	return resp.Node.Value, nil
 }
 
+func (c *etcdClient) Delete(key string) error {
+	_, err := c.etcd.Delete(key, false)
+	return err
+}
+
 func (c *etcdClient) Set(key string, value string) (string, error) {
 	resp, err := c.etcd.Set(key, value, 0) // don't use TTLs
 	if err != nil {


### PR DESCRIPTION
I went with `rm` over `unset` because `etcdctl` uses `rm`. I didn't add any test for this, as there doesn't seem to be any tests for this part of deisctl. If I overlooked where they were let me know. The tests in `config_test` seemed mostly to test the special behavior of keys and not the etcd integration.

Fixes #3515