### PR TITLE
fix(publisher): display http error if connection failed

### DIFF
--- a/publisher/server/publisher.go
+++ b/publisher/server/publisher.go
@@ -186,7 +186,7 @@ func (s *Server) IsPortOpen(hostAndPort string) bool {
 func (s *Server) HealthCheckOK(url string, expectedStatusCode int) bool {
 	resp, err := http.Get(url)
 	if err != nil {
-		log.Printf("healthcheck failed for %s (expected %d, got %v)\n", url, expectedStatusCode, err)
+		log.Printf("healthcheck failed for %s (%v)\n", url, err)
 		return false
 	}
 	if resp.StatusCode == expectedStatusCode {


### PR DESCRIPTION
This fixes a confusing log message:

```
Jul 07 17:49:54 ip-10-21-1-91.us-west-2.compute.internal sh[3320]: 2015/07/07 17:49:53 healthcheck failed for http://10.21.1.91:32811/ (expected 200, got Get http://10.21.1.91:32811/: read tcp 10.21.1.91:32811: connection reset by peer)
```

Now it should read

```
Jul 07 17:49:54 ip-10-21-1-91.us-west-2.compute.internal sh[3320]: 2015/07/07 17:49:53 healthcheck failed for http://10.21.1.91:32811/ (Get http://10.21.1.91:32811/: read tcp 10.21.1.91:32811: connection reset by peer)
```