### PR TITLE
fix(*): check for key already exists errors only

### DIFF
--- a/builder/rootfs/bin/boot
+++ b/builder/rootfs/bin/boot
@@ -30,9 +30,10 @@ sleep $(($ETCD_TTL+1))
 
 function etcd_safe_mkdir {
 	set +e
-	etcdctl --no-sync -C $ETCD mkdir $1 >/dev/null 2>&1
-	if [[ $? -ne 0 && $? -ne 4 ]]; then
-		echo "etcd_safe_mkdir: an etcd error occurred. aborting..."
+	ERROR="$(etcdctl --no-sync -C $ETCD mkdir $1 2>&1 >/dev/null)"
+	if [[ $? -ne 0 && $(echo $ERROR | grep -ive "key already exists") ]]; then
+		echo "etcd_safe_mkdir: an etcd error occurred ($ERROR)"
+		echo "aborting..."
 		exit 1
 	fi
 	set -e

--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -26,9 +26,10 @@ sleep $(($ETCD_TTL+1))
 
 function etcd_set_default {
 	set +e
-	etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1
-	if [[ $? -ne 0 && $? -ne 4 ]]; then
-		echo "etcd_set_default: an etcd error occurred. aborting..."
+	ERROR="$(etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 2>&1 >/dev/null)"
+	if [[ $? -ne 0 && $(echo $ERROR | grep -ive "key already exists") ]]; then
+		echo "etcd_set_default: an etcd error occurred ($ERROR)"
+		echo "aborting..."
 		exit 1
 	fi
 	set -e
@@ -36,9 +37,10 @@ function etcd_set_default {
 
 function etcd_safe_mkdir {
 	set +e
-	etcdctl --no-sync -C $ETCD mkdir $1 >/dev/null 2>&1
-	if [[ $? -ne 0 && $? -ne 4 ]]; then
-		echo "etcd_safe_mkdir: an etcd error occurred. aborting..."
+	ERROR="$(etcdctl --no-sync -C $ETCD mkdir $1 2>&1 >/dev/null)"
+	if [[ $? -ne 0 && $(echo $ERROR | grep -ive "key already exists") ]]; then
+		echo "etcd_safe_mkdir: an etcd error occurred ($ERROR)"
+		echo "aborting..."
 		exit 1
 	fi
 	set -e

--- a/database/bin/boot
+++ b/database/bin/boot
@@ -28,9 +28,10 @@ sleep $(($ETCD_TTL+1))
 
 function etcd_set_default {
   set +e
-  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1
-  if [[ $? -ne 0 && $? -ne 4 ]]; then
-    echo "etcd_set_default: an etcd error occurred. aborting..."
+  ERROR="$(etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 2>&1 >/dev/null)"
+  if [[ $? -ne 0 && $(echo $ERROR | grep -ive "key already exists") ]]; then
+    echo "etcd_set_default: an etcd error occurred ($ERROR)"
+    echo "aborting..."
     exit 1
   fi
   set -e

--- a/registry/bin/boot
+++ b/registry/bin/boot
@@ -32,9 +32,10 @@ sleep $(($ETCD_TTL+1))
 
 function etcd_set_default {
   set +e
-  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1
-  if [[ $? -ne 0 && $? -ne 4 ]]; then
-    echo "etcd_set_default: an etcd error occurred. aborting..."
+  ERROR="$(etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 2>&1 >/dev/null)"
+  if [[ $? -ne 0 && $(echo $ERROR | grep -ive "key already exists") ]]; then
+    echo "etcd_set_default: an etcd error occurred ($ERROR)"
+    echo "aborting..."
     exit 1
   fi
   set -e

--- a/store/monitor/bin/boot
+++ b/store/monitor/bin/boot
@@ -10,9 +10,10 @@ HOSTNAME=`hostname`
 
 function etcd_set_default {
   set +e
-  etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 >/dev/null 2>&1
-  if [[ $? -ne 0 && $? -ne 4 ]]; then
-    echo "etcd_set_default: an etcd error occurred. aborting..."
+  ERROR="$(etcdctl --no-sync -C $ETCD mk $ETCD_PATH/$1 $2 2>&1 >/dev/null)"
+  if [[ $? -ne 0 && $(echo $ERROR | grep -ive "key already exists") ]]; then
+    echo "etcd_set_default: an etcd error occurred ($ERROR)"
+    echo "aborting..."
     exit 1
   fi
   set -e


### PR DESCRIPTION
refs #3790

This change is necessary as etcdctl globs all server errors as exit code 4, including the infamous `all the given peers are not reachable` as well as `Key already exists`. Instead of checking the error code, we can check what's on stderr so we can safely ignore `Key already exists` "errors".