### PR TITLE
fix(builder): only build slugbuilder/slugrunner when necessary

### DIFF
--- a/builder/rootfs/bin/boot
+++ b/builder/rootfs/bin/boot
@@ -85,9 +85,14 @@ while [[ ! -e /var/run/docker.sock ]]; do
 	sleep 1
 done
 
-# build required images
-docker build -t deis/slugbuilder /usr/local/src/slugbuilder/
-docker build -t deis/slugrunner /usr/local/src/slugrunner/
+# build required images if they don't already exist
+if ! docker history deis/slugbuilder >/dev/null 2>&1; then
+	docker build -t deis/slugbuilder /usr/local/src/slugbuilder/
+fi
+
+if ! docker history deis/slugrunner >/dev/null 2>&1; then
+	docker build -t deis/slugrunner /usr/local/src/slugrunner/
+fi
 
 function gen_host_keys {
 	if ! etcd_get sshHostKey; then


### PR DESCRIPTION
On start, the slugbuilder and slugrunner images are built from
the builder's source directory. This is unnecessary on restarts,
and prevents optimizations where the slugbuilder and slugrunner images
are already pre-cached (for example, by bind-mounting a host volume
into builder with the images).

This commit simply wraps these `docker build` instructions in
`docker history` checks to see if the images exist before
attempting to build them.

/cc @iancoffey @technosophos 