### PR TITLE
[wip] feat(*): label all of the deis platform components

### DIFF
--- a/deisctl/units/deis-builder.service
+++ b/deisctl/units/deis-builder.service
@@ -8,7 +8,7 @@ ExecStartPre=/bin/sh -c "docker inspect deis-builder-data >/dev/null 2>&1 || doc
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-builder >/dev/null 2>&1 && docker rm -f deis-builder || true"
 ExecStartPre=-/bin/sh -c "/sbin/losetup -f"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker run --name deis-builder --rm -p 2223:2223 --volumes-from=deis-builder-data -c 800 -e EXTERNAL_PORT=2223 -e HOST=$COREOS_PRIVATE_IPV4 --privileged -v /etc/environment_proxy:/etc/environment_proxy $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker run --label io.deis.control=builder --name deis-builder --rm -p 2223:2223 --volumes-from=deis-builder-data -c 800 -e EXTERNAL_PORT=2223 -e HOST=$COREOS_PRIVATE_IPV4 --privileged -v /etc/environment_proxy:/etc/environment_proxy $IMAGE"
 ExecStartPost=/bin/sh -c "echo 'Waiting for builder on 2223/tcp...' && until ncat $COREOS_PRIVATE_IPV4 2223 --exec '/usr/bin/echo dummy-value' >/dev/null 2>&1; do sleep 1; done"
 ExecStop=-/usr/bin/docker stop deis-builder
 Restart=on-failure

--- a/deisctl/units/deis-cache.service
+++ b/deisctl/units/deis-cache.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-cache >/dev/null 2>&1 && docker rm -f deis-cache || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache` && docker run --name deis-cache --rm -p 6379:6379 -e EXTERNAL_PORT=6379 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/cache` && docker run --label io.deis.component=cache --name deis-cache --rm -p 6379:6379 -e EXTERNAL_PORT=6379 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-cache
 Restart=on-failure
 RestartSec=5

--- a/deisctl/units/deis-controller.service
+++ b/deisctl/units/deis-controller.service
@@ -9,7 +9,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-controller >/dev/null 2>&1 && docker rm -f deis-controller || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker run --name deis-controller --rm -p 8000:8000 -e EXTERNAL_PORT=8000 -e HOST=$COREOS_PRIVATE_IPV4 -v /var/run/fleet.sock:/var/run/fleet.sock -v /var/lib/deis/store:/data $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker run --label io.deis.component=controller --name deis-controller --rm -p 8000:8000 -e EXTERNAL_PORT=8000 -e HOST=$COREOS_PRIVATE_IPV4 -v /var/run/fleet.sock:/var/run/fleet.sock -v /var/lib/deis/store:/data $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-controller
 Restart=on-failure
 RestartSec=5

--- a/deisctl/units/deis-database.service
+++ b/deisctl/units/deis-database.service
@@ -7,7 +7,7 @@ TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "docker inspect deis-database-data >/dev/null 2>&1 || docker run --name deis-database-data -v /var/lib/postgresql alpine:3.1 /bin/true"
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-database >/dev/null 2>&1 && docker rm -f deis-database >/dev/null 2>&1 || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker run --name deis-database --rm --volumes-from=deis-database-data -p 5432:5432 -e EXTERNAL_PORT=5432 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker run --label io.deis.component=database --name deis-database --rm --volumes-from=deis-database-data -p 5432:5432 -e EXTERNAL_PORT=5432 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStop=-/usr/bin/docker exec deis-database sudo -u postgres envdir /etc/wal-e.d/env wal-e backup-push /var/lib/postgresql/9.3/main
 ExecStop=-/usr/bin/docker exec deis-database sudo service postgresql stop
 ExecStop=-/usr/bin/docker stop deis-database

--- a/deisctl/units/deis-logger.service
+++ b/deisctl/units/deis-logger.service
@@ -8,7 +8,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-logger >/dev/null 2>&1 && docker rm -f deis-logger || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker run --name deis-logger --rm -p 514:514/udp -e EXTERNAL_PORT=514 -e HOST=$COREOS_PRIVATE_IPV4 -v /var/lib/deis/store:/data $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker run --label io.deis.component=logger --name deis-logger --rm -p 514:514/udp -e EXTERNAL_PORT=514 -e HOST=$COREOS_PRIVATE_IPV4 -v /var/lib/deis/store:/data $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-logger
 Restart=on-failure
 RestartSec=5

