### PR TITLE
fix(database): work around wal-e error by pinning pbr lib

### DIFF
--- a/database/build.sh
+++ b/database/build.sh
@@ -41,7 +41,7 @@ git clone https://github.com/wal-e/wal-e.git
 cd /tmp/wal-e
 git checkout c6dd4b1
 
-pip install .
+pip install . pbr==0.11.0
 
 # python port of daemontools
 pip install envdir


### PR DESCRIPTION
Deis CI is currently stalled on wal-e/wal-e#181, so this is an attempt to work around the issue by pinning `pbr` to a last-known-good version.