### PR TITLE
chore(*): update confd to v0.10.0

### DIFF
--- a/builder/rootfs/Dockerfile
+++ b/builder/rootfs/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/get-d
     && chmod +x /usr/local/bin/etcdctl
 
 # install confd
-RUN curl -sSL -o /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v0.9.0/confd-0.9.0-linux-amd64 \
+RUN curl -sSL -o /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v0.10.0/confd-0.10.0-linux-amd64 \
     && chmod +x /usr/local/bin/confd
 
 RUN apk add --update-cache \

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/get-d
     && chmod +x /usr/local/bin/etcdctl
 
 # install confd
-RUN curl -sSL -o /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v0.9.0/confd-0.9.0-linux-amd64 \
+RUN curl -sSL -o /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v0.10.0/confd-0.10.0-linux-amd64 \
     && chmod +x /usr/local/bin/confd
 
 # define execution environment

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/get-d
     && chmod +x /usr/local/bin/etcdctl
 
 # install confd
-RUN curl -sSL -o /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v0.9.0/confd-0.9.0-linux-amd64 \
+RUN curl -sSL -o /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v0.10.0/confd-0.10.0-linux-amd64 \
     && chmod +x /usr/local/bin/confd
 
 ADD build.sh /tmp/build.sh

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/get-d
     && chmod +x /usr/local/bin/etcdctl
 
 # install confd
-RUN curl -sSL -o /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v0.9.0/confd-0.9.0-linux-amd64 \
+RUN curl -sSL -o /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v0.10.0/confd-0.10.0-linux-amd64 \
     && chmod +x /usr/local/bin/confd
 
 ENV DOCKER_REGISTRY_CONFIG /docker-registry/config/config.yml

--- a/store/base/build.sh
+++ b/store/base/build.sh
@@ -20,7 +20,7 @@ curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/get-deis/
     && chmod +x /usr/local/bin/etcdctl
 
 # install confd
-CONFD_VERSION=0.9.0
+CONFD_VERSION=0.10.0
 curl -sSL -o /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v$CONFD_VERSION/confd-$CONFD_VERSION-linux-amd64 \
 	&& chmod +x /usr/local/bin/confd
 


### PR DESCRIPTION
See https://github.com/kelseyhightower/confd/releases/tag/v0.10.0

Tested manually to ensure no dotfiles were left in builder's `/home/git` directory. Note that router is still using a customized post-v0.9.0 version of `confd`, which I left intact for now. Thanks to @bacongobbler for making the `confd` release happen!

Closes #3570.