### PR TITLE
fix(controller): sleep until publisher's refresh interval

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -1058,14 +1058,14 @@ def _etcd_publish_config(**kwargs):
     # deis config:unset would remove an existing value, but not delete the
     # old config object
     try:
-        _etcd_client.delete('/deis/services/{}/config'.format(config.app),
+        _etcd_client.delete('/deis/config/{}'.format(config.app),
                             prevExist=True, dir=True, recursive=True)
     except KeyError:
         pass
     if kwargs['created']:
         for k, v in config.values.iteritems():
             _etcd_client.write(
-                '/deis/services/{}/config/{}'.format(
+                '/deis/config/{}/{}'.format(
                     config.app,
                     unicode(k).encode('utf-8').lower()),
                 unicode(v).encode('utf-8'))
@@ -1074,7 +1074,7 @@ def _etcd_publish_config(**kwargs):
 def _etcd_purge_config(**kwargs):
     config = kwargs['instance']
     try:
-        _etcd_client.delete('/deis/services/{}/config'.format(config.app),
+        _etcd_client.delete('/deis/config/{}'.format(config.app),
                             prevExist=True, dir=True, recursive=True)
     except KeyError:
         pass

--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -314,6 +314,15 @@ class App(UuidAuditedModel):
             pass
 
     def _do_healthcheck(self, config):
+        # HACK (bacongobbler): sleep until publisher has hit the refresh interval. Publisher may
+        # take up to 20 seconds before it refreshes the keyspace containers, which we want to make
+        # sure that they're responding before performing the health check and/or recycle the old
+        # containers.
+        #
+        # The FIXME here would be to utilize confd --watch in both publisher and the router, but
+        # that is blocked dueto an issue upstream with etcd:
+        # https://github.com/coreos/etcd/issues/2679
+        time.sleep(20)
         timeout = time.time() + 60  # 1 minute from now
         while True:
             if time.time() > timeout:

--- a/controller/api/tests/test_build.py
+++ b/controller/api/tests/test_build.py
@@ -24,6 +24,7 @@ def mock_import_repository_task(*args, **kwargs):
     return resp
 
 
+@mock.patch('time.sleep', lambda func: func)
 class BuildTest(TransactionTestCase):
 
     """Tests build notification from build system"""

--- a/controller/api/tests/test_config.py
+++ b/controller/api/tests/test_config.py
@@ -47,6 +47,7 @@ def mock_time(*args, **kwargs):
     return mock_time.counter
 
 
+@mock.patch('time.sleep', lambda func: func)
 class ConfigTest(TransactionTestCase):
 
     """Tests setting and updating config values"""

--- a/controller/api/tests/test_container.py
+++ b/controller/api/tests/test_container.py
@@ -25,6 +25,7 @@ def mock_import_repository_task(*args, **kwargs):
     return resp
 
 
+@mock.patch('time.sleep', lambda func: func)
 class ContainerTest(TransactionTestCase):
     """Tests creation of containers on nodes"""
 

--- a/controller/api/tests/test_hooks.py
+++ b/controller/api/tests/test_hooks.py
@@ -23,6 +23,7 @@ def mock_import_repository_task(*args, **kwargs):
     return resp
 
 
+@mock.patch('time.sleep', lambda func: func)
 class HookTest(TransactionTestCase):
 
     """Tests API hooks used to trigger actions from external components"""

--- a/controller/api/tests/test_release.py
+++ b/controller/api/tests/test_release.py
@@ -24,6 +24,7 @@ def mock_import_repository_task(*args, **kwargs):
     return resp
 
 
+@mock.patch('time.sleep', lambda func: func)
 class ReleaseTest(TransactionTestCase):
 
     """Tests push notification from build system"""

--- a/controller/api/tests/test_scheduler.py
+++ b/controller/api/tests/test_scheduler.py
@@ -7,6 +7,7 @@ Run the tests with "./manage.py test api"
 from __future__ import unicode_literals
 
 import json
+import mock
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -16,6 +17,7 @@ from rest_framework.authtoken.models import Token
 from scheduler import chaos
 
 
+@mock.patch('time.sleep', lambda func: func)
 class SchedulerTest(TransactionTestCase):
     """Tests creation of containers on nodes"""
 

--- a/publisher/server/publisher.go
+++ b/publisher/server/publisher.go
@@ -116,7 +116,7 @@ func (s *Server) publishContainer(container *docker.APIContainers, ttl time.Dura
 			port := strconv.Itoa(int(p.PublicPort))
 			hostAndPort := s.host + ":" + port
 			if s.IsPublishableApp(containerName) && s.IsPortOpen(hostAndPort) {
-				configKey := fmt.Sprintf("/deis/services/%s/config/", appName)
+				configKey := fmt.Sprintf("/deis/config/%s/", appName)
 				// check if the user specified an upcheck URL
 				healthcheckURL := s.getEtcd(configKey + "healthcheck_url")
 				var healthcheckStatusCode int

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -23,6 +23,7 @@ test-full: test-style
 	godep go test -tags integration -v -run TestBuilds
 	godep go test -tags integration -v -run TestConfig
 	godep go test -tags integration -v -run TestDomains
+	godep go test -tags integration -v -run TestHealthcheck
 	godep go test -tags integration -v -run TestKeys
 	godep go test -tags integration -v -run TestPerms
 	godep go test -tags integration -v -run TestPs

--- a/tests/healthcheck_test.go
+++ b/tests/healthcheck_test.go
@@ -1,0 +1,48 @@
+// +build integration
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/deis/deis/tests/utils"
+)
+
+var (
+	healthcheckGoodCmd  = "config:set HEALTHCHECK_URL=/ HEALTHCHECK_STATUS_CODE=200 --app={{.AppName}}"
+	healthcheckBadCmd   = "config:set HEALTHCHECK_URL=/ HEALTHCHECK_STATUS_CODE=999 --app={{.AppName}}"
+	healthcheckUnsetCmd = "config:unset HEALTHCHECK_URL HEALTHCHECK_STATUS_CODE --app={{.AppName}}"
+)
+
+func TestHealthcheck(t *testing.T) {
+	params := healthcheckSetup(t)
+	psScaleTest(t, params, psScaleCmd)
+	utils.Execute(t, healthcheckGoodCmd, params, false, "/")
+	psScaleTest(t, params, psScaleCmd)
+	psScaleTest(t, params, psDownScaleCmd)
+	psScaleTest(t, params, psScaleCmd)
+	utils.Execute(t, healthcheckUnsetCmd, params, false, "")
+	// FIXME (bacongobbler): publisher will not template the app if the status code is incorrect, which means we'll receive
+	// a 404 response from the router.
+	utils.Execute(t, healthcheckBadCmd, params, true, "aborting, app failed health check (got '404', expected: '999')")
+	utils.Execute(t, healthcheckGoodCmd, params, false, "/")
+	appsOpenTest(t, params)
+	utils.AppsDestroyTest(t, params)
+}
+
+func healthcheckSetup(t *testing.T) *utils.DeisTestConfig {
+	cfg := utils.GetGlobalConfig()
+	cfg.AppName = "healthchecksample"
+	utils.Execute(t, authLoginCmd, cfg, false, "")
+	utils.Execute(t, gitCloneCmd, cfg, false, "")
+	if err := utils.Chdir(cfg.ExampleApp); err != nil {
+		t.Fatal(err)
+	}
+	utils.Execute(t, appsCreateCmd, cfg, false, "")
+	utils.Execute(t, gitPushCmd, cfg, false, "")
+	utils.CurlApp(t, *cfg)
+	if err := utils.Chdir(".."); err != nil {
+		t.Fatal(err)
+	}
+	return cfg
+}


### PR DESCRIPTION
Deis' publisher component has a maximum latency of 10 seconds before
it refreshes its config from etcd. For a true zero-downtime
deployment, we want to make sure that the new containers are
templated in the router before performing the health check and/or
recycling the old containers.

The FIXME here would be to utilize confd --watch in the router and in
publisher, but that is blocked due to an [issue upstream with etcd](1).

[1]: coreos/etcd#2679