### PR TITLE
docs(backing_up_data): Add community tools for reference

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -18,6 +18,10 @@ Some of these projects are listed below. This is not an exhaustive list.
 
 Please add to this list by opening a pull request!
 
+### Backup Tools
+* [Deis Backup and Restore](https://github.com/myriadmobile/deis-backup-restore) by [@croemmich](https://github.com/croemmich) - Container to backup and restore etcd, database, registry, and logs to/from any S3 compatible store.
+* [deis-backup-service](https://github.com/mozilla/deis-backup-service) by [@glogiotatidis](https://github.com/glogiotatidis) - Container to backup the database and registry. Uses s3cmd behind the scenes and supports data encryption.
+
 ### Deis API Clients
 * [Node.js](https://github.com/aledbf/deis-api) by [@aledbf](https://github.com/aledbf) - node.js Deis API wrapper
 
@@ -30,8 +34,6 @@ Please add to this list by opening a pull request!
 
 ### CoreOS Unit Files
 * [CoreOS unit files](https://github.com/ianblenke/coreos-vagrant-kitchen-sink/tree/master/cloud-init) by [@ianblenke](https://github.com/ianblenke) - Unit files to launch various services on CoreOS hosts
-* [Deis Backup and Restore](https://github.com/myriadmobile/deis-backup-restore) by [@croemmich](https://github.com/croemmich) - Container to backup and restore etcd, database, registry, and logs to/from any S3 compatible store
-* [deis-backup-service](https://github.com/mozilla/deis-backup-service) by [@glogiotatidis](https://github.com/glogiotatidis) - Unit Files to automatically backup to S3 database and registry data.
 * [Docker S3 Cleaner](https://github.com/myriadmobile/docker-s3-cleaner) by [@croemmich](https://github.com/croemmich) - Unit file to remove orphaned image layers from S3 backed private docker registries
 * [New Relic unit for CoreOS](https://github.com/lorieri/coreos-newrelic) by [@lorieri](https://github.com/lorieri) - A global unit to launch New Relic sysmond
 

--- a/docs/managing_deis/backing_up_data.rst
+++ b/docs/managing_deis/backing_up_data.rst
@@ -217,6 +217,13 @@ use in the ``export`` command should correspond to the IP of the host machine wh
 
 That's it! The cluster should be fully restored.
 
+Tools
+-----
+
+Various community members have developed tools to assist in automating the backup and restore process outlined above.
+Information on the tools can be found on the `Community Contributions`_ page.
+
 .. _`Ceph`: http://ceph.com
 .. _`download s3cmd`: http://s3tools.org/download
+.. _`Community Contributions`: https://github.com/deis/deis/blob/master/contrib/README.md#backup-tools
 .. _`s3cmd`: http://s3tools.org/


### PR DESCRIPTION
The page with contributed tools is a bit hard to find. Maybe include the backup/restore tools on the backup page?