### PR TITLE
ref(deisctl): clean up some parsing and error behavior

### DIFF
--- a/deisctl/deisctl.go
+++ b/deisctl/deisctl.go
@@ -60,15 +60,16 @@ Options:
 	argv, helpFlag := parseArgs(argv)
 	// give docopt an optional final false arg so it doesn't call os.Exit()
 	args, err := docopt.Parse(usage, argv, false, version.Version, true, false)
-	if err != nil || len(args) == 0 {
-		if helpFlag {
-			fmt.Print(usage)
-			return 0
-		} else if argv[0] == "--version" {
-			return 0
-		}
+
+	if err != nil && err.Error() != "" {
+		fmt.Println(err)
 		return 1
 	}
+
+	if len(args) == 0 {
+		return 0
+	}
+
 	command := args["<command>"]
 	setTunnel := true
 	// "--help" and "refresh-units" doesn't need SSH tunneling

--- a/deisctl/deisctl_test.go
+++ b/deisctl/deisctl_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -47,8 +48,9 @@ func TestHelp(t *testing.T) {
 // TestUsage ensures that deisctl prints a short usage string when no arguments were provided.
 func TestUsage(t *testing.T) {
 	out := commandOutput(nil)
-	if out != "Usage: deisctl [options] <command> [<args>...]\n" {
-		t.Error(out)
+	expected := "Usage: deisctl [options] <command> [<args>...]\n"
+	if out != expected {
+		t.Error(fmt.Errorf("Expected '%s', Got '%s'", expected, out))
 	}
 }
 


### PR DESCRIPTION
Note: `./deisctl` will trigger a docopt error because it wasn't given any command line arguments. However, this error is empty, so go just prints an empty line. I think it looks better, but it is a slight change in behavior.  The advantage is that if docopt has an actual error, instead of throwing it away like we currently do we print it.

Before:

``` shell
$ deisctl
Usage: deisctl [options] <command> [<args>...]
$
```

After:

``` shell
$ deisctl
Usage: deisctl [options] <command> [<args>...]

$
```