### PR TITLE
fix(logger): gracefully handle a nil return from etcd watch

### DIFF
--- a/logger/main.go
+++ b/logger/main.go
@@ -66,8 +66,10 @@ func main() {
 
 	for {
 		select {
-		case er := <-drainRespChan:
-			drainChan <- er.Node.Value
+		case dr := <-drainRespChan:
+			if dr != nil && dr.Node != nil {
+				drainChan <- dr.Node.Value
+			}
 		case <-signalChan:
 			close(exitChan)
 			stopChan <- true


### PR DESCRIPTION
I was not able to reproduce but I assume there are some situations where the response can be nil (see [godoc](http://godoc/github.com/coreos/go-etcd/etcd#Client.Watch)) or the node in the response is nil (see [godoc](http://godoc/github.com/coreos/go-etcd/etcd#Response)). @bacongobbler can you please try to reproduce with this patch?

closes #3772 
closes #3773