--- a/deisctl/units/deis-logspout.service
+++ b/deisctl/units/deis-logspout.service
@@ -8,7 +8,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logspout` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-logspout >/dev/null 2>&1 && docker rm -f deis-logspout || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logspout` && docker run --name deis-logspout --rm -v /var/run/docker.sock:/tmp/docker.sock -e ETCD_HOST=$COREOS_PRIVATE_IPV4 -e HOST=$COREOS_PRIVATE_IPV4 -e DEBUG=1 $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logspout` && docker run --label io.deis.componet=logspout --name deis-logspout --rm -v /var/run/docker.sock:/tmp/docker.sock -e ETCD_HOST=$COREOS_PRIVATE_IPV4 -e HOST=$COREOS_PRIVATE_IPV4 -e DEBUG=1 $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-logspout
 Restart=on-failure
 RestartSec=5

--- a/deisctl/units/deis-publisher.service
+++ b/deisctl/units/deis-publisher.service
@@ -8,7 +8,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-publisher >/dev/null 2>&1 && docker rm -f deis-publisher || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker run --name deis-publisher --rm -v /var/run/docker.sock:/var/run/docker.sock $IMAGE --host=$COREOS_PRIVATE_IPV4 --etcd-host=$COREOS_PRIVATE_IPV4"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker run --label io.deis.component=publisher --name deis-publisher --rm -v /var/run/docker.sock:/var/run/docker.sock $IMAGE --host=$COREOS_PRIVATE_IPV4 --etcd-host=$COREOS_PRIVATE_IPV4"
 ExecStop=-/usr/bin/docker stop deis-publisher
 Restart=on-failure
 RestartSec=5

--- a/deisctl/units/deis-registry.service
+++ b/deisctl/units/deis-registry.service
@@ -7,7 +7,7 @@ TimeoutStartSec=30m
 ExecStartPre=-/usr/bin/etcdctl mkdir /deis/cache >/dev/null 2>&1
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-registry >/dev/null 2>&1 && docker rm -f deis-registry || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docker run --name deis-registry --rm -p 5000:5000 -e EXTERNAL_PORT=5000 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docker run --label io.deis.component=registry --name deis-registry --rm -p 5000:5000 -e EXTERNAL_PORT=5000 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-registry
 Restart=on-failure
 RestartSec=5

--- a/deisctl/units/deis-router.service
+++ b/deisctl/units/deis-router.service
@@ -7,7 +7,7 @@ TimeoutStartSec=20m
 ExecStartPre=-/usr/bin/etcdctl mkdir /registry/services/ >/dev/null 2>&1
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-router >/dev/null 2>&1 && docker rm -f deis-router || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router` && docker run --name deis-router --rm -p 80:80 -p 2222:2222 -p 443:443 -e EXTERNAL_PORT=80 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router` && docker run --label io.deis.component=router --name deis-router --rm -p 80:80 -p 2222:2222 -p 443:443 -e EXTERNAL_PORT=80 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-router
 Restart=on-failure
 RestartSec=5

--- a/deisctl/units/deis-store-admin.service
+++ b/deisctl/units/deis-store-admin.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-admin` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-admin >/dev/null 2>&1 && docker rm -f deis-store-admin >/dev/null 2>&1 || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-admin` && docker run --name deis-store-admin --rm --volumes-from=deis-store-daemon-data --volumes-from=deis-store-monitor-data -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-admin` && docker run --label io.deis.component=store-admin --name deis-store-admin --rm --volumes-from=deis-store-daemon-data --volumes-from=deis-store-monitor-data -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-store-admin
 Restart=on-failure
 RestartSec=5

--- a/deisctl/units/deis-store-daemon.service
+++ b/deisctl/units/deis-store-daemon.service
@@ -8,7 +8,7 @@ ExecStartPre=/bin/sh -c "docker inspect deis-store-daemon-data >/dev/null 2>&1 |
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-daemon` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-daemon >/dev/null 2>&1 && docker rm -f deis-store-daemon >/dev/null 2>&1 || true"
 ExecStartPre=/usr/bin/sleep 10
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-daemon` && docker run --name deis-store-daemon --rm --volumes-from=deis-store-daemon-data -e HOST=$COREOS_PRIVATE_IPV4 -p 6800 --net host $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-daemon` && docker run --label io.deis.component=store-daemon --name deis-store-daemon --rm --volumes-from=deis-store-daemon-data -e HOST=$COREOS_PRIVATE_IPV4 -p 6800 --net host $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-store-daemon
 Restart=on-failure
 RestartSec=5

--- a/deisctl/units/deis-store-gateway.service
+++ b/deisctl/units/deis-store-gateway.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-gateway` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-gateway >/dev/null 2>&1 && docker rm -f deis-store-gateway || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-gateway` && docker run --name deis-store-gateway --rm -h deis-store-gateway -e HOST=$COREOS_PRIVATE_IPV4 -e EXTERNAL_PORT=8888 -p 8888:8888 $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-gateway` && docker run --label io.deis.component=store-gateway --name deis-store-gateway --rm -h deis-store-gateway -e HOST=$COREOS_PRIVATE_IPV4 -e EXTERNAL_PORT=8888 -p 8888:8888 $IMAGE"
 ExecStartPost=/bin/sh -c "until (echo 'Waiting for ceph gateway on 8888/tcp...' && curl -sSL http://localhost:8888|grep -e '<ID>anonymous</ID><DisplayName></DisplayName>' >/dev/null 2>&1); do sleep 1; done"
 ExecStop=-/usr/bin/docker stop deis-store-gateway
 Restart=on-failure

