### PR TITLE
WIP: feat(*): Allow applications to be in maintenance mode

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -410,6 +410,19 @@ class App(UuidAuditedModel):
         escaped_command = command.replace("'", "'\\''")
         return c.run(escaped_command)
 
+    def maintenance_on(self, user):
+        msg = "{} enables miantenance mode".format(user.username)
+        log_event(self, msg)
+        _etcd_client.write('/deis/maintenance/{}'.format(id), True)
+
+    def maintenance_on(self, user):
+        msg = "{} enables miantenance mode".format(user.username)
+        log_event(self, msg)
+        try:
+            _etcd_client.delete('/deis/maintenance/{}'.format(id))
+        except KeyError:
+            pass
+
 
 @python_2_unicode_compatible
 class Container(UuidAuditedModel):

--- a/controller/api/urls.py
+++ b/controller/api/urls.py
@@ -56,6 +56,10 @@ urlpatterns = patterns(
         views.AppViewSet.as_view({'get': 'logs'})),
     url(r"^apps/(?P<id>{})/run/?".format(settings.APP_URL_REGEX),
         views.AppViewSet.as_view({'post': 'run'})),
+    url(r"^apps/(?P<id>{})/maintenance/on?".format(settings.APP_URL_REGEX),
+        views.AppViewSet.as_view({'post': 'maintenance_on'})),
+    url(r"^apps/(?P<id>{})/maintenance/off?".format(settings.APP_URL_REGEX),
+        views.AppViewSet.as_view({'post': 'maintenance_off'})),
     # apps sharing
     url(r"^apps/(?P<id>{})/perms/(?P<username>[-_\w]+)/?".format(settings.APP_URL_REGEX),
         views.AppPermsViewSet.as_view({'delete': 'destroy'})),

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -176,6 +176,26 @@ class AppViewSet(BaseDeisViewSet):
         return Response(output_and_rc, status=status.HTTP_200_OK,
                         content_type='text/plain')
 
+    def maintenance_on(self, request, **kwargs):
+        app = self.get_object
+        try:
+            success = app.maintenance_on(self.request.user)
+        except EnvironmentError as e:
+            return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except RuntimeError as e:
+            return Response({'detail': str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        return Response({'maintenance': 'on'}, status=status.HTTP_200_OK)
+
+    def maintenance_off(self, request, **kwargs):
+        app = self.get_object
+        try:
+            success = app.maintenance_off(self.request.user)
+        except EnvironmentError as e:
+            return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except RuntimeError as e:
+            return Response({'detail': str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        return Response({'maintenance': 'off'}, status=status.HTTP_200_OK)
+
 
 class BuildViewSet(ReleasableViewSet):
     """A viewset for interacting with Build objects."""

--- a/router/image/conf.d/nginx.conf.toml
+++ b/router/image/conf.d/nginx.conf.toml
@@ -12,6 +12,7 @@ keys = [
   "/deis/builder",
   "/deis/store/gateway",
   "/deis/certs",
+  "/deis/maintenance",
 ]
 check_cmd  = "/app/bin/check {{ .src }}"
 reload_cmd = "/opt/nginx/sbin/nginx -s reload"

--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -165,6 +165,7 @@ http {
     {{ end }}
     ## start service definitions for each application
     {{ range $app := lsdir "/deis/services" }}
+    {{ $maintenance := printf "/deis/maintenance/%s" $app }}
     {{ $upstreams := printf "/deis/services/%s/*" $app}}
     upstream {{ $app }} {
         {{ if exists "/deis/router/affinityArg" }}
@@ -196,6 +197,7 @@ http {
         {{ else }}
         include deis.conf;
         {{ end }}
+        {{ if ne $maintenance }}
         {{ if ne $appContainerLen 0 }}
         location / {
             {{ if eq $useFirewall "true" }}include                     /opt/nginx/firewall/active-mode.rules;{{ end }}
@@ -234,6 +236,12 @@ http {
             proxy_pass                  http://{{ $app }};
         }
         {{ else }}
+        location / {
+            return 503;
+        }
+        {{ else }}
+        {{/* maintenance mode different from no containers to make it easier to add different
+             error pages later. */}}
         location / {
             return 503;
         }


### PR DESCRIPTION
Closes: #3722

Note this is very much a non working wip.

TODO:
[ ] Test the basics, I just wrote the code without even testing if it made syntactical (or semantical) sense. I will try  this later on a computer with more RAM in vagrant
[ ] Add unit tests
[ ] Add documentation for controller API
[ ] Add user documentation
[ ] Change client
[ ] Add custom error/maintenance pages

If someone from the core dev team could tell me this is more or less the right way to implement this feature, let me now