### PR TITLE
ref(deisctl): remove redundant usage print

### DIFF
--- a/deisctl/deisctl.go
+++ b/deisctl/deisctl.go
@@ -61,10 +61,7 @@ Options:
 	// give docopt an optional final false arg so it doesn't call os.Exit()
 	args, err := docopt.Parse(usage, argv, false, version.Version, true, false)
 	if err != nil || len(args) == 0 {
-		if helpFlag {
-			fmt.Print(usage)
-			return 0
-		} else if argv[0] == "--version" {
+		if argv[0] == "--version" {
 			return 0
 		}
 		return 1


### PR DESCRIPTION
The command switch already looks for a help command, so this code was unnecessary.