### PR TITLE
feat(router): read list of preferred ciphers

### DIFF
--- a/docs/customizing_deis/router_settings.rst
+++ b/docs/customizing_deis/router_settings.rst
@@ -63,6 +63,7 @@ setting                                      description
 /deis/router/serverNameHashMaxSize           nginx server_names_hash_max_size setting (default: 512)
 /deis/router/serverNameHashBucketSize        nginx server_names_hash_bucket_size (default: 64)
 /deis/router/sslCert                         cluster-wide SSL certificate
+/deis/router/sslCiphers                      cluster-wide enabled SSL ciphers
 /deis/router/sslKey                          cluster-wide SSL private key
 /deis/router/workerProcesses                 nginx number of worker processes to start (default: auto i.e. available CPU cores)
 /deis/router/proxyProtocol                   nginx PROXY protocol enabled

--- a/router/image/templates/deis.conf
+++ b/router/image/templates/deis.conf
@@ -7,4 +7,8 @@ listen 443 ssl spdy{{ if exists "/deis/router/proxyProtocol" }} proxy_protocol{{
 ssl_certificate /etc/ssl/deis.cert;
 ssl_certificate_key /etc/ssl/deis.key;
 ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+{{ if exists "/deis/router/sslCiphers" }}
+ssl_ciphers '{{ getv "/deis/router/sslCiphers" }}';
+ssl_prefer_server_ciphers on;
+{{ end }}
 {{ end }}

--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -184,6 +184,10 @@ http {
         ssl_certificate /etc/ssl/deis/certs/{{ $app_domain }}.cert;
         ssl_certificate_key /etc/ssl/deis/keys/{{ $app_domain }}.key;
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+        {{ if exists "/deis/router/sslCiphers" }}
+        ssl_ciphers '{{ getv "/deis/router/sslCiphers" }}';
+        ssl_prefer_server_ciphers on;
+        {{ end }}
         {{/* if there's no app SSL cert but we have a router SSL cert, enable that instead */}}
         {{/* TODO (bacongobbler): wait for https://github.com/kelseyhightower/confd/issues/270 */}}
         {{/* so we can apply this config to just subdomains of the platform domain. */}}


### PR DESCRIPTION
This allows a custom ordered ciphersuite list to be used. For recommendations, read [Mozilla's guide to Server Side TLS](https://wiki.mozilla.org/Security/Server_Side_TLS)

One might use their modern compatibility list like so:
```bash
deisctl config router set sslCiphers='ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK'
```
noting the single quotes on `sslCiphers='...'`