### PR TITLE
feat(router): enable HSTS when enforceHTTPS is set

### DIFF
--- a/docs/customizing_deis/router_settings.rst
+++ b/docs/customizing_deis/router_settings.rst
@@ -60,7 +60,7 @@ setting                                      description
 /deis/router/gzipDisable                     nginx gzipDisable setting (default: "msie6")
 /deis/router/gzipTypes                       nginx gzipTypes setting (default: "application/x-javascript application/xhtml+xml application/xml application/xml+rss application/json text/css text/javascript text/plain text/xml")
 /deis/router/hsts/enabled                    enable HTTP Strict Transport Security headers for HTTPS requests (default: false)
-/deis/router/hsts/maxAge                     maximum number of seconds user agents should observe HSTS rewrites (default: 2628000)
+/deis/router/hsts/maxAge                     maximum number of seconds user agents should observe HSTS rewrites (default: 10886400)
 /deis/router/hsts/includeSubDomains          enforce HSTS for requests on all subdomains (default: false)
 /deis/router/hsts/preload                    allow the domain to be included in the HSTS preload list (default: false)
 /deis/router/maxWorkerConnections            maximum number of simultaneous connections that can be opened by a worker process (default: 768)

--- a/docs/customizing_deis/router_settings.rst
+++ b/docs/customizing_deis/router_settings.rst
@@ -60,6 +60,7 @@ setting                                      description
 /deis/router/gzipDisable                     nginx gzipDisable setting (default: "msie6")
 /deis/router/gzipTypes                       nginx gzipTypes setting (default: "application/x-javascript application/xhtml+xml application/xml application/xml+rss application/json text/css text/javascript text/plain text/xml")
 /deis/router/maxWorkerConnections            maximum number of simultaneous connections that can be opened by a worker process (default: 768)
+/deis/router/secondsToEnforceHSTS            maximum time to observe HSTS when enforceHTTPS is enabled (default: 2628000)
 /deis/router/serverNameHashMaxSize           nginx server_names_hash_max_size setting (default: 512)
 /deis/router/serverNameHashBucketSize        nginx server_names_hash_bucket_size (default: 64)
 /deis/router/sslCert                         cluster-wide SSL certificate

--- a/docs/customizing_deis/router_settings.rst
+++ b/docs/customizing_deis/router_settings.rst
@@ -59,8 +59,11 @@ setting                                      description
 /deis/router/gzipVary                        nginx gzipVary setting (default: on)
 /deis/router/gzipDisable                     nginx gzipDisable setting (default: "msie6")
 /deis/router/gzipTypes                       nginx gzipTypes setting (default: "application/x-javascript application/xhtml+xml application/xml application/xml+rss application/json text/css text/javascript text/plain text/xml")
+/deis/router/hsts/enabled                    enable HTTP Strict Transport Security headers for HTTPS requests (default: false)
+/deis/router/hsts/maxAge                     maximum number of seconds user agents should observe HSTS rewrites (default: 2628000)
+/deis/router/hsts/includeSubDomains          enforce HSTS for requests on all subdomains (default: false)
+/deis/router/hsts/preload                    allow the domain to be included in the HSTS preload list (default: false)
 /deis/router/maxWorkerConnections            maximum number of simultaneous connections that can be opened by a worker process (default: 768)
-/deis/router/secondsToEnforceHSTS            maximum time to observe HSTS when enforceHTTPS is enabled (default: 2628000)
 /deis/router/serverNameHashMaxSize           nginx server_names_hash_max_size setting (default: 512)
 /deis/router/serverNameHashBucketSize        nginx server_names_hash_bucket_size (default: 64)
 /deis/router/sslCert                         cluster-wide SSL certificate

