### PR TITLE
feat(router): enable OCSP stapling by default

### DIFF
--- a/router/boot.go
+++ b/router/boot.go
@@ -60,6 +60,7 @@ func main() {
 	mkdirEtcd(client, "/deis/certs")
 	mkdirEtcd(client, "/deis/router/hosts")
 	mkdirEtcd(client, "/deis/router/hsts")
+	mkdirEtcd(client, "/deis/router/ocsp")
 
 	setDefaultEtcd(client, etcdPath+"/gzip", "on")
 

--- a/router/image/templates/deis.conf
+++ b/router/image/templates/deis.conf
@@ -14,4 +14,9 @@ ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 ssl_ciphers '{{ getv "/deis/router/sslCiphers" }}';
 ssl_prefer_server_ciphers on;
 {{ end }}
+ssl_stapling {{ or (getv "/deis/router/ocsp/stapling") "on" }};
+ssl_stapling_verify {{ or (getv "/deis/router/ocsp/verify") "off" }};
+{{ if exists "/deis/router/ocsp/responder" }}
+ssl_stapling_responder {{ getv "/deis/router/ocsp/responder" }};
+{{ end }}
 {{ end }}

--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -39,6 +39,10 @@ http {
     gzip_vary {{ or (getv "/deis/router/gzipVary") "on" }};
     {{ end }}
 
+    # DNS servers to query for address resolution. Needed to resolve OCSP responder.
+    resolver 8.8.8.8 8.8.4.4 valid=300s;
+    resolver_timeout 5s;
+
     {{ $useFirewall := or (getv "/deis/router/firewall/enabled") "false" }}{{ if eq $useFirewall "true" }}# include naxsi rules
     include     /opt/nginx/firewall/naxsi_core.rules;
     include     /opt/nginx/firewall/web_apps.rules;

--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -202,6 +202,11 @@ http {
         ssl_ciphers '{{ getv "/deis/router/sslCiphers" }}';
         ssl_prefer_server_ciphers on;
         {{ end }}
+        ssl_stapling {{ or (getv "/deis/router/ocsp/stapling") "on" }};
+        ssl_stapling_verify {{ or (getv "/deis/router/ocsp/verify") "off" }};
+        {{ if exists "/deis/router/ocsp/responder" }}
+        ssl_stapling_responder {{ getv "/deis/router/ocsp/responder" }};
+        {{ end }}
         {{/* if there's no app SSL cert but we have a router SSL cert, enable that instead */}}
         {{/* TODO (bacongobbler): wait for https://github.com/kelseyhightower/confd/issues/270 */}}
         {{/* so we can apply this config to just subdomains of the platform domain. */}}


### PR DESCRIPTION
This allows nginx to cache the [OCSP] response from the Certificate Authority
and return a signed copy of it to the User Agent. This reduces the
number of roundtrips necessary to verify the certificate and therefore
results in both a performance improvement and reduced load on the OCSP
server.

If an invalid response is stapled and sent to the client it is ignored
so disabling verification by default does no harm.

This currently requires `/deis/router/ocsp/responder` to be manually set to the
IP Address of the certificate's OCSP server. This will not be necessary if
a dns resolver is configured so nginx can look up the domain name specified
by the certificate.

[OCSP]: https://tools.ietf.org/html/rfc2560