### PR TITLE
fix(controller): allow non superusers to manage their keys

### DIFF
--- a/controller/api/tests/test_key.py
+++ b/controller/api/tests/test_key.py
@@ -152,3 +152,13 @@ class KeyTest(TestCase):
     def test_rsa_key_fingerprint(self):
         fp = fingerprint(RSA_PUBKEY)
         self.assertEquals(fp, '54:6d:da:1f:91:b5:2b:6f:a2:83:90:c4:f9:73:76:f5')
+
+    def test_key_api_with_non_superuser_rsa(self):
+        self.user = User.objects.get(username='autotest2')
+        self.token = self.user.auth_token.key
+        self._check_key(RSA_PUBKEY)
+
+    def test_key_api_with_non_superuser_ecdsa(self):
+        self.user = User.objects.get(username='autotest2')
+        self.token = self.user.auth_token.key
+        self._check_key(ECDSA_PUBKEY)

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -287,6 +287,7 @@ class CertificateViewSet(BaseDeisViewSet):
 class KeyViewSet(BaseDeisViewSet):
     """A viewset for interacting with Key objects."""
     model = models.Key
+    permission_classes = [IsAuthenticated, permissions.IsOwner]
     serializer_class = serializers.KeySerializer
 
 


### PR DESCRIPTION
Users were unable to remove their SSH keys. This PR fixes the Key management view configuration that was blocking the API access. The wrong view configuration was being inherited from `api.views.BaseDeisViewSet`. 

Error using API directly:


```
$ http DELETE deis.platform/v1/keys/rochacon@machine.local "Authorization:token <rochacon-token>"
HTTP/1.1 403 FORBIDDEN
Allow: GET, DELETE, HEAD, OPTIONS
Connection: keep-alive
Content-Encoding: gzip
Content-Type: application/json
DEIS_API_VERSION: 1.4
DEIS_PLATFORM_VERSION: 1.7.3
Date: Sat, 27 Jun 2015 00:58:41 GMT
Server: nginx/1.9.0
Transfer-Encoding: chunked
Vary: Accept-Encoding
X_DEIS_API_VERSION: 1.4
X_DEIS_PLATFORM_VERSION: 1.7.3

{
    "detail": "You do not have permission to perform this action."
}
```

Error using the CLI:

```
$ deis keys
=== rochacon Keys
rochacon@machine.local ssh-rsa AAAAB3Nz...2eSfWk4irQ

$ deis keys:remove rochacon@machine.local
Removing rochacon@machine.local SSH Key... 403 FORBIDDEN
Detail:
You do not have permission to perform this action.
```