### PR TITLE
fix(builder): ignore etcdctl stdout in cleanup script

### DIFF
--- a/builder/rootfs/bin/cleanup
+++ b/builder/rootfs/bin/cleanup
@@ -4,6 +4,6 @@ export ETCD=${ETCD:-$HOST:4001}
 
 while true
 do
-    etcdctl -C $ETCD watch --recursive /deis/services
+    etcdctl -C $ETCD watch --recursive /deis/services > /dev/null
     /home/git/check-repos
 done


### PR DESCRIPTION
Changes to the builder `cleanup` script added uninformative log messages because `etcdctl watch` prints the value of the key that triggered it:
```console
$ etcdctl -C 10.21.2.201:4001 watch --recursive /deis/services
10.21.1.47:32788
$ etcdctl -C 10.21.2.201:4001 watch --recursive /deis/services > /dev/null
$
```
This redirects non-error output to `/dev/null`, which will clean up the builder log. Thanks to @bacongobbler for pinpointing the problem.

Closes #3986.