### PR TITLE
feat(router): add Diffie-Hellman parameter for DHE ciphersuites

### DIFF
--- a/deisctl/config/config.go
+++ b/deisctl/config/config.go
@@ -13,7 +13,8 @@ import (
 var fileKeys = []string{
 	"/deis/platform/sshPrivateKey",
 	"/deis/router/sslCert",
-	"/deis/router/sslKey"}
+	"/deis/router/sslKey",
+	"/deis/router/sslDhparam"}
 
 // b64Keys define config keys to be base64 encoded before stored
 var b64Keys = []string{"/deis/platform/sshPrivateKey"}

--- a/docs/customizing_deis/router_settings.rst
+++ b/docs/customizing_deis/router_settings.rst
@@ -64,6 +64,7 @@ setting                                      description
 /deis/router/serverNameHashBucketSize        nginx server_names_hash_bucket_size (default: 64)
 /deis/router/sslCert                         cluster-wide SSL certificate
 /deis/router/sslKey                          cluster-wide SSL private key
+/deis/router/sslDhparam                      cluster-wide SSL dhparam
 /deis/router/workerProcesses                 nginx number of worker processes to start (default: auto i.e. available CPU cores)
 /deis/router/proxyProtocol                   nginx PROXY protocol enabled
 /deis/router/proxyRealIpCidr                 nginx IP with CIDR used by the load balancer in front of deis-router (default: 10.0.0.0/8)

--- a/router/image/conf.d/dhparam.pem.toml
+++ b/router/image/conf.d/dhparam.pem.toml
@@ -1,0 +1,10 @@
+[template]
+src   = "dhparam.pem"
+dest  = "/etc/ssl/dhparam.pem"
+uid = 0
+gid = 0
+mode  = "0644"
+keys = [
+  "/deis/router",
+]
+reload_cmd = "/opt/nginx/sbin/nginx -s reload"

--- a/router/image/templates/deis.conf
+++ b/router/image/templates/deis.conf
@@ -6,5 +6,8 @@ listen 80{{ if exists "/deis/router/proxyProtocol" }} proxy_protocol{{ end }};
 listen 443 ssl spdy{{ if exists "/deis/router/proxyProtocol" }} proxy_protocol{{ end }};
 ssl_certificate /etc/ssl/deis.cert;
 ssl_certificate_key /etc/ssl/deis.key;
+{{ if exists "/deis/router/sslDhparam" }}
+ssl_dhparam /etc/ssl/dhparam.pem;
+{{ end }}
 ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 {{ end }}

--- a/router/image/templates/dhparam.pem
+++ b/router/image/templates/dhparam.pem
@@ -1,0 +1,1 @@
+{{ getv "/deis/router/sslDhparam" }}


### PR DESCRIPTION
The openssl defaults for Ephemeral Diffie-Hellman exchange are considered by some to be inadequate.

Generate a 2048-bit key and upload to the cluster with:
```
openssl dhparam -out ./dhparam.pem 2048
deisctl config router set sslDhparam=./dhparam.pem
```