### PR TITLE
fix(client+deisctl): remove colors from installer messages

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -21,8 +21,8 @@ installer: build
 	PATH=./makeself:$$PATH BINARY=deis makeself.sh --bzip2 --current --nox11 dist \
 		dist/deis-cli-`grep '__version__\ =\ ' deis.py | cut -d' ' -f3 | tr -d \'`-`go env GOOS`-`go env GOARCH`.run \
 		"Deis CLI" "echo \
-		&& echo '\033[0;36mdeis\033[0m is in the current directory. Please' \
-		&& echo 'move \033[0;36mdeis\033[0m to a directory in your search PATH.' \
+		&& echo 'deis is in the current directory. Please' \
+		&& echo 'move deis to a directory in your search PATH.' \
 		&& echo \
 		&& echo 'See http://docs.deis.io/ for documentation.' \
 		&& echo"

--- a/deisctl/Makefile
+++ b/deisctl/Makefile
@@ -21,8 +21,8 @@ installer:
 		dist/deisctl-`cat deis-version`-`go env GOOS`-`go env GOARCH`.run "Deis Control Utility" \
 		"./deisctl refresh-units \
 		&& echo \
-		&& echo '\033[0;36mdeisctl\033[0m is in the current directory and unit files are' \
-		&& echo 'in \$$HOME/.deis/units. Please move \033[0;36mdeisctl\033[0m to a' \
+		&& echo 'deisctl is in the current directory and unit files are' \
+		&& echo 'in \$$HOME/.deis/units. Please move deisctl to a' \
 		&& echo 'directory in your search PATH.' \
 		&& echo \
 		&& echo 'See http://docs.deis.io/ for documentation.' \


### PR DESCRIPTION
The ANSI color codes used in the "all done" installer messages won't print correctly on some platforms without using "echo -e", but the "-e" flag isn't recognized on all platforms.

Closes #3852.