### PR TITLE
ref(*): disable pip version check and caching

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -1,6 +1,6 @@
 
 build: setup-venv
-	venv/bin/pip install -r requirements.txt git+https://github.com/pyinstaller/pyinstaller@32bbb954b355937ccfe377afbe56979db79a7b30
+	venv/bin/pip install --disable-pip-version-check -r requirements.txt git+https://github.com/pyinstaller/pyinstaller@32bbb954b355937ccfe377afbe56979db79a7b30
 	venv/bin/pyinstaller deis.spec
 	chmod +x dist/deis
 
@@ -31,7 +31,7 @@ setup-venv:
 	@if [ ! -d venv ]; then virtualenv venv; fi
 
 test-style: setup-venv
-	venv/bin/pip install -q flake8==2.4.0
+	venv/bin/pip install --disable-pip-version-check -q flake8==2.4.0
 	venv/bin/flake8
 
 test-unit:

--- a/contrib/util/add_server_dev_deps.sh
+++ b/contrib/util/add_server_dev_deps.sh
@@ -6,7 +6,7 @@ echo "which coverage > /dev/null" | ./dshell deis-controller
 if [ $? -ne 0 ]; then
 	cat <<-EOF | ./dshell deis-controller
 		cd /app
-		pip install -r dev_requirements.txt
+		pip install --disable-pip-version-check -r dev_requirements.txt
 	EOF
 else
 	echo "Deis server development dependencies already installed."

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -69,7 +69,7 @@ test: test-unit test-functional
 
 setup-venv:
 	@if [ ! -d venv ]; then virtualenv venv; fi
-	venv/bin/pip install -q -r requirements.txt -r dev_requirements.txt
+	venv/bin/pip install --disable-pip-version-check -q -r requirements.txt -r dev_requirements.txt
 
 test-style: setup-venv
 	venv/bin/flake8

--- a/controller/build.sh
+++ b/controller/build.sh
@@ -36,7 +36,7 @@ mkdir -p /app && chown -R deis:deis /app
 mkdir -p /templates && chown -R deis:deis /templates
 
 # install dependencies
-pip install -r /app/requirements.txt
+pip install --disable-pip-version-check --no-cache-dir -r /app/requirements.txt
 
 # cleanup.
 apk del --purge \

--- a/database/build.sh
+++ b/database/build.sh
@@ -41,10 +41,10 @@ git clone https://github.com/wal-e/wal-e.git
 cd /tmp/wal-e
 git checkout c6dd4b1
 
-pip install . oslo.config>=1.12.0
+pip install --disable-pip-version-check --no-cache-dir . oslo.config>=1.12.0
 
 # python port of daemontools
-pip install envdir
+pip install --disable-pip-version-check --no-cache-dir envdir
 
 mkdir -p /etc/wal-e.d/env /etc/postgresql/main /var/lib/postgresql
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -69,7 +69,7 @@ server: dirhtml
 
 test: clean
 	@if [ ! -d venv ]; then virtualenv venv; fi
-	venv/bin/pip install -q -r docs_requirements.txt
+	venv/bin/pip install --disable-pip-version-check -q -r docs_requirements.txt
 	venv/bin/$(SPHINXBUILD) -b dirhtml -N $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	grep -q \<h1\>Welcome _build/dirhtml/index.html || exit 1
 	@echo

--- a/registry/build.sh
+++ b/registry/build.sh
@@ -25,7 +25,7 @@ apk add --update-cache \
 curl -sSL https://raw.githubusercontent.com/pypa/pip/7.0.3/contrib/get-pip.py | python -
 
 # workaround to python > 2.7.8 SSL issues
-pip install pyopenssl ndg-httpsclient pyasn1
+pip install --disable-pip-version-check --no-cache-dir pyopenssl ndg-httpsclient pyasn1
 
 # create a registry user
 adduser -D -s /bin/bash registry
@@ -36,13 +36,13 @@ git clone -b new-repository-import-v091 --single-branch https://github.com/deis/
 
 # install boto configuration
 cp /docker-registry/config/boto.cfg /etc/boto.cfg
-cd /docker-registry && pip install -r requirements/main.txt
+cd /docker-registry && pip install --disable-pip-version-check --no-cache-dir -r requirements/main.txt
 
 # Install core
-pip install /docker-registry/depends/docker-registry-core
+pip install --disable-pip-version-check --no-cache-dir /docker-registry/depends/docker-registry-core
 
 # Install registry
-pip install file:///docker-registry#egg=docker-registry[bugsnag,newrelic,cors]
+pip install --disable-pip-version-check --no-cache-dir file:///docker-registry#egg=docker-registry[bugsnag,newrelic,cors]
 
 patch \
   $(python -c 'import boto; import os; print os.path.dirname(boto.__file__)')/connection.py \

--- a/tests/bin/test-integration-ec2.sh
+++ b/tests/bin/test-integration-ec2.sh
@@ -18,7 +18,7 @@ export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID?}
 export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY?}
 
 # install python requirements for this script
-pip install awscli boto docopt
+pip install --disable-pip-version-check awscli boto docopt
 
 function cleanup_ec2 {
     if [ "$SKIP_CLEANUP" != true ]; then


### PR DESCRIPTION
The constant reminders that pip has a new version involve a network transaction and are not helpful to our build process, and some python libraries were being inadvertently cached at /root/.cache/ inside Docker images.