### PR TITLE
ref(Makefiles): use wildcard for GO_FILES

### DIFF
--- a/builder/Makefile
+++ b/builder/Makefile
@@ -3,7 +3,7 @@ include ../includes.mk
 # the filepath to this repository, relative to $GOPATH/src
 repo_path = github.com/deis/deis/builder
 
-GO_FILES = types.go utils.go utils_test.go
+GO_FILES = $(wildcard *.go)
 GO_PACKAGES = src tests
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
 

--- a/deisctl/Makefile
+++ b/deisctl/Makefile
@@ -3,7 +3,7 @@ include ../includes.mk
 # the filepath to this repository, relative to $GOPATH/src
 repo_path = github.com/deis/deis/deisctl
 
-GO_FILES = deisctl.go deisctl_test.go
+GO_FILES = $(wildcard *.go)
 GO_PACKAGES = backend client cmd config units utils
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
 

--- a/logger/Makefile
+++ b/logger/Makefile
@@ -3,7 +3,7 @@ include ../includes.mk
 # the filepath to this repository, relative to $GOPATH/src
 repo_path = github.com/deis/deis/logger
 
-GO_FILES = main.go
+GO_FILES = $(wildcard *.go)
 GO_PACKAGES = syslog syslogd tests
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
 GO_TESTABLE_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,syslog syslogd)

--- a/logspout/Makefile
+++ b/logspout/Makefile
@@ -3,7 +3,7 @@ include ../includes.mk
 # the filepath to this repository, relative to $GOPATH/src
 repo_path = github.com/deis/deis/logspout
 
-GO_FILES = attacher.go logspout.go routes.go types.go
+GO_FILES = $(wildcard *.go)
 GO_PACKAGES = utils
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
 

--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -3,7 +3,7 @@ include ../includes.mk
 # the filepath to this repository, relative to $GOPATH/src
 repo_path = github.com/deis/deis/publisher
 
-GO_FILES = main.go
+GO_FILES = $(wildcard *.go)
 GO_PACKAGES = server
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
 

--- a/router/Makefile
+++ b/router/Makefile
@@ -3,7 +3,7 @@ include ../includes.mk
 # the filepath to this repository, relative to $GOPATH/src
 repo_path = github.com/deis/deis/router
 
-GO_FILES = boot.go
+GO_FILES = $(wildcard *.go)
 GO_PACKAGES = logger tests
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
 

--- a/swarm/Makefile
+++ b/swarm/Makefile
@@ -3,7 +3,7 @@ include ../includes.mk
 # the filepath to this repository, relative to $GOPATH/src
 repo_path = github.com/deis/deis/swarm
 
-GO_FILES = swarm.go
+GO_FILES = $(wildcard *.go)
 GO_PACKAGES =
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,9 +3,7 @@ include ../includes.mk
 # the filepath to this repository, relative to $GOPATH/src
 repo_path = github.com/deis/deis/tests
 
-GO_FILES = apps_test.go auth_test.go builds_test.go config_test.go integration_test.go \
-			keys_test.go limits_test.go main.go perms_test.go ps_test.go releases_test.go \
-			smoke_test.go tags_test.go
+GO_FILES = $(wildcard *.go)
 GO_PACKAGES = dockercli etcdutils mock utils
 GO_PACKAGES_REPO_PATH = $(addprefix $(repo_path)/,$(GO_PACKAGES))
 


### PR DESCRIPTION
Many components have a Makefile with `GO_FILES` hard-coded to the list of .go files in the current directory. Using the `wildcard` func will stop the need for this maintenance.

I noticed we weren't linting `domains_test.go` and `users_test.go`, then decided to fix it in general rather than just add two more files to tests/Makefile.