### PR TITLE
feat(contrib/linode): add Linode provision scripts and docs

### DIFF
--- a/contrib/linode/.gitignore
+++ b/contrib/linode/.gitignore
@@ -1,0 +1,1 @@
+linode-user-data.yaml

--- a/contrib/linode/README.md
+++ b/contrib/linode/README.md
@@ -1,0 +1,3 @@
+# Provision a Deis Cluster on Linode
+
+Please refer to the instructions at http://docs.deis.io/en/latest/installing_deis/linode/.

--- a/contrib/linode/apply-firewall.py
+++ b/contrib/linode/apply-firewall.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+"""
+Apply a "Security Group" to the members of an etcd cluster.
+
+Usage: apply-firewall.py
+"""
+import os
+import re
+import string
+import argparse
+from threading import Thread
+import uuid
+
+import colorama
+from colorama import Fore, Style
+import paramiko
+import requests
+import sys
+import yaml
+
+
+def get_nodes_from_args(args):
+    if args.discovery_url is not None:
+        return get_nodes_from_discovery_url(args.discovery_url)
+
+    return get_nodes_from_discovery_url(get_discovery_url_from_user_data())
+
+
+def get_nodes_from_discovery_url(discovery_url):
+    try:
+        nodes = []
+        json = requests.get(discovery_url).json()
+        discovery_nodes = json['node']['nodes']
+        for node in discovery_nodes:
+            value = node['value']
+            ip = re.search('([0-9]{1,3}\.){3}[0-9]{1,3}', value).group(0)
+            nodes.append(ip)
+        return nodes
+    except:
+        raise IOError('Could not load nodes from discovery url ' + discovery_url)
+
+
+def get_discovery_url_from_user_data():
+    name = 'linode-user-data.yaml'
+    log_info('Loading discovery url from ' + name)
+    try:
+        current_dir = os.path.dirname(__file__)
+        user_data_file = file(os.path.abspath(os.path.join(current_dir, name)), 'r')
+        user_data = yaml.safe_load(user_data_file)
+        return user_data['coreos']['etcd']['discovery']
+    except:
+        raise IOError('Could not load discovery url from ' + name)
+
+
+def validate_ip_address(ip):
+    return True if re.match('([0-9]{1,3}\.){3}[0-9]{1,3}', ip) else False
+
+
+def get_firewall_contents(node_ips, private=False):
+    rules_template_text = """*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [0:0]
+:DOCKER - [0:0]
+:Firewall-INPUT - [0:0]
+-A INPUT -j Firewall-INPUT
+-A FORWARD -j Firewall-INPUT
+-A Firewall-INPUT -i lo -j ACCEPT
+-A Firewall-INPUT -p icmp --icmp-type echo-reply -j ACCEPT
+-A Firewall-INPUT -p icmp --icmp-type destination-unreachable -j ACCEPT
+-A Firewall-INPUT -p icmp --icmp-type time-exceeded -j ACCEPT
+# Ping
+-A Firewall-INPUT -p icmp --icmp-type echo-request -j ACCEPT
+# Accept any established connections
+-A Firewall-INPUT -m conntrack --ctstate  ESTABLISHED,RELATED -j ACCEPT
+# Enable the traffic between the nodes of the cluster
+-A Firewall-INPUT -s $node_ips -j ACCEPT
+# Allow connections from docker container
+-A Firewall-INPUT -i docker0 -j ACCEPT
+# Accept ssh, http, https and git
+-A Firewall-INPUT -m conntrack --ctstate NEW -m multiport$multiport_private -p tcp --dports 22,2222,80,443 -j ACCEPT
+# Log and drop everything else
+-A Firewall-INPUT -j REJECT
+COMMIT
+"""
+
+    multiport_private = ' -s 192.168.0.0/16' if private else ''
+
+    rules_template = string.Template(rules_template_text)
+    return rules_template.substitute(node_ips=string.join(node_ips, ','), multiport_private=multiport_private)
+
+
+def apply_rules_to_all(host_ips, rules, private_key):
+    pkey = detect_and_create_private_key(private_key)
+
+    threads = []
+    for ip in host_ips:
+        t = Thread(target=apply_rules, args=(ip, rules, pkey))
+        t.setDaemon(False)
+        t.start()
+        threads.append(t)
+    for thread in threads:
+        thread.join()
+
+
+def detect_and_create_private_key(private_key):
+    private_key_text = private_key.read()
+    private_key.seek(0)
+    if '-----BEGIN RSA PRIVATE KEY-----' in private_key_text:
+        return paramiko.RSAKey.from_private_key(private_key)
+    elif '-----BEGIN DSA PRIVATE KEY-----' in private_key_text:
+        return paramiko.DSSKey.from_private_key(private_key)
+    else:
+        raise ValueError('Invalid private key file ' + private_key.name)
+
+
+def apply_rules(host_ip, rules, private_key):
+    # connect to the server via ssh
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.connect(host_ip, username='core', allow_agent=False, look_for_keys=False, pkey=private_key)
+
+    # copy the rules to the temp directory
+    temp_file = '/tmp/' + str(uuid.uuid4())
+
+    ssh.open_sftp()
+    sftp = ssh.open_sftp()
+    sftp.open(temp_file, 'w').write(rules)
+
+    # move the rules in to place and enable and run the iptables-restore.service
+    commands = [
+        'sudo mv ' + temp_file + ' /var/lib/iptables/rules-save',
+        'sudo chown root:root /var/lib/iptables/rules-save',
+        'sudo systemctl enable iptables-restore.service',
+        'sudo systemctl start iptables-restore.service'
+    ]
+
+    for command in commands:
+        stdin, stdout, stderr = ssh.exec_command(command)
+        stdout.channel.recv_exit_status()
+
+    ssh.close()
+
+    log_success('Applied rule to ' + host_ip)
+
+
+def main():
+    colorama.init()
+
+    parser = argparse.ArgumentParser(description='Apply a "Security Group" to a Deis cluster')
+    parser.add_argument('--private-key', required=True, type=file, dest='private_key', help='Cluster SSH Private Key')
+    parser.add_argument('--private', action='store_true', dest='private', help='Only allow access to the cluster from the private network')
+    parser.add_argument('--discovery-url', dest='discovery_url', help='Etcd discovery url')
+    parser.add_argument('--hosts', nargs='+', dest='hosts', help='The IP addresses of the hosts to apply rules to')
+    args = parser.parse_args()
+
+    nodes = get_nodes_from_args(args)
+    hosts = args.hosts if args.hosts is not None else nodes
+
+    node_ips = []
+    for ip in nodes:
+        if validate_ip_address(ip):
+            node_ips.append(ip)
+        else:
+            log_warning('Invalid IP will not be added to security group: ' + ip)
+
+    if not len(node_ips) > 0:
+        raise ValueError('No valid IP addresses in security group.')
+
+    host_ips = []
+    for ip in hosts:
+        if validate_ip_address(ip):
+            host_ips.append(ip)
+        else:
+            log_warning('Host has invalid IP address: ' + ip)
+
+    if not len(host_ips) > 0:
+        raise ValueError('No valid host addresses.')
+
+    log_info('Generating iptables rules...')
+    rules = get_firewall_contents(node_ips, args.private)
+    log_success('Generated rules:')
+    log_debug(rules)
+
+    log_info('Applying rules...')
+    apply_rules_to_all(host_ips, rules, args.private_key)
+    log_success('Done!')
+
+
+def log_debug(message):
+    print(Style.DIM + Fore.MAGENTA + message + Fore.RESET + Style.RESET_ALL)
+
+
+def log_info(message):
+    print(Fore.CYAN + message + Fore.RESET)
+
+
+def log_warning(message):
+    print(Fore.YELLOW + message + Fore.RESET)
+
+
+def log_success(message):
+    print(Style.BRIGHT + Fore.GREEN + message + Fore.RESET + Style.RESET_ALL)
+
+
+def log_error(message):
+    print(Style.BRIGHT + Fore.RED + message + Fore.RESET + Style.RESET_ALL)
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        log_error(e.message)
+        sys.exit(1)

