### PR TITLE
docs(reference): add missing packages to autodoc

### DIFF
--- a/docs/reference/server/api.authentication.rst
+++ b/docs/reference/server/api.authentication.rst
@@ -1,0 +1,7 @@
+:description: Python API Reference for the Deis api.authentication module
+
+api.authentication
+------------------
+.. contents::
+    :local:
+.. automodule:: api.authentication

--- a/docs/reference/server/api.middleware.rst
+++ b/docs/reference/server/api.middleware.rst
@@ -1,0 +1,7 @@
+:description: Python API Reference for the Deis api.middleware module
+
+api.middleware
+--------------
+.. contents::
+    :local:
+.. automodule:: api.middleware

--- a/docs/reference/server/api.permissions.rst
+++ b/docs/reference/server/api.permissions.rst
@@ -1,0 +1,7 @@
+:description: Python API Reference for the Deis api.permissions module
+
+api.permissions
+---------------
+.. contents::
+    :local:
+.. automodule:: api.permissions

--- a/docs/reference/server/api.viewsets.rst
+++ b/docs/reference/server/api.viewsets.rst
@@ -1,0 +1,7 @@
+:description: Python API Reference for the Deis api.viewsets module
+
+api.viewsets
+------------
+.. contents::
+    :local:
+.. automodule:: api.viewsets

--- a/docs/reference/server/index.rst
+++ b/docs/reference/server/index.rst
@@ -9,14 +9,17 @@ Server Reference
 
 .. toctree::
 
-
     api.admin
+    api.authentication
     api.fields
+    api.middleware
     api.models
+    api.permissions
     api.routers
     api.serializers
     api.utils
     api.views
+    api.viewsets
     registry
     scheduler
     web

--- a/docs/reference/server/scheduler.rst
+++ b/docs/reference/server/scheduler.rst
@@ -3,6 +3,12 @@
 scheduler
 =========
 
+scheduler.chaos
+---------------
+.. contents::
+    :local:
+.. automodule:: scheduler.chaos
+
 scheduler.fleet
 ---------------
 .. contents::
@@ -15,8 +21,14 @@ scheduler.mock
     :local:
 .. automodule:: scheduler.mock
 
-scheduler.chaos
+scheduler.states
+----------------
+.. contents::
+    :local:
+.. automodule:: scheduler.states
+
+scheduler.swarm
 ---------------
 .. contents::
     :local:
-.. automodule:: scheduler.chaos
+.. automodule:: scheduler.swarm


### PR DESCRIPTION
After #3935 fixed our Sphinx autodoc for python, I noticed several modules were missing and added them.