### PR TITLE
fix(controller): Add EnvironmentFile to the serivce files created by fleet.py

### DIFF
--- a/controller/scheduler/fleet.py
+++ b/controller/scheduler/fleet.py
@@ -377,6 +377,7 @@ SchedulerClient = FleetHTTPClient
 
 CONTAINER_TEMPLATE = [
     {"section": "Unit", "name": "Description", "value": "{name}"},
+    {"section": "Service", "name": "EnvironmentFile", "value": "/etc/environment"},
     {"section": "Service", "name": "ExecStartPre", "value": '''/bin/sh -c "IMAGE=$(etcdctl get /deis/registry/host 2>&1):$(etcdctl get /deis/registry/port 2>&1)/{image}; docker pull $IMAGE"'''},  # noqa
     {"section": "Service", "name": "ExecStartPre", "value": '''/bin/sh -c "docker inspect {name} >/dev/null 2>&1 && docker rm -f {name} || true"'''},  # noqa
     {"section": "Service", "name": "ExecStart", "value": '''/bin/sh -c "IMAGE=$(etcdctl get /deis/registry/host 2>&1):$(etcdctl get /deis/registry/port 2>&1)/{image}; docker run --name {name} {memory} {cpu} {hostname} -P $IMAGE {command}"'''},  # noqa


### PR DESCRIPTION
The service file that is created by the controller after a succesfull
build of a new container, didn't have access to the /etc/environment file
in CoreOS.

People that run etcd on the non-standard 127.0.0.1:4001 address, need to
make the etcd address availalbe to fleetctl in the .service file.
If you don't this, the etcdctl commands used in the ExecStartPre won't
be able to communicate with the correct etcd service.