--- a/contrib/linode/create-linode-user-data.py
+++ b/contrib/linode/create-linode-user-data.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+"""
+Create CoreOS user-data by merging contrib/coreos/user-data and contrib/linode/linode-user-data-template
+
+Usage: create-linode-user-data.py
+"""
+import base64
+import sys
+import os
+import collections
+import argparse
+
+import yaml
+import colorama
+from colorama import Fore, Style
+import requests
+
+
+def combine_dicts(orig_dict, new_dict):
+    for key, val in new_dict.iteritems():
+        if isinstance(val, collections.Mapping):
+            tmp = combine_dicts(orig_dict.get(key, {}), val)
+            orig_dict[key] = tmp
+        elif isinstance(val, list):
+            orig_dict[key] = (orig_dict.get(key, []) + val)
+        else:
+            orig_dict[key] = new_dict[key]
+    return orig_dict
+
+
+def get_file(name, mode="r", abspath=False):
+    current_dir = os.path.dirname(__file__)
+
+    if abspath:
+        return file(os.path.abspath(os.path.join(current_dir, name)), mode)
+    else:
+        return file(os.path.join(current_dir, name), mode)
+
+
+def main():
+    colorama.init()
+
+    parser = argparse.ArgumentParser(description='Create Linode User Data')
+    parser.add_argument('--public-key', action='append', required=True, type=file, dest='public_key_files', help='Authorized SSH Keys')
+    parser.add_argument('--etcd-token', required=False, default=None, dest='etcd_token', help='Etcd Token')
+    args = parser.parse_args()
+
+    etcd_token = args.etcd_token
+    if etcd_token is None:
+        etcd_token = generate_etcd_token()
+    else:
+        if not validate_etcd_token(args.etcd_token):
+            raise ValueError('Invalid Etcd Token. You can generate a new token at https://discovery.etcd.io/new.')
+
+    public_keys = []
+    for public_key_file in args.public_key_files:
+        public_key = public_key_file.read()
+        if validate_public_key(public_key):
+            public_keys.append(public_key)
+        else:
+            log_warning('Invalid public key: ' + public_key_file.name)
+
+    if not len(public_keys) > 0:
+        raise ValueError('Must supply at least one valid public key')
+
+    linode_user_data = get_file("linode-user-data.yaml", "w", True)
+    linode_template = get_file("linode-user-data-template.yaml")
+    coreos_template = get_file("../coreos/user-data.example")
+
+    configuration_linode_template = yaml.safe_load(linode_template)
+    configuration_coreos_template = yaml.safe_load(coreos_template)
+
+    configuration = combine_dicts(configuration_coreos_template, configuration_linode_template)
+    configuration['coreos']['etcd']['discovery'] = 'https://discovery.etcd.io/' + str(etcd_token)
+    configuration['ssh_authorized_keys'] = public_keys
+
+    with linode_user_data as outfile:
+        outfile.write("#cloud-config\n\n" + yaml.safe_dump(configuration, default_flow_style=False, default_style='|'))
+        log_success('Wrote Linode user data to ' + linode_user_data.name)
+
+
+def validate_public_key(key):
+    try:
+        type, key_string, comment = key.split()
+        data = base64.decodestring(key_string)
+        return data[4:11] == type
+    except:
+        return False
+
+
+def generate_etcd_token():
+    log_info('Generating new Etcd token...')
+    data = requests.get('https://discovery.etcd.io/new').text
+    token = data.replace('https://discovery.etcd.io/', '')
+    log_success('Generated new token: ' + token)
+    return token
+
+
+def validate_etcd_token(token):
+    try:
+        int(token, 16)
+        return True
+    except:
+        return False
+
+
+def log_info(message):
+    print(Fore.CYAN + message + Fore.RESET)
+
+
+def log_warning(message):
+    print(Fore.YELLOW + message + Fore.RESET)
+
+
+def log_success(message):
+    print(Style.BRIGHT + Fore.GREEN + message + Fore.RESET + Style.RESET_ALL)
+
+
+def log_error(message):
+    print(Style.BRIGHT + Fore.RED + message + Fore.RESET + Style.RESET_ALL)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        log_error(e.message)
+        sys.exit(1)

--- a/contrib/linode/linode-user-data-template.yaml
+++ b/contrib/linode/linode-user-data-template.yaml
@@ -1,0 +1,46 @@
+#cloud-config
+hostname: $hostname
+coreos:
+  fleet:
+    metadata: name=%H
+  units:
+  - name: 00-eth0.network
+    runtime: false
+    content: |
+      [Match]
+      Name=eth0
+
+      [Network]
+      Address=$public_ipv4/24
+      Address=$private_ipv4/17
+      Gateway=$gateway.1
+      DNS=72.14.179.5
+      DNS=8.8.8.8
+      DNS=208.67.222.222
+  - name: disable-ipv6.service
+    command: start
+    content: |
+      [Unit]
+      Description=Disable IPv6. The notion of a security group does not exist on Linode. To make firewalling each Linode easier, disable IPv6.
+      Before=network.target
+
+      [Service]
+      Type=oneshot
+      ExecStart=/bin/sh -c "sysctl -w net.ipv6.conf.all.disable_ipv6=1"
+    # use ntpd rather than timesyncd. timesyncd was not keeping the nodes close enough to keep ceph happy
+  - name: systemd-timesyncd.service
+    command: stop
+    mask: true
+  - name: ntpd.service
+    command: start
+    enable: true
+write_files:
+  - path: /etc/environment
+    content: |
+      COREOS_PUBLIC_IPV4=$public_ipv4
+      COREOS_PRIVATE_IPV4=$private_ipv4
+  - path: /etc/systemd/system/ntpd.service.d/debug.conf
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=/usr/sbin/ntpd -g -n -f /var/lib/ntp/ntp.drift

