### PR TITLE
ref(deisctl): Move parsing from CMD package to client package

### DIFF
--- a/deisctl/client/client.go
+++ b/deisctl/client/client.go
@@ -2,10 +2,14 @@ package client
 
 import (
 	"errors"
+	"fmt"
+	"os"
 
 	"github.com/deis/deis/deisctl/backend"
 	"github.com/deis/deis/deisctl/backend/fleet"
 	"github.com/deis/deis/deisctl/cmd"
+
+	docopt "github.com/docopt/docopt-go"
 )
 
 // DeisCtlClient manages Deis components, configuration, and related tasks.
@@ -57,62 +61,247 @@ func NewClient(requestedBackend string) (*Client, error) {
 // at /deis/<component>/<config>. Configuration values are typically used for component-level
 // configuration, such as enabling TLS for the routers.
 func (c *Client) Config(argv []string) error {
-	return cmd.Config(argv)
+	usage := `Gets or sets a configuration value from the cluster.
+
+A configuration value is stored and retrieved from a key/value store
+(in this case, etcd) at /deis/<component>/<config>. Configuration
+values are typically used for component-level configuration, such as
+enabling TLS for the routers.
+
+Note: "deisctl config platform set sshPrivateKey=" expects a path
+to a private key.
+
+Usage:
+  deisctl config <target> get [<key>...]
+  deisctl config <target> set <key=val>...
+  deisctl config <target> rm [<key>...]
+
+Examples:
+  deisctl config platform set domain=mydomain.com
+  deisctl config platform set sshPrivateKey=$HOME/.ssh/deis
+  deisctl config controller get webEnabled
+  deisctl config controller rm webEnabled
+`
+	// parse command-line arguments
+	args, err := docopt.Parse(usage, argv, true, "", false)
+	if err != nil {
+		return err
+	}
+
+	var action string
+	var key []string
+
+	if args["set"] == true {
+		action = "set"
+		key = args["<key=val>"].([]string)
+	} else if args["rm"] == true {
+		action = "rm"
+		key = args["<key>"].([]string)
+	} else {
+		action = "get"
+		key = args["<key>"].([]string)
+	}
+
+	return cmd.Config(args["<target>"].(string), action, key)
 }
 
 // Install loads the definitions of components from local unit files.
 // After Install, the components will be available to Start.
 func (c *Client) Install(argv []string) error {
-	return cmd.Install(argv, c.Backend)
+	usage := `Loads the definitions of components from local unit files.
+
+After install, the components will be available to start.
+
+"deisctl install" looks for unit files in these directories, in this order:
+- the $DEISCTL_UNITS environment variable, if set
+- $HOME/.deis/units
+- /var/lib/deis/units
+
+Usage:
+  deisctl install [<target>...] [options]
+`
+	// parse command-line arguments
+	args, err := docopt.Parse(usage, argv, true, "", false)
+	if err != nil {
+		return err
+	}
+
+	return cmd.Install(args["<target>"].([]string), c.Backend)
 }
 
 // Journal prints log output for the specified components.
 func (c *Client) Journal(argv []string) error {
-	return cmd.Journal(argv, c.Backend)
+	usage := `Prints log output for the specified components.
+
+Usage:
+  deisctl journal [<target>...] [options]
+`
+	// parse command-line arguments
+	args, err := docopt.Parse(usage, argv, true, "", false)
+	if err != nil {
+		return err
+	}
+
+	return cmd.Journal(args["<target>"].([]string), c.Backend)
 }
 
 // List prints a summary of installed components.
 func (c *Client) List(argv []string) error {
-	return cmd.ListUnits(argv, c.Backend)
+	usage := `Prints a list of installed units.
+
+Usage:
+  deisctl list [options]
+`
+	// parse command-line arguments
+	if _, err := docopt.Parse(usage, argv, true, "", false); err != nil {
+		return err
+	}
+	return cmd.ListUnits(c.Backend)
 }
 
 // RefreshUnits overwrites local unit files with those requested.
 func (c *Client) RefreshUnits(argv []string) error {
-	return cmd.RefreshUnits(argv)
+	usage := `Overwrites local unit files with those requested.
+
+Downloading from the Deis project GitHub URL by tag or SHA is the only mechanism
+currently supported.
+
+"deisctl install" looks for unit files in these directories, in this order:
+- the $DEISCTL_UNITS environment variable, if set
+- $HOME/.deis/units
+- /var/lib/deis/units
+
+Usage:
+  deisctl refresh-units [-p <target>] [-t <tag>]
+
+Options:
+  -p --path=<target>   where to save unit files [default: $HOME/.deis/units]
+  -t --tag=<tag>       git tag, branch, or SHA to use when downloading unit files
+                       [default: master]
+`
+	// parse command-line arguments
+	args, err := docopt.Parse(usage, argv, true, "", false)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(2)
+	}
+
+	return cmd.RefreshUnits(args["--path"].(string), args["--tag"].(string))
 }
 
 // Restart stops and then starts components.
 func (c *Client) Restart(argv []string) error {
-	return cmd.Restart(argv, c.Backend)
+	usage := `Stops and then starts the specified components.
+
+Usage:
+  deisctl restart [<target>...] [options]
+`
+	// parse command-line arguments
+	args, err := docopt.Parse(usage, argv, true, "", false)
+	if err != nil {
+		return err
+	}
+
+	return cmd.Restart(args["<target>"].([]string), c.Backend)
 }
 
 // Scale grows or shrinks the number of running components.
 func (c *Client) Scale(argv []string) error {
-	return cmd.Scale(argv, c.Backend)
+	usage := `Grows or shrinks the number of running components.
+
+Currently "router", "registry" and "store-gateway" are the only types that can be scaled.
+
+Usage:
+  deisctl scale [<target>...] [options]
+`
+	// parse command-line arguments
+	args, err := docopt.Parse(usage, argv, true, "", false)
+	if err != nil {
+		return err
+	}
+
+	return cmd.Scale(args["<target>"].([]string), c.Backend)
 }
 
 // SSH opens an interactive shell with a machine in the cluster.
 func (c *Client) SSH(argv []string) error {
-	return cmd.SSH(argv, c.Backend)
+	usage := `Open an interactive shell on a machine in the cluster given a unit or machine id.
+
+Usage:
+  deisctl ssh <target>
+`
+	// parse command-line arguments
+	args, err := docopt.Parse(usage, argv, true, "", false)
+	if err != nil {
+		return err
+	}
+
+	return cmd.SSH(args["<target>"].(string), c.Backend)
 }
 
 // Start activates the specified components.
 func (c *Client) Start(argv []string) error {
-	return cmd.Start(argv, c.Backend)
+	usage := `Activates the specified components.
+
+Usage:
+  deisctl start [<target>...] [options]
+`
+	// parse command-line arguments
+	args, err := docopt.Parse(usage, argv, true, "", false)
+	if err != nil {
+		return err
+	}
+
+	return cmd.Start(args["<target>"].([]string), c.Backend)
 }
 
 // Status prints the current status of components.
 func (c *Client) Status(argv []string) error {
-	return cmd.Status(argv, c.Backend)
+	usage := `Prints the current status of components.
+
+Usage:
+  deisctl status [<target>...] [options]
+`
+	// parse command-line arguments
+	args, err := docopt.Parse(usage, argv, true, "", false)
+	if err != nil {
+		return err
+	}
+
+	return cmd.Status(args["<target>"].([]string), c.Backend)
 }
 
 // Stop deactivates the specified components.
 func (c *Client) Stop(argv []string) error {
-	return cmd.Stop(argv, c.Backend)
+	usage := `Deactivates the specified components.
+
+Usage:
+  deisctl stop [<target>...] [options]
+`
+	// parse command-line arguments
+	args, err := docopt.Parse(usage, argv, true, "", false)
+	if err != nil {
+		return err
+	}
+
+	return cmd.Stop(args["<target>"].([]string), c.Backend)
 }
 
 // Uninstall unloads the definitions of the specified components.
 // After Uninstall, the components will be unavailable until Install is called.
 func (c *Client) Uninstall(argv []string) error {
-	return cmd.Uninstall(argv, c.Backend)
+	usage := `Unloads the definitions of the specified components.
+
+After uninstall, the components will be unavailable until install is called.
+
+Usage:
+  deisctl uninstall [<target>...] [options]
+`
+	// parse command-line arguments
+	args, err := docopt.Parse(usage, argv, true, "", false)
+	if err != nil {
+		return err
+	}
+
+	return cmd.Uninstall(args["<target>"].([]string), c.Backend)
 }

