### PR TITLE
fix(logger): reduce severity of log failure

### DIFF
--- a/logger/drain/drain.go
+++ b/logger/drain/drain.go
@@ -26,7 +26,7 @@ func SendToDrain(m string, drain string) error {
 func sendToSyslogDrain(m string, drain string) error {
 	conn, err := net.Dial("udp", drain)
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 	}
 	defer conn.Close()
 	fmt.Fprintf(conn, m)


### PR DESCRIPTION
Sending a log to an external server should not kill the logger on an error. For example, if the host is down or unavailable, the logger should just log that the error message has been lost, but carry on.