--- a/contrib/linode/provision-linode-cluster.py
+++ b/contrib/linode/provision-linode-cluster.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python
+"""
+Provision a Deis cluster on Linode
+
+Usage: provision-linode-cluster.py
+"""
+import argparse
+import random
+import string
+import threading
+from threading import Thread
+import sys
+
+import paramiko
+import requests
+import colorama
+from colorama import Fore, Style
+
+
+class LinodeApiCommand:
+    def __init__(self, arguments):
+        self._arguments = vars(arguments)
+        self._linode_api_key = arguments.linode_api_key
+
+    def __getattr__(self, name):
+        return self._arguments.get(name)
+
+    def request(self, action, **kwargs):
+        kwargs['params'] = dict({'api_key': self._linode_api_key, 'api_action': action}.items() + kwargs.get('params', {}).items())
+        response = requests.request('get', 'https://api.linode.com/api/', **kwargs)
+
+        json = response.json()
+        errors = json.get('ERRORARRAY', [])
+        data = json.get('DATA')
+
+        if len(errors) > 0:
+            raise IOError(str(errors))
+
+        return data
+
+    def run(self):
+        raise NotImplementedError
+
+    def info(self, message):
+        print(Fore.MAGENTA + threading.current_thread().name + ': ' + Fore.CYAN + message + Fore.RESET)
+
+    def success(self, message):
+        print(Fore.MAGENTA + threading.current_thread().name + ': ' + Fore.GREEN + message + Fore.RESET)
+
+
+class ProvisionCommand(LinodeApiCommand):
+    _created_linodes = []
+
+    def run(self):
+        # validate arguments
+        self._check_num_nodes()
+        self._check_plan_size()
+
+        # create the linodes
+        self._create_linodes()
+
+        # print the results
+        self._report_created()
+
+    def _report_created(self):
+        # set up the report data
+        rows = []
+        ips = []
+        data_center = self._get_data_center().get('ABBR')
+        plan = self._get_plan().get('RAM')
+
+        for linode in self._created_linodes:
+            rows.append((
+                linode['hostname'],
+                linode['public'],
+                linode['private'],
+                linode['gateway'],
+                data_center,
+                plan
+            ))
+            ips.append(linode['public'])
+
+        firewall_command = './apply-firewall.py --private-key /path/to/key/deis --hosts ' + string.join(ips, ' ')
+
+        # set up the report constants
+        divider = Style.BRIGHT + Fore.MAGENTA + ('=' * 109) + Fore.RESET + Style.RESET_ALL
+        column_format = "  {:<20} {:<20} {:<20} {:<20} {:<12} {:>8}"
+        formatted_header = column_format.format(*('HOSTNAME', 'PUBLIC IP', 'PRIVATE IP', 'GATEWAY', 'DC', 'PLAN'))
+
+        # display the report
+        print('')
+        print(divider)
+        print(divider)
+        print('')
+        print(Style.BRIGHT + Fore.LIGHTGREEN_EX + '  Successfully provisioned ' + str(self.num_nodes) + ' nodes!' + Fore.RESET + Style.RESET_ALL)
+        print('')
+        print(Style.BRIGHT + Fore.CYAN + formatted_header + Fore.RESET + Style.RESET_ALL)
+        for row in rows:
+            print(Fore.CYAN + column_format.format(*row) + Fore.RESET)
+        print('')
+        print('')
+        print(Fore.LIGHTYELLOW_EX + '  Finish up your installation by securing your cluster with the following command:' + Fore.RESET)
+        print('')
+        print('  ' + firewall_command)
+        print('')
+        print(divider)
+        print(divider)
+        print('')
+
+    def _get_plan(self):
+        if self._plan is None:
+            plans = self.request('avail.linodeplans', params={'PlanID': self.node_plan})
+            if len(plans) != 1:
+                raise ValueError('The --plan specified is invalid. Use the `list-plans` subcommand to see valid ids.')
+            self._plan = plans[0]
+        return self._plan
+
+    def _get_plan_id(self):
+        return self._get_plan().get('PLANID')
+
+    def _get_data_center(self):
+        if self._data_center is None:
+            data_centers = self.request('avail.datacenters')
+            for data_center in data_centers:
+                if data_center.get('DATACENTERID') == self.node_data_center:
+                    self._data_center = data_center
+            if self._data_center is None:
+                raise ValueError('The --datacenter specified is invalid. Use the `list-data-centers` subcommand to see valid ids.')
+        return self._data_center
+
+    def _get_data_center_id(self):
+        return self._get_data_center().get('DATACENTERID')
+
+    def _check_plan_size(self):
+        ram = self._get_plan().get('RAM')
+        if ram < 4096:
+            raise ValueError('Deis cluster members must have at least 4GB of memory. Please choose a plan with more memory.')
+
+    def _check_num_nodes(self):
+        if self.num_nodes < 1:
+            raise ValueError('Must provision at least one node.')
+        elif self.num_nodes < 3:
+            print(Fore.YELLOW + 'A Deis cluster must have 3 or more nodes, only continue if you adding to a current cluster.' + Fore.RESET)
+            print(Fore.YELLOW + 'Continue? (y/n)' + Fore.RESET)
+            accept = None
+            while True:
+                if accept == 'y':
+                    return
+                elif accept == 'n':
+                    raise StandardError('User canceled provisioning')
+                else:
+                    accept = self._get_user_input('--> ').strip().lower()
+
+    def _get_user_input(self, prompt):
+        if sys.version_info[0] < 3:
+            return raw_input(prompt)
+        else:
+            return input(prompt)
+
+    def _create_linodes(self):
+        threads = []
+        for i in range(0, self.num_nodes):
+            t = Thread(target=self._create_linode,
+                       args=(self._get_plan_id(), self._get_data_center_id(), self.node_name_prefix, self.node_display_group))
+            t.setDaemon(False)
+            t.start()
+
+            threads.append(t)
+
+        for thread in threads:
+            thread.join()
+
+    def _create_linode(self, plan_id, data_center_id, name_prefix, display_group):
+        self.info('Creating the Linode...')
+
+        # create the linode
+        node_id = self.request('linode.create', params={
+            'DatacenterID': data_center_id,
+            'PlanID': plan_id
+        }).get('LinodeID')
+
+        # update the configuration
+        self.request('linode.update', params={
+            'LinodeID': node_id,
+            'Label': name_prefix + str(node_id),
+            'lpm_displayGroup': display_group,
+            'Alert_cpu_enabled': False,
+            'Alert_diskio_enabled': False,
+            'Alert_bwin_enabled': False,
+            'Alert_bwout_enabled': False,
+            'Alert_bwquota_enabled': False
+        })
+
+        self.success('Linode ' + str(node_id) + ' created!')
+        hostname = name_prefix + str(node_id)
+        threading.current_thread().name = hostname
+
+        # configure the networking
+        network = self._configure_networking(node_id)
+        network['hostname'] = hostname
+
+        # generate a password for the provisioning disk
+        password = ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(24))
+
+        # configure the disks
+        total_hd = self.request('linode.list', params={'LinodeID': node_id})[0]['TOTALHD']
+        provision_disk_mb = 600
+        coreos_disk_mb = total_hd - provision_disk_mb
+        provision_disk_id = self._create_provisioning_disk(node_id, provision_disk_mb, password)
+        coreos_disk_id = self._create_coreos_disk(node_id, coreos_disk_mb)
+
+        # create the provision config
+        provision_config_id = self._create_provision_profile(node_id, provision_disk_id, coreos_disk_id)
+
+        # create the CoreOS config
+        coreos_config_id = self._create_coreos_profile(node_id, coreos_disk_id)
+
+        # install CoreOS
+        self._install_coreos(node_id, provision_config_id, network, password)
+
+        # boot in to coreos
+        self.info('Booting into CoreOS configuration profile...')
+        self.request('linode.reboot', params={'LinodeID': node_id, 'ConfigID': coreos_config_id})
+
+        # append the linode to the created list
+        self._created_linodes.append(network)
+
+    def _configure_networking(self, node_id):
+        self.info('Configuring network...')
+
+        # add the private network
+        self.request('linode.ip.addprivate', params={'LinodeID': node_id})
+
+        # pull the network config
+        ip_data = self.request('linode.ip.list', params={'LinodeID': node_id})
+
+        network = {'public': None, 'private': None, 'gateway': None}
+
+        for ip in ip_data:
+            if ip.get('ISPUBLIC') == 1:
+                network['public'] = ip.get('IPADDRESS')
+                # the gateway is the public ip with the last octet set to 1
+                split_ip = str(network['public']).split('.')
+                split_ip[3] = '1'
+                network['gateway'] = string.join(split_ip, '.')
+            else:
+                network['private'] = ip.get('IPADDRESS')
+
+        if network.get('public') is None:
+            raise RuntimeError('Public IP address could not be found.')
+
+        if network.get('private') is None:
+            raise RuntimeError('Private IP address could not be found.')
+
+        self.success('Network configured!')
+        self.success('    Public IP:  ' + str(network['public']))
+        self.success('    Private IP: ' + str(network['private']))
+        self.success('    Gateway:    ' + str(network['gateway']))
+
+        return network
+
+    def _create_provisioning_disk(self, node_id, size, root_password):
+        self.info('Creating provisioning disk...')
+
+        disk_id = self.request('linode.disk.createfromdistribution', params={
+            'LinodeID': node_id,
+            'Label': 'Provision',
+            'DistributionID': 130,
+            'Type': 'ext4',
+            'Size': size,
+            'rootPass': root_password
+        }).get('DiskID')
+
+        self.success('Created provisioning disk!')
+
+        return disk_id
+
+    def _create_coreos_disk(self, node_id, size):
+        self.info('Creating CoreOS disk...')
+
+        disk_id = self.request('linode.disk.create', params={
+            'LinodeID': node_id,
+            'Label': 'CoreOS',
+            'Type': 'ext4',
+            'Size': size
+        }).get('DiskID')
+
+        self.success('Created CoreOS disk!')
+
+        return disk_id
+
+    def _create_provision_profile(self, node_id, provision_disk_id, coreos_disk_id):
+        self.info('Creating Provision configuration profile...')
+
+        # create a disk the total hd size
+        config_id = self.request('linode.config.create', params={
+            'LinodeID': node_id,
+            'KernelID': 138,
+            'Label': 'Provision',
+            'DiskList': str(provision_disk_id) + ',' + str(coreos_disk_id)
+        }).get('ConfigID')
+
+        self.success('Provision profile created!')
+
+        return config_id
+
+    def _create_coreos_profile(self, node_id, coreos_disk_id):
+        self.info('Creating CoreOS configuration profile...')
+
+        # create a disk the total hd size
+        config_id = self.request('linode.config.create', params={
+            'LinodeID': node_id,
+            'KernelID': 213,
+            'Label': 'CoreOS',
+            'DiskList': str(coreos_disk_id)
+        }).get('ConfigID')
+
+        self.success('CoreOS profile created!')
+
+        return config_id
+
+    def _get_cloud_config(self):
+        if self.cloud_config_text is None:
+            self.cloud_config_text = self.cloud_config.read()
+        return self.cloud_config_text
+
+    def _install_coreos(self, node_id, provision_config_id, network, password):
+        self.info('Installing CoreOS...')
+
+        # boot in to the provision configuration
+        self.info('Booting into Provision configuration profile...')
+        self.request('linode.boot', params={'LinodeID': node_id, 'ConfigID': provision_config_id})
+
+        # connect to the server via ssh
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+        while True:
+            try:
+                ssh.connect(str(network['public']), username='root', password=password, allow_agent=False, look_for_keys=False)
+                break
+            except:
+                continue
+
+        # copy the cloud config
+        self.info('Pushing cloud config...')
+        cloud_config_template = string.Template(self._get_cloud_config())
+        cloud_config = cloud_config_template.safe_substitute(public_ipv4=network['public'], private_ipv4=network['private'], gateway=network['gateway'],
+                                                             hostname=network['hostname'])
+
+        sftp = ssh.open_sftp()
+        sftp.open('cloud-config.yaml', 'w').write(cloud_config)
+
+        self.info('Installing...')
+
+        commands = [
+            'wget https://raw.githubusercontent.com/coreos/init/master/bin/coreos-install -O $HOME/coreos-install',
+            'chmod +x $HOME/coreos-install',
+            '$HOME/coreos-install -d /dev/sdb -C ' + self.coreos_channel + ' -V ' + self.coreos_version + ' -c $HOME/cloud-config.yaml -t /dev/shm'
+        ]
+
+        for command in commands:
+            stdin, stdout, stderr = ssh.exec_command(command)
+            stdout.channel.recv_exit_status()
+            print stdout.read()
+
+        ssh.close()
+
+
+class ListDataCentersCommand(LinodeApiCommand):
+    def run(self):
+        data = self.request('avail.datacenters')
+        column_format = "{:<4} {:}"
+        print(Style.BRIGHT + Fore.GREEN + column_format.format(*('ID', 'LOCATION')) + Fore.RESET + Style.RESET_ALL)
+        for data_center in data:
+            row = (
+                data_center.get('DATACENTERID'),
+                data_center.get('LOCATION')
+            )
+            print(Fore.GREEN + column_format.format(*row) + Fore.RESET)
+
+
+class ListPlansCommand(LinodeApiCommand):
+    def run(self):
+        data = self.request('avail.linodeplans')
+        column_format = "{:<4} {:<16} {:<8} {:<12} {:}"
+        print(Style.BRIGHT + Fore.GREEN + column_format.format(
+            *('ID', 'LABEL', 'CORES', 'RAM', 'PRICE')) + Fore.RESET + Style.RESET_ALL)
+        for plan in data:
+            row = (
+                plan.get('PLANID'),
+                plan.get('LABEL'),
+                plan.get('CORES'),
+                str(plan.get('RAM')) + 'MB',
+                '$' + str(plan.get('PRICE'))
+            )
+            print(Fore.GREEN + column_format.format(*row) + Fore.RESET)
+
+
+if __name__ == '__main__':
+    colorama.init()
+
+    parser = argparse.ArgumentParser(description='Provision Linode Deis Cluster')
+    parser.add_argument('--api-key', required=True, dest='linode_api_key', help='Linode API Key')
+    subparsers = parser.add_subparsers()
+
+    provision_parser = subparsers.add_parser('provision', help="Provision the Deis cluster")
+    provision_parser.add_argument('--num', required=False, default=3, type=int, dest='num_nodes', help='Number of nodes to provision')
+    provision_parser.add_argument('--name-prefix', required=False, default='deis', dest='node_name_prefix', help='Node name prefix')
+    provision_parser.add_argument('--display-group', required=False, default='deis', dest='node_display_group', help='Node display group')
+    provision_parser.add_argument('--plan', required=False, default=4, type=int, dest='node_plan', help='Node plan id. Use list-plans to find the id.')
+    provision_parser.add_argument('--datacenter', required=False, default=2, type=int, dest='node_data_center',
+                                  help='Node data center id. Use list-data-centers to find the id.')
+    provision_parser.add_argument('--cloud-config', required=False, default='linode-user-data.yaml', type=file, dest='cloud_config',
+                                  help='CoreOS cloud config user-data file')
+    provision_parser.add_argument('--coreos-version', required=False, default='695.2.0', dest='coreos_version',
+                                  help='CoreOS version number to install')
+    provision_parser.add_argument('--coreos-channel', required=False, default='beta', dest='coreos_channel',
+                                  help='CoreOS channel to install from')
+    provision_parser.set_defaults(cmd=ProvisionCommand)
+
+    list_data_centers_parser = subparsers.add_parser('list-data-centers', help="Lists the available Linode data centers.")
+    list_data_centers_parser.set_defaults(cmd=ListDataCentersCommand)
+
+    list_plans_parser = subparsers.add_parser('list-plans', help="Lists the available Linode plans.")
+    list_plans_parser.set_defaults(cmd=ListPlansCommand)
+
+    args = parser.parse_args()
+    cmd = args.cmd(args)
+
+    try:
+        cmd.run()
+    except Exception as e:
+        print(Style.BRIGHT + Fore.RED + e.message + Fore.RESET + Style.RESET_ALL)
+        sys.exit(1)

