### PR TITLE
fix(client): Fix attribute errors on windows

### DIFF
--- a/client/deis.py
+++ b/client/deis.py
@@ -76,8 +76,9 @@ import urllib3.contrib.pyopenssl
 
 # Don't throw IOError when a pipe closes
 # https://github.com/deis/deis/issues/3764
-from signal import signal, SIGPIPE, SIG_DFL
-signal(SIGPIPE, SIG_DFL)
+import signal
+if hasattr(signal, 'SIGPIPE') and hasattr(signal, 'SIG_DFL'):
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 __version__ = '1.7.0-dev'
 


### PR DESCRIPTION
Fixes a regression where starting up the client in windows would result in a crash, becuase windows does not have support for pipes, and so no SIGPIPE as well.

I didn't test if things still worked in Unix, but I assume they do...