### PR TITLE
fix(*): ensure container removal with --rm

### DIFF
--- a/controller/scheduler/fleet.py
+++ b/controller/scheduler/fleet.py
@@ -379,9 +379,8 @@ CONTAINER_TEMPLATE = [
     {"section": "Unit", "name": "Description", "value": "{name}"},
     {"section": "Service", "name": "ExecStartPre", "value": '''/bin/sh -c "IMAGE=$(etcdctl get /deis/registry/host 2>&1):$(etcdctl get /deis/registry/port 2>&1)/{image}; docker pull $IMAGE"'''},  # noqa
     {"section": "Service", "name": "ExecStartPre", "value": '''/bin/sh -c "docker inspect {name} >/dev/null 2>&1 && docker rm -f {name} || true"'''},  # noqa
-    {"section": "Service", "name": "ExecStart", "value": '''/bin/sh -c "IMAGE=$(etcdctl get /deis/registry/host 2>&1):$(etcdctl get /deis/registry/port 2>&1)/{image}; docker run --name {name} {memory} {cpu} {hostname} -P $IMAGE {command}"'''},  # noqa
+    {"section": "Service", "name": "ExecStart", "value": '''/bin/sh -c "IMAGE=$(etcdctl get /deis/registry/host 2>&1):$(etcdctl get /deis/registry/port 2>&1)/{image}; docker run --name {name} --rm {memory} {cpu} {hostname} -P $IMAGE {command}"'''},  # noqa
     {"section": "Service", "name": "ExecStop", "value": '''/usr/bin/docker stop {name}'''},
-    {"section": "Service", "name": "ExecStop", "value": '''/usr/bin/docker rm -f {name}'''},
     {"section": "Service", "name": "TimeoutStartSec", "value": "20m"},
     {"section": "Service", "name": "TimeoutStopSec", "value": "10"},
     {"section": "Service", "name": "RestartSec", "value": "5"},

--- a/deisctl/units/deis-builder.service
+++ b/deisctl/units/deis-builder.service
@@ -11,7 +11,6 @@ ExecStartPre=-/bin/sh -c "/sbin/losetup -f"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker run --name deis-builder --rm -p 2223:22 --volumes-from=deis-builder-data -c 800 -e EXTERNAL_PORT=2223 -e HOST=$COREOS_PRIVATE_IPV4 --privileged -v /etc/environment_proxy:/etc/environment_proxy $IMAGE"
 ExecStartPost=/bin/sh -c "echo 'Waiting for builder on 2223/tcp...' && until ncat $COREOS_PRIVATE_IPV4 2223 --exec '/usr/bin/echo dummy-value' >/dev/null 2>&1; do sleep 1; done"
 ExecStartPost=/usr/bin/docker exec deis-builder /usr/local/bin/push-images
-ExecStopPost=-/usr/bin/docker rm -f deis-builder
 Restart=on-failure
 RestartSec=5
 

--- a/deisctl/units/deis-cache.service
+++ b/deisctl/units/deis-cache.service
@@ -7,7 +7,6 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-cache >/dev/null 2>&1 && docker rm -f deis-cache || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache` && docker run --name deis-cache --rm -p 6379:6379 -e EXTERNAL_PORT=6379 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
-ExecStopPost=-/usr/bin/docker rm -f deis-cache
 Restart=on-failure
 RestartSec=5
 

--- a/deisctl/units/deis-controller.service
+++ b/deisctl/units/deis-controller.service
@@ -9,7 +9,6 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-controller >/dev/null 2>&1 && docker rm -f deis-controller || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker run --name deis-controller --rm -p 8000:8000 -e EXTERNAL_PORT=8000 -e HOST=$COREOS_PRIVATE_IPV4 -v /var/run/fleet.sock:/var/run/fleet.sock -v /var/lib/deis/store:/data $IMAGE"
-ExecStopPost=-/usr/bin/docker rm -f deis-controller
 Restart=on-failure
 RestartSec=5
 

--- a/deisctl/units/deis-database.service
+++ b/deisctl/units/deis-database.service
@@ -7,9 +7,8 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "docker inspect deis-database-data >/dev/null 2>&1 || docker run --name deis-database-data -v /var/lib/postgresql alpine:3.1 /bin/true"
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-database >/dev/null 2>&1 && docker rm -f deis-database >/dev/null 2>&1 || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker run --name deis-database --volumes-from=deis-database-data -p 5432:5432 -e EXTERNAL_PORT=5432 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker run --name deis-database --rm --volumes-from=deis-database-data -p 5432:5432 -e EXTERNAL_PORT=5432 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStopPost=-/usr/bin/docker exec deis-database sudo service postgresql stop
-ExecStopPost=-/usr/bin/docker rm -f deis-database
 Restart=on-failure
 RestartSec=5
 

--- a/deisctl/units/deis-logger.service
+++ b/deisctl/units/deis-logger.service
@@ -9,7 +9,6 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-logger >/dev/null 2>&1 && docker rm -f deis-logger || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker run --name deis-logger --rm -p 514:514/udp -e EXTERNAL_PORT=514 -e HOST=$COREOS_PRIVATE_IPV4 -v /var/lib/deis/store:/data $IMAGE"
-ExecStopPost=-/usr/bin/docker rm -f deis-logger
 Restart=on-failure
 RestartSec=5
 

--- a/deisctl/units/deis-logspout.service
+++ b/deisctl/units/deis-logspout.service
@@ -9,7 +9,6 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logspout` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-logspout >/dev/null 2>&1 && docker rm -f deis-logspout || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logspout` && docker run --name deis-logspout --rm -v /var/run/docker.sock:/tmp/docker.sock -e ETCD_HOST=$COREOS_PRIVATE_IPV4 -e HOST=$COREOS_PRIVATE_IPV4 -e DEBUG=1 $IMAGE"
-ExecStopPost=-/usr/bin/docker rm -f deis-logspout
 Restart=on-failure
 RestartSec=5
 

--- a/deisctl/units/deis-publisher.service
+++ b/deisctl/units/deis-publisher.service
@@ -9,7 +9,6 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-publisher >/dev/null 2>&1 && docker rm -f deis-publisher || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker run --name deis-publisher --rm -v /var/run/docker.sock:/var/run/docker.sock $IMAGE --host=$COREOS_PRIVATE_IPV4 --etcd-host=$COREOS_PRIVATE_IPV4"
-ExecStopPost=-/usr/bin/docker rm -f deis-publisher
 Restart=on-failure
 RestartSec=5
 

--- a/deisctl/units/deis-registry.service
+++ b/deisctl/units/deis-registry.service
@@ -8,7 +8,6 @@ ExecStartPre=-/usr/bin/etcdctl mkdir /deis/cache >/dev/null 2>&1
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-registry >/dev/null 2>&1 && docker rm -f deis-registry || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docker run --name deis-registry --rm -p 5000:5000 -e EXTERNAL_PORT=5000 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
-ExecStopPost=-/usr/bin/docker rm -f deis-registry
 Restart=on-failure
 RestartSec=5
 

--- a/deisctl/units/deis-router.service
+++ b/deisctl/units/deis-router.service
@@ -7,7 +7,6 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-router >/dev/null 2>&1 && docker rm -f deis-router || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router` && docker run --name deis-router --rm -p 80:80 -p 2222:2222 -p 443:443 -e EXTERNAL_PORT=80 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
-ExecStopPost=-/usr/bin/docker rm -f deis-router
 Restart=on-failure
 RestartSec=5
 

--- a/deisctl/units/deis-store-admin.service
+++ b/deisctl/units/deis-store-admin.service
@@ -7,7 +7,6 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-admin` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-admin >/dev/null 2>&1 && docker rm -f deis-store-admin >/dev/null 2>&1 || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-admin` && docker run --name deis-store-admin --rm --volumes-from=deis-store-daemon-data --volumes-from=deis-store-monitor-data -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
-ExecStopPost=-/usr/bin/docker rm -f deis-store-admin
 Restart=on-failure
 RestartSec=5
 

--- a/deisctl/units/deis-store-daemon.service
+++ b/deisctl/units/deis-store-daemon.service
@@ -8,8 +8,7 @@ ExecStartPre=/bin/sh -c "docker inspect deis-store-daemon-data >/dev/null 2>&1 |
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-daemon` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-daemon >/dev/null 2>&1 && docker rm -f deis-store-daemon >/dev/null 2>&1 || true"
 ExecStartPre=/usr/bin/sleep 10
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-daemon` && docker run --name deis-store-daemon --volumes-from=deis-store-daemon-data --rm -e HOST=$COREOS_PRIVATE_IPV4 -p 6800 --net host $IMAGE"
-ExecStopPost=-/usr/bin/docker rm -f deis-store-daemon
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-daemon` && docker run --name deis-store-daemon --rm --volumes-from=deis-store-daemon-data -e HOST=$COREOS_PRIVATE_IPV4 -p 6800 --net host $IMAGE"
 Restart=on-failure
 RestartSec=5
 

--- a/deisctl/units/deis-store-gateway.service
+++ b/deisctl/units/deis-store-gateway.service
@@ -6,9 +6,8 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-gateway` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-gateway >/dev/null 2>&1 && docker rm -f deis-store-gateway || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-gateway` && docker run --name deis-store-gateway -h deis-store-gateway --rm -e HOST=$COREOS_PRIVATE_IPV4 -e EXTERNAL_PORT=8888 -p 8888:8888 $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-gateway` && docker run --name deis-store-gateway --rm -h deis-store-gateway -e HOST=$COREOS_PRIVATE_IPV4 -e EXTERNAL_PORT=8888 -p 8888:8888 $IMAGE"
 ExecStartPost=/bin/sh -c "until (echo 'Waiting for ceph gateway on 8888/tcp...' && curl -sSL http://localhost:8888|grep -e '<ID>anonymous</ID><DisplayName></DisplayName>' >/dev/null 2>&1); do sleep 1; done"
-ExecStopPost=-/usr/bin/docker rm -f deis-store-gateway
 Restart=on-failure
 RestartSec=5
 

--- a/deisctl/units/deis-store-monitor.service
+++ b/deisctl/units/deis-store-monitor.service
@@ -9,7 +9,6 @@ ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-monitor` && 
 ExecStartPre=/bin/sh -c "etcdctl set /deis/store/hosts/$COREOS_PRIVATE_IPV4 `hostname` >/dev/null"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-monitor >/dev/null 2>&1 && docker rm -f deis-store-monitor >/dev/null 2>&1 || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-monitor` && docker run --name deis-store-monitor --rm --volumes-from=deis-store-monitor-data -e HOST=$COREOS_PRIVATE_IPV4 -p 6789 --net host $IMAGE"
-ExecStopPost=-/usr/bin/docker rm -f deis-store-monitor
 Restart=on-failure
 RestartSec=5
 

--- a/deisctl/units/deis-swarm-manager.service
+++ b/deisctl/units/deis-swarm-manager.service
@@ -7,7 +7,6 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/swarm` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-swarm-manager >/dev/null 2>&1 && docker rm -f deis-swarm-manager >/dev/null 2>&1 || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/swarm` && docker run --name deis-swarm-manager --rm -p 2395:2375 -e EXTERNAL_PORT=2395 -e HOST=$COREOS_PRIVATE_IPV4 -v /etc/environment_proxy:/etc/environment_proxy $IMAGE manage"
-ExecStopPost=-/usr/bin/docker rm -f deis-swarm-manager
 Restart=on-failure
 RestartSec=5
 

--- a/deisctl/units/deis-swarm-node.service
+++ b/deisctl/units/deis-swarm-node.service
@@ -7,7 +7,6 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/swarm` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-swarm-node >/dev/null 2>&1 && docker rm -f deis-swarm-node >/dev/null 2>&1 || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/swarm` && docker run --name deis-swarm-node --rm -e HOST=$COREOS_PRIVATE_IPV4 -v /etc/environment_proxy:/etc/environment_proxy $IMAGE join"
-ExecStopPost=-/usr/bin/docker rm -f deis-swarm-node
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
@jwaldrip reported in #3885 that we seemingly leave behind orphaned containers that are not cleaned up after they are removed. This PR ensures all unit files use `--rm` to automatically clean up the container (`database` was lacking it before). This also removes the unnecessary `ExecStopPost` to clean up the container, as this is seemingly unnecessary (and may not even work). A side benefit of this change is that we no longer see "container does not exist" in the Docker logs whenever a service is stopped (as the container is already cleaned up by the time the `ExecStopPost` hits).

Note that we don't change the run template in the fleet scheduler to use `--rm` since as @bacongobbler mentioned, we have to log in and perform a `docker inspect` to check on the success of the container.

replaces #3885