### PR TITLE
fix(docs): mock out python ldap modules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,17 @@
 import os
 import sys
 
+from mock import MagicMock
+
+# Mock out modules that can't be installed at ReadTheDocs.org.
+class MockModule(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+            return MockModule()
+
+MOCK_MODULES = ['django_auth_ldap', 'django_auth_ldap.config', 'django_auth_ldap.models', 'ldap']
+sys.modules.update((mod_name, MockModule()) for mod_name in MOCK_MODULES)
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -13,7 +13,6 @@ django-cors-headers==1.0.0
 django-fsm==2.2.0
 django-guardian==1.2.5
 django-json-field==0.5.7
-django-auth-ldap==1.2.5
 djangorestframework==3.0.5
 docker-py==1.1.0
 gunicorn==19.3.0
@@ -21,7 +20,6 @@ paramiko==1.15.2
 python-etcd==0.3.2
 PyYAML==3.11
 South==1.0.2
-python-ldap==2.4.19
 
 # Deis client requirements, copied from client/requirements.txt
 cryptography==0.8.2
@@ -39,3 +37,4 @@ urllib3==1.10.2
 # Deis documentation requirements
 Sphinx==1.3.1
 smartypants==1.8.6
+mock==1.0.1


### PR DESCRIPTION
ReadTheDocs.org doesn't have libldap2-dev installed in its build environment, which prevents python-ldap from building, which prevents generating Deis' [python autodocs](http://docs.deis.io/en/latest/reference/client/). This makes the dependency unnecessary by mocking the required modules.

Closes #3909, refs rtfd/readthedocs.org#1363