### PR TITLE
test(deisctl): parallelize all of the things

### DIFF
--- a/deisctl/backend/fleet/create_test.go
+++ b/deisctl/backend/fleet/create_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestCreate(t *testing.T) {
+	t.Parallel()
 
 	unitFiles := []string{"deis-controller.service", "deis-builder.service",
 		"deis-router.service"}

--- a/deisctl/backend/fleet/destroy_test.go
+++ b/deisctl/backend/fleet/destroy_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestDestroy(t *testing.T) {
+	t.Parallel()
+
 	testUnits := []*schema.Unit{
 		&schema.Unit{
 			Name: "deis-registry.service",

--- a/deisctl/backend/fleet/fleet_test.go
+++ b/deisctl/backend/fleet/fleet_test.go
@@ -127,6 +127,8 @@ func logState(outchan chan string, errchan chan error, errOutput *string, mutex 
 }
 
 func TestNewClient(t *testing.T) {
+	t.Parallel()
+
 	// set required flags
 	Flags.Endpoint = "http://127.0.0.1:4001"
 

--- a/deisctl/backend/fleet/journal_test.go
+++ b/deisctl/backend/fleet/journal_test.go
@@ -34,6 +34,8 @@ func (m mockJournalCommandRunner) RemoteCommand(cmd string, addr string, timeout
 }
 
 func TestJournal(t *testing.T) {
+	t.Parallel()
+
 	testMachines := []machine.MachineState{
 		machine.MachineState{
 			ID:       "test-1",

--- a/deisctl/backend/fleet/list_unit_files_test.go
+++ b/deisctl/backend/fleet/list_unit_files_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestListUnitFiles(t *testing.T) {
+	t.Parallel()
 
 	testUnits := []*schema.Unit{
 		&schema.Unit{

--- a/deisctl/backend/fleet/list_units_test.go
+++ b/deisctl/backend/fleet/list_units_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestListUnits(t *testing.T) {
+	t.Parallel()
 
 	testUnitStates := []*schema.UnitState{
 		&schema.UnitState{

--- a/deisctl/backend/fleet/registry_test.go
+++ b/deisctl/backend/fleet/registry_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestGetTunnelFlag(t *testing.T) {
+	t.Parallel()
+
 	flag := getTunnelFlag()
 	if flag != "" {
 		t.Fatalf("got %v, expected \"\"", flag)
@@ -23,6 +25,8 @@ func TestGetTunnelFlag(t *testing.T) {
 }
 
 func TestGetChecker(t *testing.T) {
+	t.Parallel()
+
 	Flags.StrictHostKeyChecking = false
 	checker := getChecker()
 	if checker != nil {
@@ -31,6 +35,8 @@ func TestGetChecker(t *testing.T) {
 }
 
 func TestFakeClient(t *testing.T) {
+	t.Parallel()
+
 	_, err := getFakeClient()
 	if err != nil {
 		t.Fatal(err)
@@ -38,6 +44,8 @@ func TestFakeClient(t *testing.T) {
 }
 
 func TestRegistryClient(t *testing.T) {
+	t.Parallel()
+
 	Flags.Tunnel = ""
 	Flags.Endpoint = "http://127.0.0.1:4001"
 	_, err := getRegistryClient()

--- a/deisctl/backend/fleet/scale_test.go
+++ b/deisctl/backend/fleet/scale_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestScaleUp(t *testing.T) {
+	t.Parallel()
+
 	name, err := ioutil.TempDir("", "deisctl-fleetctl")
 
 	if err != nil {
@@ -71,6 +73,8 @@ func TestScaleUp(t *testing.T) {
 }
 
 func TestScaleDown(t *testing.T) {
+	t.Parallel()
+
 	testUnits := []*schema.Unit{
 		&schema.Unit{
 			Name:         "deis-router@1.service",
@@ -130,6 +134,8 @@ func TestScaleDown(t *testing.T) {
 }
 
 func TestScaleError(t *testing.T) {
+	t.Parallel()
+
 	c := &FleetClient{Fleet: &stubFleetClient{}}
 
 	var errOutput string

--- a/deisctl/backend/fleet/ssh_test.go
+++ b/deisctl/backend/fleet/ssh_test.go
@@ -26,6 +26,8 @@ func (mockCommandRunner) RemoteCommand(cmd string, addr string, timeout time.Dur
 }
 
 func TestRunCommand(t *testing.T) {
+	t.Parallel()
+
 	expected := machine.MachineState{
 		ID:       "test-1",
 		PublicIP: "1.1.1.1",
@@ -51,6 +53,8 @@ func TestRunCommand(t *testing.T) {
 }
 
 func TestFindUnit(t *testing.T) {
+	t.Parallel()
+
 	expectedID := "testing"
 
 	testUnits := []*schema.Unit{
@@ -97,6 +101,8 @@ func TestFindUnit(t *testing.T) {
 }
 
 func TestMachineState(t *testing.T) {
+	t.Parallel()
+
 	expected := machine.MachineState{
 		ID:       "test-1",
 		PublicIP: "1.1.1.1",

--- a/deisctl/backend/fleet/start_test.go
+++ b/deisctl/backend/fleet/start_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestStart(t *testing.T) {
+	t.Parallel()
+
 	testUnits := []*schema.Unit{
 		&schema.Unit{
 			Name:         "deis-controller.service",

--- a/deisctl/backend/fleet/status_test.go
+++ b/deisctl/backend/fleet/status_test.go
@@ -34,6 +34,8 @@ func (m mockStatusCommandRunner) RemoteCommand(cmd string, addr string, timeout 
 }
 
 func TestStatus(t *testing.T) {
+	t.Parallel()
+
 	testMachines := []machine.MachineState{
 		machine.MachineState{
 			ID:       "test-1",

--- a/deisctl/backend/fleet/stop_test.go
+++ b/deisctl/backend/fleet/stop_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestStop(t *testing.T) {
+	t.Parallel()
+
 	testUnits := []*schema.Unit{
 		&schema.Unit{
 			Name:         "deis-controller.service",

--- a/deisctl/backend/fleet/unit_test.go
+++ b/deisctl/backend/fleet/unit_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestUnits(t *testing.T) {
+	t.Parallel()
+
 	testUnits := []*schema.Unit{
 		&schema.Unit{
 			Name: "deis-router@1.service",
@@ -41,6 +43,8 @@ func TestUnits(t *testing.T) {
 }
 
 func TestNextUnit(t *testing.T) {
+	t.Parallel()
+
 	testUnits := []*schema.Unit{
 		&schema.Unit{
 			Name: "deis-router@1.service",
@@ -66,6 +70,8 @@ func TestNextUnit(t *testing.T) {
 }
 
 func TestLastUnit(t *testing.T) {
+	t.Parallel()
+
 	testUnits := []*schema.Unit{
 		&schema.Unit{
 			Name: "deis-router@1.service",
@@ -91,6 +97,8 @@ func TestLastUnit(t *testing.T) {
 }
 
 func TestFormatUnitName(t *testing.T) {
+	t.Parallel()
+
 	unitName, err := formatUnitName("router", 1)
 	if err != nil {
 		t.Fatal(err)
@@ -102,6 +110,8 @@ func TestFormatUnitName(t *testing.T) {
 }
 
 func TestNewUnit(t *testing.T) {
+	t.Parallel()
+
 	name, err := ioutil.TempDir("", "deisctl-fleetctl")
 	unitFile := `[Unit]
 Description=deis-controller`
@@ -124,6 +134,8 @@ Description=deis-controller`
 }
 
 func TestReadTemplate(t *testing.T) {
+	t.Parallel()
+
 	name, err := ioutil.TempDir("", "deisctl-fleetctl")
 	expected := []byte("test")
 
@@ -146,6 +158,8 @@ func TestReadTemplate(t *testing.T) {
 }
 
 func TestReadTemplateError(t *testing.T) {
+	t.Parallel()
+
 	name, err := ioutil.TempDir("", "deisctl-fleetctl")
 
 	if err != nil {

--- a/deisctl/backend/fleet/utils_test.go
+++ b/deisctl/backend/fleet/utils_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestNextComponent(t *testing.T) {
+	t.Parallel()
+
 	// test first component
 	num, err := nextUnitNum([]string{})
 	if err != nil {
@@ -65,6 +67,8 @@ func TestNextComponent(t *testing.T) {
 }
 
 func TestLastComponent(t *testing.T) {
+	t.Parallel()
+
 	num, err := lastUnitNum([]string{})
 	errorf := fmt.Sprintf("%v", err)
 	expectedErr := "Component not found"
@@ -115,6 +119,8 @@ func TestLastComponent(t *testing.T) {
 }
 
 func TestSplitJobName(t *testing.T) {
+	t.Parallel()
+
 	c, num, err := splitJobName("deis-router@1.service")
 	if err != nil {
 		t.Fatal(err)
@@ -125,6 +131,8 @@ func TestSplitJobName(t *testing.T) {
 }
 
 func TestSplitTarget(t *testing.T) {
+	t.Parallel()
+
 	c, num, err := splitTarget("router")
 	if err != nil {
 		t.Fatal(err)
@@ -152,6 +160,8 @@ func TestSplitTarget(t *testing.T) {
 }
 
 func TestExpandTargets(t *testing.T) {
+	t.Parallel()
+
 	testUnits := []*schema.Unit{
 		&schema.Unit{
 			Name: "deis-router@1.service",

--- a/deisctl/cmd/cmd_test.go
+++ b/deisctl/cmd/cmd_test.go
@@ -84,6 +84,8 @@ func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 }
 
 func TestRefreshUnits(t *testing.T) {
+	t.Parallel()
+
 	name, err := ioutil.TempDir("", "deisctl")
 
 	if err != nil {
@@ -122,6 +124,8 @@ func TestRefreshUnits(t *testing.T) {
 }
 
 func TestRefreshUnitsError(t *testing.T) {
+	t.Parallel()
+
 	name, err := ioutil.TempDir("", "deisctl")
 
 	if err != nil {
@@ -142,6 +146,8 @@ func TestRefreshUnitsError(t *testing.T) {
 }
 
 func TestListUnits(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{installedUnits: []string{"router@1", "router@2"}}
 
 	if ListUnits(&b) != nil {
@@ -150,6 +156,8 @@ func TestListUnits(t *testing.T) {
 }
 
 func TestListUnitFiles(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 
 	if ListUnitFiles(&b) != nil {
@@ -158,6 +166,8 @@ func TestListUnitFiles(t *testing.T) {
 }
 
 func TestScaling(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{expected: false}
 	scale := []string{"registry=4", "router=3"}
 
@@ -169,6 +179,8 @@ func TestScaling(t *testing.T) {
 }
 
 func TestScalingNonScalableComponent(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := "cannot scale controller component"
 	err := fmt.Sprintf("%v", Scale([]string{"controller=2"}, &b))
@@ -179,6 +191,8 @@ func TestScalingNonScalableComponent(t *testing.T) {
 }
 
 func TestScalingInvalidFormat(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := "Could not parse: controller2"
 	err := fmt.Sprintf("%v", Scale([]string{"controller2"}, &b))
@@ -189,6 +203,8 @@ func TestScalingInvalidFormat(t *testing.T) {
 }
 
 func TestStart(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := []string{"router@1", "router@2"}
 
@@ -200,6 +216,8 @@ func TestStart(t *testing.T) {
 }
 
 func TestStartPlatform(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := []string{"store-monitor", "store-daemon", "store-metadata", "store-gateway@*",
 		"store-volume", "logger", "logspout", "database", "registry@*", "controller",
@@ -214,6 +232,8 @@ func TestStartPlatform(t *testing.T) {
 }
 
 func TestStartSwarm(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := []string{"swarm-node", "swarm-manager"}
 
@@ -225,6 +245,8 @@ func TestStartSwarm(t *testing.T) {
 }
 
 func TestStop(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := []string{"router@1", "router@2"}
 	Stop(expected, &b)
@@ -235,6 +257,8 @@ func TestStop(t *testing.T) {
 }
 
 func TestStopPlatform(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := []string{"router@*", "publisher", "controller", "builder", "database",
 		"registry@*", "logger", "logspout", "store-volume", "store-gateway@*",
@@ -247,6 +271,8 @@ func TestStopPlatform(t *testing.T) {
 }
 
 func TestStopSwarm(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := []string{"swarm-node", "swarm-manager"}
 	Stop([]string{"swarm"}, &b)
@@ -257,6 +283,8 @@ func TestStopSwarm(t *testing.T) {
 }
 
 func TestRestart(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := []string{"router@4", "router@5"}
 
@@ -271,6 +299,8 @@ func TestRestart(t *testing.T) {
 }
 
 func TestSSH(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	err := SSH("controller", &b)
 
@@ -280,6 +310,8 @@ func TestSSH(t *testing.T) {
 }
 
 func TestSSHError(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	err := SSH("registry", &b)
 
@@ -289,6 +321,8 @@ func TestSSHError(t *testing.T) {
 }
 
 func TestStatus(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 
 	if Status([]string{"controller", "builder"}, &b) != nil {
@@ -297,6 +331,8 @@ func TestStatus(t *testing.T) {
 }
 
 func TestStatusError(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 
 	expected := "Test Error"
@@ -308,6 +344,8 @@ func TestStatusError(t *testing.T) {
 }
 
 func TestJournal(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 
 	if Journal([]string{"controller", "builder"}, &b) != nil {
@@ -316,6 +354,8 @@ func TestJournal(t *testing.T) {
 }
 
 func TestJournalError(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 
 	expected := "Test Error"
@@ -327,6 +367,8 @@ func TestJournalError(t *testing.T) {
 }
 
 func TestInstall(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := []string{"router@1", "router@2"}
 
@@ -338,6 +380,8 @@ func TestInstall(t *testing.T) {
 }
 
 func TestInstallPlatform(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := []string{"store-daemon", "store-monitor", "store-metadata", "store-volume",
 		"store-gateway@1", "logger", "logspout", "database", "registry@1",
@@ -351,6 +395,8 @@ func TestInstallPlatform(t *testing.T) {
 }
 
 func TestInstallSwarm(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := []string{"swarm-node", "swarm-manager"}
 
@@ -362,6 +408,8 @@ func TestInstallSwarm(t *testing.T) {
 }
 
 func TestUninstall(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := []string{"router@3", "router@4"}
 
@@ -373,6 +421,8 @@ func TestUninstall(t *testing.T) {
 }
 
 func TestUninstallPlatform(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := []string{"router@*", "publisher", "controller", "builder", "database",
 		"registry@*", "logger", "logspout", "store-volume", "store-gateway@*",
@@ -386,6 +436,8 @@ func TestUninstallPlatform(t *testing.T) {
 }
 
 func TestUninstallSwarm(t *testing.T) {
+	t.Parallel()
+
 	b := backendStub{}
 	expected := []string{"swarm-node", "swarm-manager"}
 

--- a/deisctl/config/config_test.go
+++ b/deisctl/config/config_test.go
@@ -48,6 +48,7 @@ func (m mockClient) Delete(key string) (err error) {
 }
 
 func TestGetConfig(t *testing.T) {
+	t.Parallel()
 
 	testMock := mockClient{expected: MockStore{{key: "/deis/controller/testing", value: "foo"}, {key: "/deis/controller/port", value: "8000"}}}
 	testWriter := bytes.Buffer{}
@@ -66,6 +67,8 @@ func TestGetConfig(t *testing.T) {
 }
 
 func TestGetConfigError(t *testing.T) {
+	t.Parallel()
+
 	testMock := mockClient{expected: MockStore{{key: "/deis/controller/testing", value: "foo"}}}
 	testWriter := bytes.Buffer{}
 
@@ -77,6 +80,8 @@ func TestGetConfigError(t *testing.T) {
 }
 
 func TestSetConfig(t *testing.T) {
+	t.Parallel()
+
 	testMock := mockClient{expected: MockStore{{key: "/deis/controller/testing", value: "foo"}, {key: "/deis/controller/port", value: "8000"}}}
 	testWriter := bytes.Buffer{}
 
@@ -94,6 +99,8 @@ func TestSetConfig(t *testing.T) {
 }
 
 func TestDeleteConfig(t *testing.T) {
+	t.Parallel()
+
 	testMock := mockClient{expected: MockStore{{key: "/deis/controller/testing", value: "foo"}, {key: "/deis/controller/port", value: "8000"}}}
 	testWriter := bytes.Buffer{}
 
@@ -112,6 +119,7 @@ func TestDeleteConfig(t *testing.T) {
 
 // TestConfigSSHPrivateKey ensures private keys are base64 encoded from file path
 func TestConfigSSHPrivateKey(t *testing.T) {
+	t.Parallel()
 
 	f, err := writeTempFile("private-key")
 	if err != nil {
@@ -131,6 +139,7 @@ func TestConfigSSHPrivateKey(t *testing.T) {
 }
 
 func TestConfigRouterKey(t *testing.T) {
+	t.Parallel()
 
 	f, err := writeTempFile("router-key")
 	if err != nil {
@@ -149,6 +158,7 @@ func TestConfigRouterKey(t *testing.T) {
 }
 
 func TestConfigRouterCert(t *testing.T) {
+	t.Parallel()
 
 	f, err := writeTempFile("router-cert")
 	if err != nil {

--- a/deisctl/utils/utils_test.go
+++ b/deisctl/utils/utils_test.go
@@ -7,6 +7,8 @@ import (
 
 // TestResolvePath ensures ResolvePath replaces $HOME and ~ as expected
 func TestResolvePath(t *testing.T) {
+	t.Parallel()
+
 	paths := []string{"$HOME/foo/bar", "~/foo/bar"}
 	expected := os.Getenv("HOME") + "/foo/bar"
 	for _, path := range paths {


### PR DESCRIPTION
In theory this should speed your builds up. We should test to confirm that there is a performance benefit.

##### Before:

``` shell
$ time make -C deisctl test
...
real 0m21.975s
user 0m15.506s
sys  0m4.569s
```

##### After:

``` shell
$ GOMAXPROCS=4 time make -C deisctl test
...
15.98 real        15.70 user         6.10 sys
```

I'd appreciate it if anybody has any time to test this and report if this had enough impact to warrant merging