### PR TITLE
docs(installing_deis): include Deis Pro in AWS docs

### DIFF
--- a/docs/_includes/_deis-pro.rst
+++ b/docs/_includes/_deis-pro.rst
@@ -1,0 +1,7 @@
+.. note::
+
+  An automated deployment of a Deis cluster on AWS is provided for free by Engine Yard at `try.deis.com`_.
+  For Engine Yard deployments, your cluster is already fully provisioned. Skip to the :ref:`using_deis`
+  documentation for details on deploying applications, creating users, and other tasks.
+
+.. _`try.deis.com`: https://try.deis.com/

--- a/docs/installing_deis/aws.rst
+++ b/docs/installing_deis/aws.rst
@@ -11,6 +11,7 @@ In this tutorial, we will show you how to set up your own 3-node cluster on Amaz
 Please :ref:`get the source <get_the_source>` and refer to the scripts in `contrib/ec2`_
 while following this documentation.
 
+.. include:: ../_includes/_deis-pro.rst
 
 Install the AWS Command Line Interface
 --------------------------------------

--- a/docs/installing_deis/quick-start.rst
+++ b/docs/installing_deis/quick-start.rst
@@ -6,11 +6,7 @@ Quick Start
 
 These steps will help you provision a Deis cluster.
 
-.. note::
-
-  An automated deployment of a Deis cluster on AWS is provided by Engine Yard at `try.deis.com`_.
-  For Engine Yard deployments, skip to the :ref:`using_deis` documentation.
-
+.. include:: ../_includes/_deis-pro.rst
 
 .. _get_the_source:
 
@@ -73,4 +69,3 @@ please refer to :ref:`install_deisctl` and :ref:`install_deis_platform`.
 
 
 .. _`CoreOS`: https://coreos.com/
-.. _`try.deis.com`: https://try.deis.com/


### PR DESCRIPTION
Moves the link to Deis Pro to a snippet, and includes it on both the
Quick Start and AWS installation guides.