### PR TITLE
Clean up old git repos and images on destroy

### DIFF
--- a/builder/rootfs/bin/boot
+++ b/builder/rootfs/bin/boot
@@ -77,10 +77,14 @@ docker build -t deis/slugrunner /usr/local/src/slugrunner/
 /usr/sbin/sshd -D -e &
 SSHD_PID=$!
 
+# start a cleanup script to remote old repositories and images
+/bin/cleanup &
+CLEANUP_PID=$!
+
 # smart shutdown on SIGINT and SIGTERM
 function on_exit() {
-	kill -TERM $DOCKER_PID $SSHD_PID
-	wait $DOCKER_PID $SSHD_PID 2>/dev/null
+	kill -TERM $DOCKER_PID $SSHD_PID $CLEANUP_PID
+	wait $DOCKER_PID $SSHD_PID $CLEANUP_PID 2>/dev/null
 	exit 0
 }
 trap on_exit INT TERM EXIT

--- a/builder/rootfs/bin/cleanup
+++ b/builder/rootfs/bin/cleanup
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+export ETCD=${ETCD:-$HOST:4001}
+
+while true
+do
+    etcdctl -C $ETCD watch --recursive /deis/services
+    /home/git/check-repos
+done

--- a/builder/rootfs/etc/confd/conf.d/check-repos.toml
+++ b/builder/rootfs/etc/confd/conf.d/check-repos.toml
@@ -5,7 +5,5 @@ uid = 0
 gid = 0
 mode  = "0755"
 keys = [
-  "/deis/services",
   "/deis/registry",
 ]
-reload_cmd = "/home/git/check-repos"

--- a/builder/rootfs/etc/confd/templates/check-repos
+++ b/builder/rootfs/etc/confd/templates/check-repos
@@ -1,21 +1,16 @@
 #!/usr/bin/env bash
 
-listcontains() {
-    for word in $1; do
-        [[ $word = $2 ]] && return 0
-    done
-    return 1
-}
+export ETCD=${ETCD:-$HOST:4001}
 
 cd $(dirname $0) # absolute path
 
-for repo in *.git;
+for repo in *.git
 do
     reponame="${repo%.*}"
-    appname="{{ getv "/deis/registry/host" }}:{{ getv "/deis/registry/port" }}/$reponame"
-    if ! listcontains "{{ join (lsdir "/deis/services/*") " " }}" "$reponame";
+    if ! etcdctl -C $ETCD ls /deis/services/"$reponame" > /dev/null 2>&1
     then
         rm -rf "$repo"
+        appname="{{ getv "/deis/registry/host" }}:{{ getv "/deis/registry/port" }}/$reponame"
         docker images | grep $appname | awk '{ print $3 }' | xargs -r docker rmi -f
         # remove any dangling images left over from the cleanup
         docker images --filter "dangling=true" | awk '{ print $3 }' | grep -v IMAGE | xargs -r docker rmi -f

--- a/publisher/server/publisher.go
+++ b/publisher/server/publisher.go
@@ -109,7 +109,6 @@ func (s *Server) publishContainer(container *docker.APIContainers, ttl time.Dura
 		appName := match[1]
 		appPath := fmt.Sprintf("%s/%s", appName, containerName)
 		keyPath := fmt.Sprintf("/deis/services/%s", appPath)
-		dirPath := fmt.Sprintf("/deis/services/%s", appName)
 		for _, p := range container.Ports {
 			// lowest port wins (docker sorts the ports)
 			// TODO (bacongobbler): support multiple exposed ports
@@ -117,7 +116,6 @@ func (s *Server) publishContainer(container *docker.APIContainers, ttl time.Dura
 			hostAndPort := s.host + ":" + port
 			if s.IsPublishableApp(containerName) && s.IsPortOpen(hostAndPort) {
 				s.setEtcd(keyPath, hostAndPort, uint64(ttl.Seconds()))
-				s.updateDir(dirPath, uint64(ttl.Seconds()))
 				safeMap.Lock()
 				safeMap.data[container.ID] = appPath
 				safeMap.Unlock()
@@ -232,16 +230,5 @@ func (s *Server) removeEtcd(key string, recursive bool) {
 	}
 	if s.logLevel == "debug" {
 		log.Println("del", key)
-	}
-}
-
-// updateDir updates the given directory for a given ttl. It succeeds
-// only if the given directory already exists.
-func (s *Server) updateDir(directory string, ttl uint64) {
-	if _, err := s.EtcdClient.UpdateDir(directory, ttl); err != nil {
-		log.Println(err)
-	}
-	if s.logLevel == "debug" {
-		log.Println("updateDir", directory)
 	}
 }


### PR DESCRIPTION
This fixes two problems in Deis master:
- `deis destroy` leaves a git repo dropping in builder at `/home/git/appname.git`
- `deis scale cmd=0` deletes the `/deis/services/appname` dir after 20 seconds, but that causes the (fixed) `check-repos` script to purge its git repo prematurely

My assumption is that the templating for `check-repos` worked in earlier versions of `confd` that were more specific to `etcd` behavior. This PR switches to `etcd watch` in a loop rather than rely on `confd` templating to launch the script. It also reverts #3348 so that `/deis/services/appname` dirs don't have a TTL, since `deis destroy` deletes them reliably in my testing.

Closes #3249, refs #3348.