### PR TITLE
feat(deisctl): Add deisctl ssh

### DIFF
--- a/deisctl/backend/backend.go
+++ b/deisctl/backend/backend.go
@@ -9,6 +9,7 @@ type Backend interface {
 	Start([]string, *sync.WaitGroup, chan string, chan error)
 	Stop([]string, *sync.WaitGroup, chan string, chan error)
 	Scale(string, int, *sync.WaitGroup, chan string, chan error)
+	SSH(string) error
 	ListUnits() error
 	ListUnitFiles() error
 	Status(string) error

--- a/deisctl/backend/fleet/journal.go
+++ b/deisctl/backend/fleet/journal.go
@@ -2,7 +2,6 @@ package fleet
 
 import (
 	"fmt"
-	"os"
 )
 
 // Journal prints the systemd journal of target unit(s)
@@ -19,24 +18,12 @@ func (c *FleetClient) Journal(target string) (err error) {
 
 // runJournal tails the systemd journal for a given unit
 func runJournal(name string) (exit int) {
+	machineID, err := findUnit(name)
 
-	u, err := cAPI.Unit(name)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error retrieving Unit %s: %v", name, err)
-		return 1
-	}
-	if suToGlobal(*u) {
-		fmt.Fprintf(os.Stderr, "Unable to get journal for global unit %s. Check the logs on the host using journalctl.\n", name)
-		return 1
-	}
-	if u == nil {
-		fmt.Fprintf(os.Stderr, "Unit %s does not exist.\n", name)
-		return 1
-	} else if u.CurrentState == "" {
-		fmt.Fprintf(os.Stderr, "Unit %s does not appear to be running.\n", name)
 		return 1
 	}
 
 	command := fmt.Sprintf("journalctl --unit %s --no-pager -n 40 -f", name)
-	return runCommand(command, u.MachineID)
+	return runCommand(command, machineID)
 }

--- a/deisctl/backend/fleet/ssh.go
+++ b/deisctl/backend/fleet/ssh.go
@@ -12,6 +12,54 @@ import (
 	"github.com/coreos/fleet/ssh"
 )
 
+// SSH opens an interactive shell to a machine in the cluster
+func (c *FleetClient) SSH(name string) (err error) {
+	var sshClient *ssh.SSHForwardingClient
+
+	timeout := time.Duration(Flags.SSHTimeout*1000) * time.Millisecond
+
+	ms, err := machineState(name)
+	if err != nil {
+		return err
+	}
+
+	// If name isn't a machine ID, try it as a unit instead
+	if ms == nil {
+		units, err := c.Units(name)
+
+		if err != nil {
+			return err
+		}
+
+		machID, err := findUnit(units[0])
+
+		if err != nil {
+			return err
+		}
+
+		ms, err = machineState(machID)
+
+		if err != nil || ms == nil {
+			return err
+		}
+	}
+
+	addr := ms.PublicIP
+
+	if tun := getTunnelFlag(); tun != "" {
+		sshClient, err = ssh.NewTunnelledSSHClient("core", tun, addr, getChecker(), false, timeout)
+	} else {
+		sshClient, err = ssh.NewSSHClient("core", addr, getChecker(), false, timeout)
+	}
+	if err != nil {
+		return err
+	}
+
+	defer sshClient.Close()
+	err = ssh.Shell(sshClient)
+	return err
+}
+
 // runCommand will attempt to run a command on a given machine. It will attempt
 // to SSH to the machine if it is identified as being remote.
 func runCommand(cmd string, machID string) (retcode int) {
@@ -74,6 +122,24 @@ func runRemoteCommand(cmd string, addr string, timeout time.Duration) (exit int,
 
 	err, exit = ssh.Execute(sshClient, cmd)
 	return
+}
+
+// findUnits returns the machine ID of a running unit
+func findUnit(name string) (machID string, err error) {
+	u, err := cAPI.Unit(name)
+	if err != nil {
+		return "", fmt.Errorf("Error retrieving Unit %s: %v", name, err)
+	}
+	if suToGlobal(*u) {
+		return "", fmt.Errorf("Unable to connect to global unit %s.\n", name)
+	}
+	if u == nil {
+		return "", fmt.Errorf("Unit %s does not exist.\n", name)
+	} else if u.CurrentState == "" {
+		return "", fmt.Errorf("Unit %s does not appear to be running.\n", name)
+	}
+
+	return u.MachineID, nil
 }
 
 func machineState(machID string) (*machine.MachineState, error) {

--- a/deisctl/client/client.go
+++ b/deisctl/client/client.go
@@ -17,6 +17,7 @@ type DeisCtlClient interface {
 	RefreshUnits(argv []string) error
 	Restart(argv []string) error
 	Scale(argv []string) error
+	SSH(argv []string) error
 	Start(argv []string) error
 	Status(argv []string) error
 	Stop(argv []string) error
@@ -88,6 +89,11 @@ func (c *Client) Restart(argv []string) error {
 // Scale grows or shrinks the number of running components.
 func (c *Client) Scale(argv []string) error {
 	return cmd.Scale(argv, c.Backend)
+}
+
+// SSH opens an interactive shell with a machine in the cluster.
+func (c *Client) SSH(argv []string) error {
+	return cmd.SSH(argv, c.Backend)
 }
 
 // Start activates the specified components.

--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -589,3 +589,23 @@ Options:
 	}
 	return nil
 }
+
+// SSH opens an interactive shell on a machine in the cluster
+func SSH(argv []string, b backend.Backend) error {
+	usage := `Open an interactive shell on a machine in the cluster given a unit or machine id.
+
+Usage:
+  deisctl ssh <target>
+`
+	// parse command-line arguments
+	args, err := docopt.Parse(usage, argv, true, "", false)
+	if err != nil {
+		return err
+	}
+
+	if err := b.SSH(args["<target>"].(string)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/deisctl/cmd/cmd_test.go
+++ b/deisctl/cmd/cmd_test.go
@@ -44,6 +44,9 @@ func (backend stubBackend) Status(string) error {
 func (backend stubBackend) Journal(string) error {
 	return fmt.Errorf("Journal not implemented yet.")
 }
+func (backend stubBackend) SSH(string) error {
+	return fmt.Errorf("SSH not implemented yet.")
+}
 
 var b stubBackend
 

--- a/deisctl/deisctl.go
+++ b/deisctl/deisctl.go
@@ -39,6 +39,7 @@ Commands, use "deisctl help <command>" to learn more:
   journal           print the log output of a component
   config            set platform or component values
   refresh-units     refresh unit files from GitHub
+  ssh               open an interacive shell on a machine in the cluster
   help              show the help screen for a command
 
 Options:
@@ -106,6 +107,8 @@ Options:
 		err = c.Config(argv)
 	case "refresh-units":
 		err = c.RefreshUnits(argv)
+	case "ssh":
+		err = c.SSH(argv)
 	case "help":
 		fmt.Print(usage)
 		return 0

--- a/docs/troubleshooting_deis/index.rst
+++ b/docs/troubleshooting_deis/index.rst
@@ -18,16 +18,11 @@ Common issues that users have run into when provisioning Deis are detailed below
 Logging in to the cluster
 -------------------------
 
-Deis runs on CoreOS, so connecting is as simple as using ``ssh``.
-
-CoreOS's default username is ``core``. Use the SSH key you provisioned the cluster with.
-
-Connect to the public IP address of one of your nodes (or use "convenience" DNS records if you've set them up).
+To open a interactive shell on a machine in your cluster:
 
 .. code-block:: console
 
-    $ ssh core@deis-1.example.com -i ~/.ssh/deis
-
+    $ deisctl ssh <unit>
 
 Troubleshooting etcd
 --------------------


### PR DESCRIPTION
**Todo**: You can't list machines or get a machine ID in `deisctl` at the moment, so this isn't useful until normal users can look up a machine ID, rather than use fleetctl to look them up.

We might want to expand this by allowing users to specify a unit, then ssh to the host running the unit, like `fleetctl` does.

``` shell
$ deisctl ssh controller
Last login: Wed Jun  3 02:55:49 2015 from 172.17.8.100
 * *    *   *****    ddddd   eeeeeee iiiiiii   ssss
*   *  * *  *   *     d   d   e    e    i     s    s
 * *  ***** *****     d    d  e         i    s
*****  * *    *       d     d e         i     s
*   * *   *  * *      d     d eee       i      sss
*****  * *  *****     d     d e         i         s
  *   *****  * *      d    d  e         i          s
 * *  *   * *   *     d   d   e    e    i    s    s
***** *****  * *     ddddd   eeeeeee iiiiiii  ssss

Welcome to Deis			Powered by CoreOS
core@deis-02 ~ $ uname -a 
Linux deis-02 4.0.1 #2 SMP Wed May 27 03:33:38 UTC 2015 x86_64 Intel(R) Core(TM) i5-4570 CPU @ 3.20GHz GenuineIntel GNU/Linux
core@deis-02 ~ $ exit
logout
$ 
```
Fixes #3062