### PR TITLE
fix(router): set_random belongs in a `location` block

### DIFF
--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -158,11 +158,6 @@ http {
     {{ $useSSL := or (getv "/deis/router/sslCert") "false" }}
     {{ $domains := ls "/deis/domains" }}
     {{ $certs := ls "/deis/certs" }}
-    ## workaround for nginx hashing empty string bug http://trac.nginx.org/nginx/ticket/765
-    {{ if exists "/deis/router/affinityArg" }}
-    set_random $prng 0 99;
-    set_if_empty $arg_{{ getv "/deis/router/affinityArg" }} $prng;
-    {{ end }}
     ## start service definitions for each application
     {{ range $app := lsdir "/deis/services" }}
     {{ $upstreams := printf "/deis/services/%s/*" $app}}
@@ -229,6 +224,12 @@ http {
             if ($access_scheme != "https") {
               return 301 https://$host$request_uri;
             }
+            {{ end }}
+
+            ## workaround for nginx hashing empty string bug http://trac.nginx.org/nginx/ticket/765
+            {{ if exists "/deis/router/affinityArg" }}
+            set_random $prng 0 99;
+            set_if_empty $arg_{{ getv "/deis/router/affinityArg" }} $prng;
             {{ end }}
 
             proxy_pass                  http://{{ $app }};


### PR DESCRIPTION
Corrects placement of patch from #3768 since `set_random` is only defined within a `location` block.