### PR TITLE
fix(tests): fix assertions on default beverage

### DIFF
--- a/tests/bin/test-setup.sh
+++ b/tests/bin/test-setup.sh
@@ -85,6 +85,9 @@ ssh-add -D || eval $(ssh-agent) && ssh-add -D
 ssh-add ~/.ssh/$DEIS_TEST_AUTH_KEY
 ssh-add $DEIS_TEST_SSH_KEY
 
+# clear the drink of choice in case the user has set it
+unset DEIS_DRINK_OF_CHOICE
+
 # wipe out all vagrants & deis virtualboxen
 function cleanup {
     if [ "$SKIP_CLEANUP" != true ]; then


### PR DESCRIPTION
This has burned me two times too many:

https://github.com/deis/deis/blob/master/tests/ps_test.go#L41

This fixes an issue where integration tests that would otherwise
succeed, locally, fail close to the end because the user executing
the tests has set the DEIS_DRINK_OF_CHOICE environment variable,
which interferes with the assertion that the default beverage to
be enjoyed whilst scaling is coffee.  This corrects that problem
by unsetting the DEIS_DRINK_OF_CHOICE environment variable prior
to testing.