### PR TITLE
fix(registry): run pkill as registry user, removing "-u"

### DIFF
--- a/registry/bin/reload
+++ b/registry/bin/reload
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Send SIGHUP to gunicorn in general, since we didn't launch it with `--pid`
-pkill -HUP -u gunicorn
+sudo -u registry pkill -HUP -f gunicorn || true


### PR DESCRIPTION
The registry reload script had been broken since the busybox / alpine linux version of `pkill` didn't understand the `-u` flag. I tested this command interactively in a running `deis-registry` container, and `-f` is necessary to actually match the `gunicorn` processes as well.

This fixes this type of output (see line 3):
```
--- Run deisci/registry:jenkins-test-ec2-1546 at 10.164.164.159:57631
Error response from daemon: No such container: deis-registry-jenkins-test-ec2-1546
2015-06-30T18:09:43Z 5d0a83f3e232 confd[20]: ERROR "invalid option -- u\nBusyBox v1.22.1 (2015-03-20 11:09:37 GMT) multi-call binary.\n\nUsage: pkill [-l|-SIGNAL] [-fnovx] [-s SID|-P PPID|PATTERN]\n\nSend a signal to process(es) selected by regex PATTERN\n\n\t-l\tList all signals\n\t-f\tMatch against entire command line\n\t-n\tSignal the newest process only\n\t-o\tSignal the oldest process only\n\t-v\tNegate the match\n\t-x\tMatch whole name (not substring)\n\t-s\tMatch session ID (0 for current)\n\t-P\tMatch parent process ID\n\n"
2015-06-30T18:09:43Z 5d0a83f3e232 confd[20]: ERROR exit status 1
registry: waiting for confd to write initial templates...
deis-registry running...
[2015-06-30 18:09:53 +0000] [38] [INFO] Starting gunicorn 19.1.1
[2015-06-30 18:09:53 +0000] [38] [INFO] Listening at: http://0.0.0.0:5000 (38)
[2015-06-30 18:09:53 +0000] [38] [INFO] Using worker: gevent
[2015-06-30 18:09:53 +0000] [51] [INFO] Booting worker with pid: 51
```