### PR TITLE
fix(builder): call ls rather than using a wildcard

### DIFF
--- a/builder/rootfs/etc/confd/templates/check-repos
+++ b/builder/rootfs/etc/confd/templates/check-repos
@@ -4,7 +4,7 @@ export ETCD=${ETCD:-$HOST:4001}
 
 cd $(dirname $0) # absolute path
 
-for repo in *.git
+for repo in $(ls | grep .git)
 do
     reponame="${repo%.*}"
     if ! etcdctl -C $ETCD ls /deis/services/"$reponame" > /dev/null 2>&1


### PR DESCRIPTION
The wildcard caused an off-by-one error where if no git repositories
existed, the wildcard was then interpreted, causing all images prefixed
with the registry IP address to be removed inside builder.

As an example:

    $ for repo in *.git; do echo $repo; done
    *.git
    $ for repo in $(ls | grep .git); do echo $repo; done
    $ mkdir foo.git
    $ for repo in *.git; do echo $repo; done
    foo.git
    $ for repo in $(ls | grep .git); do echo $repo; done
    foo.git

closes #3862