--- a/router/boot.go
+++ b/router/boot.go
@@ -59,6 +59,7 @@ func main() {
 	mkdirEtcd(client, "/deis/builder")
 	mkdirEtcd(client, "/deis/certs")
 	mkdirEtcd(client, "/deis/router/hosts")
+	mkdirEtcd(client, "/deis/router/hsts")
 
 	setDefaultEtcd(client, etcdPath+"/gzip", "on")
 

--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -71,6 +71,11 @@ http {
 
     {{ $enforceHTTPS := or (getv "/deis/router/enforceHTTPS") "false" }}
 
+    {{ $secondsToEnforceHSTS := or (getv "/deis/router/secondsToEnforceHSTS") "2628000" }}
+    map $access_scheme $sts {
+      'https' 'max-age={{ $secondsToEnforceHSTS }}; preload';
+    }
+
     ## start deis-controller
     {{ if exists "/deis/controller/host" }}
     upstream deis-controller {
@@ -114,6 +119,7 @@ http {
         if ($access_scheme != "https") {
           return 301 https://$host$request_uri;
         }
+        add_header Strict-Transport-Security $sts always;
         {{ end }}
     }
     ## end deis-controller
@@ -224,6 +230,7 @@ http {
             if ($access_scheme != "https") {
               return 301 https://$host$request_uri;
             }
+            add_header Strict-Transport-Security $sts always;
             {{ end }}
 
             ## workaround for nginx hashing empty string bug http://trac.nginx.org/nginx/ticket/765
@@ -282,6 +289,7 @@ http {
             if ($access_scheme != "https") {
               return 301 https://$host$request_uri;
             }
+            add_header Strict-Transport-Security $sts always;
             {{ end }}
 
             proxy_pass                  http://{{ $app }};

--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -71,7 +71,7 @@ http {
 
     ## HSTS instructs the browser to replace all HTTP links with HTTPS links for this domain until maxAge seconds from now
     {{ $enableHSTS := or (getv "/deis/router/hsts/enabled") "false" }}
-    {{ $maxAgeHSTS := or (getv "/deis/router/hsts/maxAge") "2628000" }}
+    {{ $maxAgeHSTS := or (getv "/deis/router/hsts/maxAge") "10886400" }}
     {{ $includeSubdomainsHSTS := or (getv "/deis/router/hsts/includeSubDomains") "false" }}
     {{ $preloadHSTS := or (getv "/deis/router/hsts/preload") "false" }}
     map $access_scheme $sts {

--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -69,12 +69,17 @@ http {
       ''      $scheme;
     }
 
-    {{ $enforceHTTPS := or (getv "/deis/router/enforceHTTPS") "false" }}
-
-    {{ $secondsToEnforceHSTS := or (getv "/deis/router/secondsToEnforceHSTS") "2628000" }}
+    ## HSTS instructs the browser to replace all HTTP links with HTTPS links for this domain until maxAge seconds from now
+    {{ $enableHSTS := or (getv "/deis/router/hsts/enabled") "false" }}
+    {{ $maxAgeHSTS := or (getv "/deis/router/hsts/maxAge") "2628000" }}
+    {{ $includeSubdomainsHSTS := or (getv "/deis/router/hsts/includeSubDomains") "false" }}
+    {{ $preloadHSTS := or (getv "/deis/router/hsts/preload") "false" }}
     map $access_scheme $sts {
-      'https' 'max-age={{ $secondsToEnforceHSTS }}; preload';
+      'https' 'max-age={{ $maxAgeHSTS }}{{ if eq $includeSubdomainsHSTS "true" }}; includeSubDomains{{ end }}{{ if eq $preloadHSTS "true" }}; preload{{ end }}';
     }
+
+    ## since HSTS headers are not permitted on HTTP requests, 301 redirects to HTTPS resources are also necessary
+    {{ $enforceHTTPS := or (getv "/deis/router/enforceHTTPS") $enableHSTS "false" }}
 
     ## start deis-controller
     {{ if exists "/deis/controller/host" }}
@@ -119,6 +124,9 @@ http {
         if ($access_scheme != "https") {
           return 301 https://$host$request_uri;
         }
+        {{ end }}
+
+        {{ if eq $enableHSTS "true" }}
         add_header Strict-Transport-Security $sts always;
         {{ end }}
     }
@@ -230,6 +238,9 @@ http {
             if ($access_scheme != "https") {
               return 301 https://$host$request_uri;
             }
+            {{ end }}
+
+            {{ if eq $enableHSTS "true" }}
             add_header Strict-Transport-Security $sts always;
             {{ end }}
 
@@ -289,6 +300,9 @@ http {
             if ($access_scheme != "https") {
               return 301 https://$host$request_uri;
             }
+            {{ end }}
+
+            {{ if eq $enableHSTS "true" }}
             add_header Strict-Transport-Security $sts always;
             {{ end }}
 


### PR DESCRIPTION
When browsers see the HSTS header on an HTTPS request then they rewrite
all links for the current domain that point at HTTP resources to point
to HTTPS resources. When /deis/router/enforceHTTPS is set, using HSTS
avoids the extranneous 301 redirect to the HTTPS resource and prevents
[some threats][1]. The HTTPS Strict Transport Security header mechanism
is defined in [RFC-6797][2]

[1]: https://www.owasp.org/index.php/HTTP_Strict_Transport_Security
[2]: https://tools.ietf.org/html/rfc6797