--- a/deisctl/cmd/cmd_test.go
+++ b/deisctl/cmd/cmd_test.go
@@ -52,7 +52,7 @@ var b stubBackend
 
 // Start units
 func TestStart(t *testing.T) {
-	Start([]string{"start", "router@1", "router@2"}, b)
+	Start([]string{"router@1", "router@2"}, b)
 
 	if !reflect.DeepEqual(startedUnits, []string{"router@1", "router@2"}) {
 		t.Error(startedUnits)
@@ -61,7 +61,7 @@ func TestStart(t *testing.T) {
 
 // Stop units
 func TestStop(t *testing.T) {
-	Stop([]string{"stop", "router@1", "router@2"}, b)
+	Stop([]string{"router@1", "router@2"}, b)
 
 	if !reflect.DeepEqual(stoppedUnits, []string{"router@1", "router@2"}) {
 		t.Error(stoppedUnits)
@@ -70,7 +70,7 @@ func TestStop(t *testing.T) {
 
 // Restart units
 func TestRestart(t *testing.T) {
-	Restart([]string{"restart", "router@4", "router@5"}, b)
+	Restart([]string{"router@4", "router@5"}, b)
 
 	if !reflect.DeepEqual(stoppedUnits, []string{"router@4", "router@5"}) {
 		t.Error(stoppedUnits)

--- a/deisctl/config/config.go
+++ b/deisctl/config/config.go
@@ -19,8 +19,8 @@ var fileKeys = []string{
 var b64Keys = []string{"/deis/platform/sshPrivateKey"}
 
 // Config runs the config subcommand
-func Config(args map[string]interface{}) error {
-	return doConfig(args)
+func Config(target string, action string, key []string) error {
+	return doConfig(target, action, key)
 }
 
 // CheckConfig looks for a value at a keyspace path
@@ -40,21 +40,21 @@ func CheckConfig(root string, k string) error {
 	return nil
 }
 
-func doConfig(args map[string]interface{}) error {
+func doConfig(target string, action string, key []string) error {
 	client, err := getEtcdClient()
 	if err != nil {
 		return err
 	}
 
-	rootPath := "/deis/" + args["<target>"].(string) + "/"
+	rootPath := "/deis/" + target + "/"
 
 	var vals []string
-	if args["set"] == true {
-		vals, err = doConfigSet(client, rootPath, args["<key=val>"].([]string))
-	} else if args["rm"] == true {
-		vals, err = doConfigRm(client, rootPath, args["<key>"].([]string))
+	if action == "set" {
+		vals, err = doConfigSet(client, rootPath, key)
+	} else if action == "rm" {
+		vals, err = doConfigRm(client, rootPath, key)
 	} else {
-		vals, err = doConfigGet(client, rootPath, args["<key>"].([]string))
+		vals, err = doConfigGet(client, rootPath, key)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
This abstracts the command line parsing away from the CMD package. Now the CMD package takes function arguments. The client package now transform the command line flags into function arguments.

Why do this?

1. This makes the CMD package much easier to test. Now you can pass function arguments rather than call the function with unparsed command line input.

2. Limits the scope of docopt. Now docopt only is part of the main and client package. If we decide to change the CLI framework, the majority of our code is now unaffected.

3. More idiomatic code. Instead of passing the command line input to every function, which contains an unknown amount of flags, we now pass sane arguments, making the code much more understandable and making function input much clearer.