### PR TITLE
fix(deisctl): Add extension when refreshing units

### DIFF
--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -569,7 +569,7 @@ Options:
 	tag := args["--tag"].(string)
 	for _, unit := range units.Names {
 		src := rootURL + tag + "/deisctl/units/" + unit + ".service"
-		dest := filepath.Join(dir, unit)
+		dest := filepath.Join(dir, unit+".service")
 		res, err := http.Get(src)
 		if err != nil {
 			return err


### PR DESCRIPTION
Units were being refreshed without their extension, causing the fleet backend to be unable to find them when installing.

Fixes #3832 

![screen shot 2015-06-09 at 12 40 50 pm](https://cloud.githubusercontent.com/assets/3526404/8068093/a1914ae6-0ea6-11e5-8cf5-47285f3bd268.png)
