### PR TITLE
fix(builder): set private key perms to 0600

### DIFF
--- a/builder/rootfs/bin/boot
+++ b/builder/rootfs/bin/boot
@@ -113,6 +113,8 @@ function gen_host_keys {
 		etcd_get sshHostKey > /etc/ssh/ssh_host_key
 		etcd_get sshHostPubKey > /etc/ssh/ssh_host_key.pub
 	fi
+	# set private key permissions to 0600
+	chmod 0600 /etc/ssh/ssh_host_*key
 }
 
 gen_host_keys


### PR DESCRIPTION
Tested interactively with `make -C builder/ build deploy`.

Closes #3958.