### PR TITLE
ref(deisctl): remove global variables in backend package

### DIFF
--- a/deisctl/backend/fleet/create.go
+++ b/deisctl/backend/fleet/create.go
@@ -60,7 +60,7 @@ func doCreate(c *FleetClient, unit *schema.Unit, wg *sync.WaitGroup, outchan cha
 outerLoop:
 	for {
 		time.Sleep(250 * time.Millisecond)
-		unitStates, err := cAPI.UnitStates()
+		unitStates, err := c.Fleet.UnitStates()
 		if err != nil {
 			errchan <- err
 		}

--- a/deisctl/backend/fleet/destroy.go
+++ b/deisctl/backend/fleet/destroy.go
@@ -46,7 +46,7 @@ func doDestroy(c *FleetClient, target string, wg *sync.WaitGroup, outchan chan s
 outerLoop:
 	for {
 		time.Sleep(250 * time.Millisecond)
-		unitStates, err := cAPI.UnitStates()
+		unitStates, err := c.Fleet.UnitStates()
 		if err != nil {
 			errchan <- err
 		}

--- a/deisctl/backend/fleet/fleet.go
+++ b/deisctl/backend/fleet/fleet.go
@@ -1,10 +1,16 @@
 package fleet
 
-import "github.com/coreos/fleet/client"
+import (
+	"github.com/coreos/fleet/client"
+	"github.com/coreos/fleet/machine"
+)
 
 // FleetClient used to wrap Fleet API calls
 type FleetClient struct {
 	Fleet client.API
+
+	// used to cache MachineStates
+	machineStates map[string]*machine.MachineState
 }
 
 // NewClient returns a client used to communicate with Fleet
@@ -14,7 +20,5 @@ func NewClient() (*FleetClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	// set global client
-	cAPI = client
 	return &FleetClient{Fleet: client}, nil
 }

--- a/deisctl/backend/fleet/journal.go
+++ b/deisctl/backend/fleet/journal.go
@@ -11,19 +11,19 @@ func (c *FleetClient) Journal(target string) (err error) {
 		return
 	}
 	for _, unit := range units {
-		runJournal(unit)
+		runJournal(c, unit)
 	}
 	return
 }
 
 // runJournal tails the systemd journal for a given unit
-func runJournal(name string) (exit int) {
-	machineID, err := findUnit(name)
+func runJournal(c *FleetClient, name string) (exit int) {
+	machineID, err := findUnit(c, name)
 
 	if err != nil {
 		return 1
 	}
 
 	command := fmt.Sprintf("journalctl --unit %s --no-pager -n 40 -f", name)
-	return runCommand(command, machineID)
+	return runCommand(c, command, machineID)
 }

--- a/deisctl/backend/fleet/registry.go
+++ b/deisctl/backend/fleet/registry.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/coreos/fleet/client"
 	"github.com/coreos/fleet/etcd"
-	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/pkg"
 	"github.com/coreos/fleet/registry"
 	"github.com/coreos/fleet/ssh"
@@ -40,13 +39,6 @@ recommended to upgrade fleetctl to prevent incompatibility issues.
 ####################################################################
 `
 )
-
-// global API client used by commands
-var cAPI client.API
-
-// used to cache MachineStates
-var machineStates map[string]*machine.MachineState
-var requestTimeout = time.Duration(10) * time.Second
 
 func getTunnelFlag() string {
 	tun := Flags.Tunnel

--- a/deisctl/backend/fleet/status.go
+++ b/deisctl/backend/fleet/status.go
@@ -12,15 +12,15 @@ func (c *FleetClient) Status(target string) (err error) {
 		return
 	}
 	for _, unit := range units {
-		printUnitStatus(unit)
+		printUnitStatus(c, unit)
 		fmt.Println()
 	}
 	return
 }
 
 // printUnitStatus displays the systemd status for a given unit
-func printUnitStatus(name string) int {
-	u, err := cAPI.Unit(name)
+func printUnitStatus(c *FleetClient, name string) int {
+	u, err := c.Fleet.Unit(name)
 	if suToGlobal(*u) {
 		fmt.Fprintf(os.Stderr, "Unable to get status for global unit %s. Check the status on the host using systemctl.\n", name)
 		return 1
@@ -37,5 +37,5 @@ func printUnitStatus(name string) int {
 		return 1
 	}
 	cmd := fmt.Sprintf("systemctl status -l %s", name)
-	return runCommand(cmd, u.MachineID)
+	return runCommand(c, cmd, u.MachineID)
 }


### PR DESCRIPTION
:fire: Some global variables in favor of member variables. It makes the code cleaner and easier to test.