### PR TITLE
feat(deisctl): specify # of routers to install

### DIFF
--- a/deisctl/client/client.go
+++ b/deisctl/client/client.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/deis/deis/deisctl/backend"
 	"github.com/deis/deis/deisctl/backend/fleet"
@@ -109,7 +110,7 @@ Examples:
 // Install loads the definitions of components from local unit files.
 // After Install, the components will be available to Start.
 func (c *Client) Install(argv []string) error {
-	usage := `Loads the definitions of components from local unit files.
+	usage := fmt.Sprintf(`Loads the definitions of components from local unit files.
 
 After install, the components will be available to start.
 
@@ -120,12 +121,23 @@ After install, the components will be available to start.
 
 Usage:
   deisctl install [<target>...] [options]
-`
+
+Options:
+  --router-mesh-size=<num>  Number of routers to be loaded when installing the platform [default: %d].
+`, cmd.DefaultRouterMeshSize)
 	// parse command-line arguments
 	args, err := docopt.Parse(usage, argv, true, "", false)
 	if err != nil {
 		return err
 	}
+
+	meshSizeArg, _ := args["--router-mesh-size"].(string)
+	parsedValue, err := strconv.ParseUint(meshSizeArg, 0, 8)
+	if err != nil || parsedValue < 1 {
+		fmt.Print("Error: argument --router-mesh-size: invalid value, make sure the value is an integer between 1 and 255.\n")
+		return err
+	}
+	cmd.RouterMeshSize = uint8(parsedValue)
 
 	return cmd.Install(args["<target>"].([]string), c.Backend, cmd.CheckRequiredKeys)
 }

--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -27,6 +27,8 @@ const (
 	StatelessPlatformCommand string = "stateless-platform"
 	swarm                    string = "swarm"
 	mesos                    string = "mesos"
+	// DefaultRouterMeshSize defines the default number of routers to be loaded when installing the platform.
+	DefaultRouterMeshSize uint8 = 3
 )
 
 // ListUnits prints a list of installed units.
@@ -44,6 +46,9 @@ var Stdout io.Writer = os.Stderr
 
 // Location to write standard error information. By default, this is the os.Stderr.
 var Stderr io.Writer = os.Stdout
+
+// Number of routers to be installed. By default, it's DefaultRouterMeshSize.
+var RouterMeshSize = DefaultRouterMeshSize
 
 // Scale grows or shrinks the number of running components.
 // Currently "router", "registry" and "store-gateway" are the only types that can be scaled.
@@ -316,9 +321,17 @@ func installDefaultServices(b backend.Backend, stateless bool, wg *sync.WaitGrou
 	wg.Wait()
 
 	fmt.Fprintln(out, "Routing mesh...")
-	b.Create([]string{"router@1", "router@2", "router@3"}, wg, out, err)
+	b.Create(getRouters(), wg, out, err)
 	wg.Wait()
 
+}
+
+func getRouters() []string {
+	routers := make([]string, RouterMeshSize)
+	for i := uint8(0); i < RouterMeshSize; i++ {
+		routers[i] = fmt.Sprintf("router@%d", i+1)
+	}
+	return routers
 }
 
 // Uninstall unloads the definitions of the specified components.

--- a/deisctl/cmd/cmd_test.go
+++ b/deisctl/cmd/cmd_test.go
@@ -423,6 +423,23 @@ func TestInstallPlatform(t *testing.T) {
 	}
 }
 
+func TestInstallPlatformWithCustomRouterMeshSize(t *testing.T) {
+	t.Parallel()
+
+	b := backendStub{}
+	expected := []string{"store-daemon", "store-monitor", "store-metadata", "store-volume",
+		"store-gateway@1", "logger", "logspout", "database", "registry@1",
+		"controller", "builder", "publisher", "router@1", "router@2", "router@3", "router@4", "router@5"}
+	RouterMeshSize = 5
+
+	Install([]string{"platform"}, &b, fakeCheckKeys)
+	RouterMeshSize = DefaultRouterMeshSize
+
+	if !reflect.DeepEqual(b.installedUnits, expected) {
+		t.Error(fmt.Errorf("Expected %v, Got %v", expected, b.installedUnits))
+	}
+}
+
 func TestInstallStatelessPlatform(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When installing the platform with deisctl, 3 routers are started by
default. This causes an annoying freeze when you use custom component
placement and you have less than 3 instances flagged as routerMesh.
Setting the $DEIS_NUM_ROUTERS variable prior calling "deisctl install
platform" will allow you to choose how many routers are to be installed
in your cluster.