### PR TITLE
chore(*): bump CoreOS to 647.2.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
 
   config.vm.box = "coreos-%s" % $update_channel
-  config.vm.box_version = ">= 647.0.0"
+  config.vm.box_version = ">= 647.2.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
 
   ["vmware_fusion", "vmware_workstation"].each do |vmware|

--- a/contrib/azure/azure-coreos-cluster
+++ b/contrib/azure/azure-coreos-cluster
@@ -35,8 +35,8 @@ parser.add_argument('--affinity-group', default='',
                    help='optional, overrides location if specified')
 parser.add_argument('--ssh', default=22001, type=int,
                    help='optional, starts with 22001 and +1 for each machine in cluster')
-parser.add_argument('--coreos-image', default='2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-647.0.0',
-                   help='optional, [2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-647.0.0]')
+parser.add_argument('--coreos-image', default='2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-647.2.0',
+                   help='optional, [2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-647.2.0]')
 parser.add_argument('--num-nodes', default=3, type=int,
                    help='optional, number of nodes to create (or add), defaults to 3')
 parser.add_argument('--virtual-network-name',

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -123,16 +123,16 @@
 
   "Mappings" : {
     "CoreOSAMIs" : {
-      "eu-central-1"   : { "PV" : "ami-3c764821", "HVM" : "ami-38764825" },
-      "ap-northeast-1" : { "PV" : "ami-9022eb90", "HVM" : "ami-8e22eb8e" },
-      "us-gov-west-1"  : { "PV" : "ami-cf0868ec", "HVM" : "ami-c90868ea" },
-      "sa-east-1"      : { "PV" : "ami-1113940c", "HVM" : "ami-1313940e" },
-      "ap-southeast-2" : { "PV" : "ami-6d83fc57", "HVM" : "ami-6383fc59" },
-      "ap-southeast-1" : { "PV" : "ami-8a546ad8", "HVM" : "ami-84546ad6" },
-      "us-east-1"      : { "PV" : "ami-e8657580", "HVM" : "ami-ea657582" },
-      "us-west-2"      : { "PV" : "ami-67427157", "HVM" : "ami-65427155" },
-      "us-west-1"      : { "PV" : "ami-75dd3331", "HVM" : "ami-77dd3333" },
-      "eu-west-1"      : { "PV" : "ami-4d1c763a", "HVM" : "ami-4b1c763c" }
+      "eu-central-1"   : { "PV" : "ami-fe6b52e3", "HVM" : "ami-f86b52e5" },
+      "ap-northeast-1" : { "PV" : "ami-9ec1119e", "HVM" : "ami-9cc1119c" },
+      "us-gov-west-1"  : { "PV" : "ami-854828a6", "HVM" : "ami-874828a4" },
+      "sa-east-1"      : { "PV" : "ami-d9b839c4", "HVM" : "ami-d5b839c8" },
+      "ap-southeast-2" : { "PV" : "ami-7985fc43", "HVM" : "ami-7b85fc41" },
+      "ap-southeast-1" : { "PV" : "ami-d4033b86", "HVM" : "ami-da033b88" },
+      "us-east-1"      : { "PV" : "ami-c16583aa", "HVM" : "ami-c36583a8" },
+      "us-west-2"      : { "PV" : "ami-995f60a9", "HVM" : "ami-975f60a7" },
+      "us-west-1"      : { "PV" : "ami-877a92c3", "HVM" : "ami-857a92c1" },
+      "eu-west-1"      : { "PV" : "ami-e38cfc94", "HVM" : "ami-e18cfc96" }
 
     },
     "RootDevices" : {

--- a/contrib/rackspace/provision-rackspace-cluster.sh
+++ b/contrib/rackspace/provision-rackspace-cluster.sh
@@ -49,7 +49,7 @@ $CONTRIB_DIR/util/check-user-data.sh
 i=1 ; while [[ $i -le $DEIS_NUM_INSTANCES ]] ; do \
     echo_yellow "Provisioning deis-$i..."
     # This image is CoreOS 633.1.0 in the stable channel
-    # TODO: Update to 647.0.0 when it's available in the stable channel
+    # TODO: Update to 647.2.0 when it's available in the stable channel
     supernova $ENV boot --image a41d8b7c-d41b-4369-a180-0734f3b1cd8c --flavor $FLAVOR --key-name $1 --user-data $CONTRIB_DIR/coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
     ((i = i + 1)) ; \
 done

--- a/docs/installing_deis/baremetal.rst
+++ b/docs/installing_deis/baremetal.rst
@@ -104,8 +104,8 @@ Start the installation
 
 
 This will install the latest `CoreOS`_ stable release to disk. The Deis provision scripts for other
-platforms typically specify a CoreOS version - currently, ``647.0.0``. To specify a CoreOS
-version, append the ``-V`` parameter to the install command, e.g. ``-V 647.0.0``.
+platforms typically specify a CoreOS version - currently, ``647.2.0``. To specify a CoreOS
+version, append the ``-V`` parameter to the install command, e.g. ``-V 647.2.0``.
 
 After the installation has finished, reboot your server. Once your machine is back up, you should
 be able to log in as the `core` user using the `deis` ssh key.

--- a/docs/installing_deis/gce.rst
+++ b/docs/installing_deis/gce.rst
@@ -118,7 +118,7 @@ Launch 3 instances. You can choose another starting CoreOS image from the listin
       --metadata-from-file user-data=gce-user-data sshKeys=~/.ssh/deis.pub \
       --disk name=cored${num} device-name=coredocker \
       --tags deis \
-      --image coreos-stable-647-0-0-v20150512 \
+      --image coreos-stable-647-2-0-v20150528 \
       --image-project coreos-cloud;
     done
 


### PR DESCRIPTION
Linux 4.0.1 kernel. See https://coreos.com/releases/#647.2.0