### PR TITLE
fix(builder): add "z" flag for compressed tar archives

### DIFF
--- a/builder/rootfs/etc/confd/templates/builder
+++ b/builder/rootfs/etc/confd/templates/builder
@@ -140,11 +140,11 @@ if [ -f Procfile ]; then
 elif [ -f $TMP_DIR/slug.tgz ]; then
     # Sometimes, the buildpack will generate a Procfile instead of populating /bin/release
     # /bin/release was unofficially deprecated for declaring default process types
-    if tar -tf $TMP_DIR/slug.tgz ./Procfile &> /dev/null;
+    if tar -tzf $TMP_DIR/slug.tgz ./Procfile &> /dev/null;
     then
-        PROCFILE="$(tar --to-stdout -xf $TMP_DIR/slug.tgz ./Procfile | yaml2json-procfile)"
+        PROCFILE="$(tar --to-stdout -xzf $TMP_DIR/slug.tgz ./Procfile | yaml2json-procfile)"
     else
-        PROCFILE=$(tar --to-stdout -xf $TMP_DIR/slug.tgz ./.release | extract-types)
+        PROCFILE=$(tar --to-stdout -xzf $TMP_DIR/slug.tgz ./.release | extract-types)
     fi
 else
     PROCFILE="{}"


### PR DESCRIPTION
When a Procfile isn't present in a `git push` operation, builder tries to extract or fabricate one, but the tar commands would fail with "invalid tar magic" since the compression flag "z" was missing.

I tested this by removing the Procfile from [example-play]() and committing it before `git push`. It failed before this change, but afterward the Procfile was correctly filled in (here's with debug output):
```console
Successfully built 39111ec4e108
+ puts-step 'Pushing image to private registry'
+ echo '-----> Pushing image to private registry'
-----> Pushing image to private registry
+ docker push 172.17.8.100:5000/ultima-underdog:git-f67f5ca1
+ echo

+ '[' -f Procfile ']'
+ '[' -f /home/git/ultima-underdog.git/build/tmp.B9dJa9cCgo/slug.tgz ']'
+ tar -tzf /home/git/ultima-underdog.git/build/tmp.B9dJa9cCgo/slug.tgz ./Procfile
++ extract-types
++ tar --to-stdout -xzf /home/git/ultima-underdog.git/build/tmp.B9dJa9cCgo/slug.tgz ./.release
+ PROCFILE='{"web":"play run --http.port=$PORT $PLAY_OPTS"}'
+ puts-step 'Launching... '
+ echo '-----> Launching... '
-----> Launching... 
```

Closes #3871.