### PR TITLE
ref(deisctl): fix error to string conversion in tests

### DIFF
--- a/deisctl/backend/fleet/fleet_test.go
+++ b/deisctl/backend/fleet/fleet_test.go
@@ -116,7 +116,7 @@ func logState(outchan chan string, errchan chan error, errOutput *string, mutex 
 			}
 			if err != nil {
 				mutex.Lock()
-				*errOutput += fmt.Sprintf("%v\n", err)
+				*errOutput += err.Error()
 				mutex.Unlock()
 			}
 		}

--- a/deisctl/backend/fleet/scale_test.go
+++ b/deisctl/backend/fleet/scale_test.go
@@ -147,7 +147,7 @@ func TestScaleError(t *testing.T) {
 	close(errchan)
 	close(outchan)
 
-	expected := "cannot scale below 0\n"
+	expected := "cannot scale below 0"
 
 	logMutex.Lock()
 	if errOutput != expected {

--- a/deisctl/backend/fleet/ssh_test.go
+++ b/deisctl/backend/fleet/ssh_test.go
@@ -69,7 +69,7 @@ func TestFindUnit(t *testing.T) {
 
 	_, err := c.findUnit("foo")
 
-	actualErr := fmt.Sprintf("%v", err)
+	actualErr := err.Error()
 
 	if actualErr != expectedErr {
 		t.Error(fmt.Errorf("Expected '%s', Got '%s'", expectedErr, actualErr))
@@ -79,7 +79,7 @@ func TestFindUnit(t *testing.T) {
 
 	_, err = c.findUnit("deis-router@2.service")
 
-	actualErr = fmt.Sprintf("%v", err)
+	actualErr = err.Error()
 
 	if actualErr != expectedErr {
 		t.Error(fmt.Errorf("Expected '%s', Got '%s'", expectedErr, actualErr))

--- a/deisctl/backend/fleet/status_test.go
+++ b/deisctl/backend/fleet/status_test.go
@@ -81,7 +81,7 @@ func TestStatus(t *testing.T) {
 	c.runner = mockStatusCommandRunner{validUnits: []string{}}
 	err = c.Status("foo")
 
-	actualErr := fmt.Sprintf("%v", err)
+	actualErr := err.Error()
 	expectedErr := "could not find unit: foo"
 
 	if actualErr != expectedErr {

--- a/deisctl/backend/fleet/unit_test.go
+++ b/deisctl/backend/fleet/unit_test.go
@@ -154,7 +154,7 @@ func TestReadTemplateError(t *testing.T) {
 
 	_, err = readTemplate("foo", []string{name})
 	expected := "Could not find unit template for foo"
-	errorf := fmt.Sprintf("%v", err)
+	errorf := err.Error()
 
 	if errorf != expected {
 		t.Error(fmt.Errorf("Expected %s, Got %s", expected, errorf))

--- a/deisctl/backend/fleet/utils_test.go
+++ b/deisctl/backend/fleet/utils_test.go
@@ -66,7 +66,7 @@ func TestNextComponent(t *testing.T) {
 
 func TestLastComponent(t *testing.T) {
 	num, err := lastUnitNum([]string{})
-	errorf := fmt.Sprintf("%v", err)
+	errorf := err.Error()
 	expectedErr := "Component not found"
 	if errorf != expectedErr {
 		t.Fatal(fmt.Errorf("Expected %d, Got %d", expectedErr, errorf))

--- a/deisctl/cmd/cmd_test.go
+++ b/deisctl/cmd/cmd_test.go
@@ -133,7 +133,7 @@ func TestRefreshUnitsError(t *testing.T) {
 	defer server.Close()
 
 	err = RefreshUnits(name, "foo", server.URL+"/%s/%s.service")
-	result := fmt.Sprintf("%v", err)
+	result := err.Error()
 	expected := "404 Not Found"
 
 	if result != expected {
@@ -171,7 +171,7 @@ func TestScaling(t *testing.T) {
 func TestScalingNonScalableComponent(t *testing.T) {
 	b := backendStub{}
 	expected := "cannot scale controller component"
-	err := fmt.Sprintf("%v", Scale([]string{"controller=2"}, &b))
+	err := Scale([]string{"controller=2"}, &b).Error()
 
 	if err != expected {
 		t.Error(fmt.Errorf("Expected '%v', Got '%v'", expected, err))
@@ -181,7 +181,7 @@ func TestScalingNonScalableComponent(t *testing.T) {
 func TestScalingInvalidFormat(t *testing.T) {
 	b := backendStub{}
 	expected := "Could not parse: controller2"
-	err := fmt.Sprintf("%v", Scale([]string{"controller2"}, &b))
+	err := Scale([]string{"controller2"}, &b).Error()
 
 	if err != expected {
 		t.Error(fmt.Errorf("Expected '%v', Got '%v'", expected, err))
@@ -300,7 +300,7 @@ func TestStatusError(t *testing.T) {
 	b := backendStub{}
 
 	expected := "Test Error"
-	err := fmt.Sprintf("%v", Status([]string{"blah"}, &b))
+	err := Status([]string{"blah"}, &b).Error()
 
 	if err != expected {
 		t.Error(fmt.Errorf("Expected '%v', Got '%v'", expected, err))
@@ -319,7 +319,7 @@ func TestJournalError(t *testing.T) {
 	b := backendStub{}
 
 	expected := "Test Error"
-	err := fmt.Sprintf("%v", Journal([]string{"blah"}, &b))
+	err := Journal([]string{"blah"}, &b).Error()
 
 	if err != expected {
 		t.Error(fmt.Errorf("Expected '%v', Got '%v'", expected, err))


### PR DESCRIPTION
The original code was very hackish. I discovered the `Error()` method and updated the code to use that. Sorry for the original horrible code :frowning: