### PR TITLE
chore(registry): use updated registry V1 fork

### DIFF
--- a/registry/build.sh
+++ b/registry/build.sh
@@ -31,7 +31,7 @@ pip install --disable-pip-version-check --no-cache-dir pyopenssl ndg-httpsclient
 adduser -D -s /bin/bash registry
 
 # add the docker registry source from github
-git clone -b new-repository-import-v091 --single-branch https://github.com/deis/docker-registry /docker-registry && \
+git clone -b new-repository-import-master --single-branch https://github.com/deis/docker-registry /docker-registry && \
   chown -R registry:registry /docker-registry
 
 # install boto configuration


### PR DESCRIPTION
See https://github.com/deis/docker-registry/compare/new-repository-import-v091...deis:new-repository-import-master. It was suggested to me at DockerCon that some post-v0.9.1 fixes in classic registry could improve stability, and that `gevent` and/or `gunicorn` had been buggy, so this rebases our fork and updates those packages. If #3814 isn't ready for the next release, this is worth testing to see if it fixes classic registry stability issues.

Refs #3479.