--- a/deisctl/units/deis-store-metadata.service
+++ b/deisctl/units/deis-store-metadata.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-metadata` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-metadata >/dev/null 2>&1 && docker rm -f deis-store-metadata || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-metadata` && docker run --name deis-store-metadata --rm -e HOST=$COREOS_PRIVATE_IPV4 --net host $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-metadata` && docker run --label io.deis.component=store-metadata --name deis-store-metadata --rm -e HOST=$COREOS_PRIVATE_IPV4 --net host $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-store-metadata
 Restart=on-failure
 RestartSec=5

--- a/deisctl/units/deis-store-monitor.service
+++ b/deisctl/units/deis-store-monitor.service
@@ -8,7 +8,7 @@ ExecStartPre=/bin/sh -c "docker inspect deis-store-monitor-data >/dev/null 2>&1 
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-monitor` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "etcdctl set /deis/store/hosts/$COREOS_PRIVATE_IPV4 `hostname` >/dev/null"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-monitor >/dev/null 2>&1 && docker rm -f deis-store-monitor >/dev/null 2>&1 || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-monitor` && docker run --name deis-store-monitor --rm --volumes-from=deis-store-monitor-data -e HOST=$COREOS_PRIVATE_IPV4 -p 6789 --net host $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-monitor` && docker run --label io.deis.component=store-monitor --name deis-store-monitor --rm --volumes-from=deis-store-monitor-data -e HOST=$COREOS_PRIVATE_IPV4 -p 6789 --net host $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-store-monitor
 Restart=on-failure
 RestartSec=5

--- a/deisctl/units/deis-swarm-manager.service
+++ b/deisctl/units/deis-swarm-manager.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/swarm` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-swarm-manager >/dev/null 2>&1 && docker rm -f deis-swarm-manager >/dev/null 2>&1 || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/swarm` && docker run --name deis-swarm-manager --rm -p 2395:2375 -e EXTERNAL_PORT=2395 -e HOST=$COREOS_PRIVATE_IPV4 -v /etc/environment_proxy:/etc/environment_proxy $IMAGE manage"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/swarm` && docker run --label io.deis.component=swarm-manager --name deis-swarm-manager --rm -p 2395:2375 -e EXTERNAL_PORT=2395 -e HOST=$COREOS_PRIVATE_IPV4 -v /etc/environment_proxy:/etc/environment_proxy $IMAGE manage"
 ExecStop=-/usr/bin/docker stop deis-swarm-manager
 Restart=on-failure
 RestartSec=5

--- a/deisctl/units/deis-swarm-node.service
+++ b/deisctl/units/deis-swarm-node.service
@@ -6,7 +6,7 @@ EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/swarm` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-swarm-node >/dev/null 2>&1 && docker rm -f deis-swarm-node >/dev/null 2>&1 || true"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/swarm` && docker run --name deis-swarm-node --rm -e HOST=$COREOS_PRIVATE_IPV4 -v /etc/environment_proxy:/etc/environment_proxy $IMAGE join"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/swarm` && docker run --label io.deis.component=swarm-node --name deis-swarm-node --rm -e HOST=$COREOS_PRIVATE_IPV4 -v /etc/environment_proxy:/etc/environment_proxy $IMAGE join"
 ExecStop=-/usr/bin/docker stop deis-swarm-node
 Restart=on-failure
 RestartSec=5

--- a/deisctl/units/deis-zookeeper.service
+++ b/deisctl/units/deis-zookeeper.service
@@ -8,11 +8,11 @@ EnvironmentFile=/etc/environment
 Restart=on-failure
 RestartSec=20
 TimeoutStartSec=0
-ExecStartPre=/bin/sh -c "docker inspect zookeeper-data >/dev/null 2>&1 || docker run --name zookeeper-data -v /opt/zookeeper-data alpine:3.1 /bin/true"
+ExecStartPre=/bin/sh -c "docker inspect zookeeper-data >/dev/null 2>&1 || docker run --label io.deis.component=zookeeper-data --name zookeeper-data -v /opt/zookeeper-data alpine:3.1 /bin/true"
 ExecStartPre=-/usr/bin/docker kill deis-zookeeper
 ExecStartPre=-/usr/bin/docker rm deis-zookeeper
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/zookeeper` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
-ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/zookeeper` && docker run -e EXTERNAL_PORT=2181 -e HOST=$COREOS_PRIVATE_IPV4 -e LOG_LEVEL=debug --net=host --rm --name deis-zookeeper --volumes-from=zookeeper-data $IMAGE"
+ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/zookeeper` && docker run --label io.deis.component=zookeeper -e EXTERNAL_PORT=2181 -e HOST=$COREOS_PRIVATE_IPV4 -e LOG_LEVEL=debug --net=host --rm --name deis-zookeeper --volumes-from=zookeeper-data $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-zookeeper
 
 [Install]


### PR DESCRIPTION
Requires Docker 1.6, so blocked until that becomes available. Making a PR now for thoughts and discussion!

Some thoughts on a `io.deis` label namespace would be great:
* `io.deis.application=name`
* `io.deis.environment=<production|staging>`

Also mixing in any fleet machine metadata or customer-provided metadata could certainly be useful, but that is largely a thought experiment at the moment.