### PR TITLE
fix(deisctl): Fix panic when deisctl is called with no arguments

### DIFF
--- a/deisctl/deisctl.go
+++ b/deisctl/deisctl.go
@@ -64,7 +64,7 @@ Options:
 		if helpFlag {
 			fmt.Print(usage)
 			return 0
-		} else if argv[0] == "--version" {
+		} else if len(argv) == 0 || argv[0] == "--version" {
 			return 0
 		}
 		return 1


### PR DESCRIPTION
Note, `deisctl` now returns `0` when called with no arguments rather than `1` as it previously had. 