### PR TITLE
fix(deisctl): return 0 when only printing version

### DIFF
--- a/deisctl/deisctl.go
+++ b/deisctl/deisctl.go
@@ -64,6 +64,8 @@ Options:
 		if helpFlag {
 			fmt.Print(usage)
 			return 0
+		} else if argv[0] == "--version" {
+			return 0
 		}
 		return 1
 	}


### PR DESCRIPTION
Fixes #3876