--- a/contrib/linode/requirements.txt
+++ b/contrib/linode/requirements.txt
@@ -1,0 +1,4 @@
+colorama==0.3.3
+requests==2.7.0
+paramiko==1.15.2
+pyyaml==3.11

--- a/docs/installing_deis/index.rst
+++ b/docs/installing_deis/index.rst
@@ -25,6 +25,7 @@ information on how to get set up with CoreOS.
     azure
     digitalocean
     gce
+    linode
     rackspace
     vagrant
     baremetal

--- a/docs/installing_deis/linode.rst
+++ b/docs/installing_deis/linode.rst
@@ -1,0 +1,218 @@
+:title: Installing Deis on Linode
+:description: How to provision a multi-node Deis cluster on Linode
+
+.. _deis_on_linode:
+
+Linode
+======
+
+In this tutorial, we will show you how to set up your own 3-node cluster on Linode.
+
+Please :ref:`get the source <get_the_source>` and refer to the scripts in `contrib/linode`_
+while following this documentation.
+
+.. important::
+
+    Linode support is untested by the Deis team, so we rely on the community to
+    improve this documentation and fix bugs. We greatly appreciate the help!
+
+
+Prerequisites
+-------------
+
+Before we can begin to provision a cluster on Linode, let's get a few things squared away.
+
+
+Enable KVM Hypervisor
+^^^^^^^^^^^^^^^^^^^^^
+
+Navigate to the `Linode Account Settings`_ page and change the Hypervisor Preference to ``KVM``.
+
+Although it is possible to provision CoreOS under Xen on Linode it is much more difficult and
+the tools included only work with the KVM Hypervisor.
+
+
+Obtain Linode API Key
+^^^^^^^^^^^^^^^^^^^^^
+
+Next, navigate to the `Linode API Keys`_ page and generate an API key. Take note of the key,
+as you will need it later when you provision your cluster.
+
+
+Install Python and Dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The scripts used to provision the cluster are written for Python 2.7 and require a few
+dependencies be installed with the `pip`_ package manager. If you are on OS X or Linux you
+likely have these already available.
+
+Lets install our dependencies:
+
+.. code-block:: console
+
+    $ pip install -r contrib/linode/requirements.txt
+
+
+Generate SSH Key
+^^^^^^^^^^^^^^^^
+
+If you don't already have a SSH key, the following command will generate
+a new keypair named "deis":
+
+.. code-block:: console
+
+    $ ssh-keygen -q -t rsa -f ~/.ssh/deis -N '' -C deis
+
+
+Check System Requirements
+-------------------------
+
+Please refer to :ref:`system-requirements` for resource considerations when choosing a Linode
+plan to run Deis. A Deis cluster must have 3 or more nodes. See :ref:`cluster-size` for more details.
+
+
+Create Cloud Init
+-----------------
+
+Create your cloud init file using Deis' ``contrib/linode/create-linode-user-data.py`` script.
+
+First navigate to the ``contrib/linode`` directory:
+
+.. code-block:: console
+
+    $ cd contrib/linode
+
+Then, create the ``linode-user-data.yaml`` file:
+
+.. code-block:: console
+
+    $ ./create-linode-user-data.py --public-key /path/to/key/deis.pub
+
+It is possible to specify multiple authorized keys and/or specify an etcd token to use for the cluster.
+See the full command usage below:
+
+.. code-block:: console
+
+    usage: create-linode-user-data.py [-h] --public-key PUBLIC_KEY_FILES
+                                  [--etcd-token ETCD_TOKEN]
+
+    Create Linode User Data
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --public-key PUBLIC_KEY_FILES
+                            Authorized SSH Keys
+      --etcd-token ETCD_TOKEN
+                            Etcd Token
+
+Provision Cluster
+-----------------
+
+The time has finally come to provision our cluster and all it takes is a single command!
+
+.. code-block:: console
+
+    $ ./provision-linode-cluster.py --api-key=YOUR_LINODE_API_KEY provision
+
+This command will create a 3 node cluster of Linode 4096s in Dallas TX, however by passing additional
+arguments you can specify the data center, size of nodes, number of nodes, and a bunch more:
+
+.. code-block:: console
+
+    usage: provision-linode-cluster.py provision [-h] [--num NUM_NODES]
+                                                 [--name-prefix NODE_NAME_PREFIX]
+                                                 [--display-group NODE_DISPLAY_GROUP]
+                                                 [--plan NODE_PLAN]
+                                                 [--datacenter NODE_DATA_CENTER]
+                                                 [--cloud-config CLOUD_CONFIG]
+                                                 [--coreos-version COREOS_VERSION]
+                                                 [--coreos-channel COREOS_CHANNEL]
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --num NUM_NODES       Number of nodes to provision
+      --name-prefix NODE_NAME_PREFIX
+                            Node name prefix
+      --display-group NODE_DISPLAY_GROUP
+                            Node display group
+      --plan NODE_PLAN      Node plan id. Use list-plans to find the id.
+      --datacenter NODE_DATA_CENTER
+                            Node data center id. Use list-data-centers to find the
+                            id.
+      --cloud-config CLOUD_CONFIG
+                            CoreOS cloud config user-data file
+      --coreos-version COREOS_VERSION
+                            CoreOS version number to install
+      --coreos-channel COREOS_CHANNEL
+                            CoreOS channel to install from
+
+
+Additionally, the provision tool contains two utilities to list available data centers and plans that
+can help find the command argument values.
+
+.. code-block:: console
+
+    $ ./provision-linode-cluster.py --api-key=YOUR_LINODE_API_KEY list-data-centers
+
+.. code-block:: console
+
+    $ ./provision-linode-cluster.py --api-key=YOUR_LINODE_API_KEY list-plans
+
+
+Apply Security Group Settings
+-----------------------------
+
+Because Linode does not have a security group feature, we'll need to add some custom
+``iptables`` rules so our components are not accessible to the outside world.
+
+
+If you are on the Linode private network, run:
+
+.. code-block:: console
+
+    $ ./apply-firewall.py --private-key /path/to/key/deis
+
+
+If you are outside the private network, you will have to manually specify the public ip address of
+each host. To do so, run:
+
+.. code-block:: console
+
+    $ ./apply-firewall.py --private-key /path/to/key/deis --hosts 1.2.3.4 11.22.33.44 111.222.33.44
+
+
+The script will use the etcd discovery url in the generated ``linode-user-data.yaml`` file or the value of the
+discovery-url argument, if provided, to find all of the nodes in your cluster and create iptables rules to allow
+connections between nodes while blocking outside connections automatically. Full command usage:
+
+.. code-block:: console
+
+    usage: apply-firewall.py [-h] --private-key PRIVATE_KEY [--private]
+                             [--discovery-url DISCOVERY_URL]
+                             [--hosts HOSTS [HOSTS ...]]
+
+    Apply a "Security Group" to a Deis cluster
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --private-key PRIVATE_KEY
+                            Cluster SSH Private Key
+      --private             Only allow access to the cluster from the private
+                            network
+      --discovery-url DISCOVERY_URL
+                            Etcd discovery url
+      --hosts HOSTS [HOSTS ...]
+                            The IP addresses of the hosts to apply rules to
+
+
+Install Deis Platform
+---------------------
+
+Now that you've finished provisioning a cluster, please refer to :ref:`install_deis_platform` to
+start installing the platform.
+
+
+.. _`contrib/linode`: https://github.com/deis/deis/tree/master/contrib/linode
+.. _`Linode Account Settings`: https://manager.linode.com/account/settings
+.. _`Linode API Keys`: https://manager.linode.com/profile/api
+.. _`pip`: https://pip.pypa.io/en/stable/

--- a/docs/installing_deis/quick-start.rst
+++ b/docs/installing_deis/quick-start.rst
@@ -48,6 +48,7 @@ Choose one of the following providers and deploy a new cluster:
 - :ref:`deis_on_digitalocean`
 - :ref:`deis_on_gce`
 - :ref:`deis_on_azure`
+- :ref:`deis_on_linode`
 - :ref:`deis_on_openstack`
 - :ref:`deis_on_rackspace`
 - :ref:`deis_on_vagrant`


### PR DESCRIPTION
Linode's recent switch to KVM gave me an added push to rewrite our team's provisioning tools to work with the new hypervisor as it makes running CoreOS much simpler. This time, I did so with the intention of fully documenting the process for the community and our team at Myriad Mobile as well as make our tools publicly available. So here's a stab at that!