### PR TITLE
fix(client): Bump pyinstaller to fix pyinstaller/pyinstaller#152

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -1,6 +1,6 @@
 
 build: setup-venv
-	venv/bin/pip install -r requirements.txt git+https://github.com/pyinstaller/pyinstaller@7413317
+	venv/bin/pip install -r requirements.txt git+https://github.com/pyinstaller/pyinstaller@32bbb954b355937ccfe377afbe56979db79a7b30
 	venv/bin/pyinstaller deis.spec
 	chmod +x dist/deis
 


### PR DESCRIPTION
I bumped Pyinstaller to the latest commit ([diff](https://github.com/pyinstaller/pyinstaller/compare/7413317...32bbb954b355937ccfe377afbe56979db79a7b30)), to fix pyinstaller/pyinstaller#152, which prevents compilation if the python headers are in certain locations (in my case, where homebrew installed python was subject to this).

I'm not sure what your policy is on bumping Pyinstaller, but I tested the client and it seemed to work after the bump.

This is a major bump, with over 200 commits since the last pyinstaller update, so this definitely needs an careful test.