### PR TITLE
feat(router): enable ssl caching and expose ssl_protocols for configuration

### DIFF
--- a/docs/customizing_deis/router_settings.rst
+++ b/docs/customizing_deis/router_settings.rst
@@ -70,6 +70,11 @@ setting                                      description
 /deis/router/sslCiphers                      cluster-wide enabled SSL ciphers
 /deis/router/sslKey                          cluster-wide SSL private key
 /deis/router/sslDhparam                      cluster-wide SSL dhparam
+/deis/router/sslProtocols                    nginx ssl_protocols setting (default: TLSv1 TLSv1.1 TLSv1.2)
+/deis/router/sslSessionCache                 nginx ssl_session_cache setting (default: not set)
+/deis/router/sslSessionTickets               nginx ssl_session_tickets setting (default: on)
+/deis/router/sslSessionTimeout               nginx ssl_session_timeout setting (default: 10m)
+/deis/router/sslBufferSize                   nginx ssl_buffer_size setting (default: 4k)
 /deis/router/workerProcesses                 nginx number of worker processes to start (default: auto i.e. available CPU cores)
 /deis/router/proxyProtocol                   nginx PROXY protocol enabled
 /deis/router/proxyRealIpCidr                 nginx IP with CIDR used by the load balancer in front of deis-router (default: 10.0.0.0/8)

--- a/router/image/conf.d/ssl.conf.toml
+++ b/router/image/conf.d/ssl.conf.toml
@@ -1,0 +1,10 @@
+[template]
+src   = "ssl.conf"
+dest  = "/opt/nginx/conf/ssl.conf"
+uid = 0
+gid = 0
+mode  = "0644"
+keys = [
+  "/deis/router",
+]
+reload_cmd = "/opt/nginx/sbin/nginx -s reload"

--- a/router/image/templates/deis.conf
+++ b/router/image/templates/deis.conf
@@ -6,12 +6,5 @@ listen 80{{ if exists "/deis/router/proxyProtocol" }} proxy_protocol{{ end }};
 listen 443 ssl spdy{{ if exists "/deis/router/proxyProtocol" }} proxy_protocol{{ end }};
 ssl_certificate /etc/ssl/deis.cert;
 ssl_certificate_key /etc/ssl/deis.key;
-{{ if exists "/deis/router/sslDhparam" }}
-ssl_dhparam /etc/ssl/dhparam.pem;
-{{ end }}
-ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-{{ if exists "/deis/router/sslCiphers" }}
-ssl_ciphers '{{ getv "/deis/router/sslCiphers" }}';
-ssl_prefer_server_ciphers on;
-{{ end }}
+include ssl.conf;
 {{ end }}

--- a/router/image/templates/nginx.conf
+++ b/router/image/templates/nginx.conf
@@ -197,11 +197,7 @@ http {
         listen 443 ssl spdy{{ if ne $useProxyProtocol "false" }} proxy_protocol{{ end }};
         ssl_certificate /etc/ssl/deis/certs/{{ $app_domain }}.cert;
         ssl_certificate_key /etc/ssl/deis/keys/{{ $app_domain }}.key;
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-        {{ if exists "/deis/router/sslCiphers" }}
-        ssl_ciphers '{{ getv "/deis/router/sslCiphers" }}';
-        ssl_prefer_server_ciphers on;
-        {{ end }}
+        include ssl.conf;
         {{/* if there's no app SSL cert but we have a router SSL cert, enable that instead */}}
         {{/* TODO (bacongobbler): wait for https://github.com/kelseyhightower/confd/issues/270 */}}
         {{/* so we can apply this config to just subdomains of the platform domain. */}}
@@ -366,11 +362,7 @@ http {
         listen 443 ssl spdy{{ if ne $useProxyProtocol "false" }} proxy_protocol{{ end }};
         ssl_certificate /etc/ssl/deis/certs/{{ $app_domain }}.cert;
         ssl_certificate_key /etc/ssl/deis/keys/{{ $app_domain }}.key;
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-        {{ if exists "/deis/router/sslCiphers" }}
-        ssl_ciphers '{{ getv "/deis/router/sslCiphers" }}';
-        ssl_prefer_server_ciphers on;
-        {{ end }}
+        include ssl.conf;
         {{/* if there's no app SSL cert but we have a router SSL cert, enable that instead */}}
         {{/* TODO (bacongobbler): wait for https://github.com/kelseyhightower/confd/issues/270 */}}
         {{/* so we can apply this config to just subdomains of the platform domain. */}}

--- a/router/image/templates/ssl.conf
+++ b/router/image/templates/ssl.conf
@@ -1,0 +1,25 @@
+# set the allowed protocols
+ssl_protocols {{ or (getv "/deis/router/sslProtocols") "TLSv1 TLSv1.1 TLSv1.2" }};
+
+# turn on session caching to drastically improve performance
+{{ if exists "/deis/router/sslSessionCache" }}
+ssl_session_cache {{ getv "/deis/router/sslSessionCache" }};
+ssl_session_timeout {{ or (getv "/deis/router/sslSessionTimeout") "10m" }};
+{{ end }}
+
+# allow configuring ssl session tickets
+ssl_session_tickets {{ or (getv "/deis/router/sslSessionTickets") "on" }};
+
+# slightly reduce the time-to-first-byte
+ssl_buffer_size {{ or (getv "/deis/router/sslBufferSize") "4k" }};
+
+# allow configuring custom ssl ciphers
+{{ if exists "/deis/router/sslCiphers" }}
+ssl_ciphers '{{ getv "/deis/router/sslCiphers" }}';
+ssl_prefer_server_ciphers on;
+{{ end }}
+
+# allow custom DH parameters
+{{ if exists "/deis/router/sslDhparam" }}
+ssl_dhparam /etc/ssl/dhparam.pem;
+{{ end }}


### PR DESCRIPTION
This pull will enable ssl session caching by default and reduce the ssl_buffer size to 4k to slightly increase the time-to-first-byte. Additionally it makes ssl_protocols configurable.

I split out the SSL configuration to a separate config file. As a side effect, the ssl_dhparam option is now affecting domain certificates, as it was likely intended to.

With the current SSL settings and these, it's now possible to score an A+ on https://www.ssllabs.com/ssltest.