### PR TITLE
chore(*): revert CoreOS to 647.2.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,16 +52,28 @@ def vm_cpus
 end
 
 Vagrant.configure("2") do |config|
-  # always use Vagrants insecure key
+  # always use Vagrant's insecure key
   config.ssh.insert_key = false
-
   config.vm.box = "coreos-%s" % $update_channel
-  config.vm.box_version = "= 647.2.0"
-  config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
+
+  # HACK to bypass the limitation of the CoreOS "current" metadata for boxes -
+  # it only specifies the latest release, so we cannot use it for older releases.
+  # TODO(carmstrong) we can remove this once we're back to using "specific release or more recent"
+  if $update_channel == "stable"
+    config.vm.box_version = "= 647.2.0"
+    config.vm.box_url = "http://stable.release.core-os.net/amd64-usr/647.2.0/coreos_production_vagrant.json"
+  else
+    config.vm.box_version = ">= 681.2.0"
+    config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
+  end
 
   ["vmware_fusion", "vmware_workstation"].each do |vmware|
     config.vm.provider vmware do |v, override|
-      override.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json" % $update_channel
+      if $update_channel == "stable"
+        override.vm.box_url = "http://stable.release.core-os.net/amd64-usr/647.2.0/coreos_production_vagrant_vmware_fusion.json" % $update_channel
+      else
+        override.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json" % $update_channel
+      end
     end
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
 
   config.vm.box = "coreos-%s" % $update_channel
-  config.vm.box_version = ">= 681.2.0"
+  config.vm.box_version = "= 647.2.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
 
   ["vmware_fusion", "vmware_workstation"].each do |vmware|

--- a/contrib/azure/azure-coreos-cluster
+++ b/contrib/azure/azure-coreos-cluster
@@ -35,8 +35,8 @@ parser.add_argument('--affinity-group', default='',
                    help='optional, overrides location if specified')
 parser.add_argument('--ssh', default=22001, type=int,
                    help='optional, starts with 22001 and +1 for each machine in cluster')
-parser.add_argument('--coreos-image', default='2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-681.2.0',
-                   help='optional, [2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-681.2.0]')
+parser.add_argument('--coreos-image', default='2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-647.2.0',
+                   help='optional, [2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-647.2.0]')
 parser.add_argument('--num-nodes', default=3, type=int,
                    help='optional, number of nodes to create (or add), defaults to 3')
 parser.add_argument('--virtual-network-name',

--- a/contrib/ec2/deis.template.json
+++ b/contrib/ec2/deis.template.json
@@ -44,7 +44,7 @@
         "m4.xlarge",
         "m4.2xlarge",
         "m4.4xlarge",
-        "m4.10xlarge",        
+        "m4.10xlarge",
         "m1.medium",
         "m1.large",
         "m1.xlarge",
@@ -128,17 +128,16 @@
 
   "Mappings" : {
     "CoreOSAMIs" : {
-      "eu-central-1"   : { "PV" : "ami-e8e5ddf5", "HVM" : "ami-eae5ddf7" },
-      "ap-northeast-1" : { "PV" : "ami-1c6fca1c", "HVM" : "ami-1a6fca1a" },
-      "us-gov-west-1"  : { "PV" : "ami-ef9fffcc", "HVM" : "ami-e99fffca" },
-      "sa-east-1"      : { "PV" : "ami-b3cb49ae", "HVM" : "ami-b1cb49ac" },
-      "ap-southeast-2" : { "PV" : "ami-2d641e17", "HVM" : "ami-23641e19" },
-      "ap-southeast-1" : { "PV" : "ami-d803078a", "HVM" : "ami-da030788" },
-      "us-east-1"      : { "PV" : "ami-91ea17fa", "HVM" : "ami-93ea17f8" },
-      "us-west-2"      : { "PV" : "ami-5f4d486f", "HVM" : "ami-5d4d486d" },
-      "us-west-1"      : { "PV" : "ami-cb67938f", "HVM" : "ami-c967938d" },
-      "eu-west-1"      : { "PV" : "ami-512f5526", "HVM" : "ami-5f2f5528" }
-
+      "eu-central-1"   : { "PV" : "ami-fe6b52e3", "HVM" : "ami-f86b52e5" },
+      "ap-northeast-1" : { "PV" : "ami-9ec1119e", "HVM" : "ami-9cc1119c" },
+      "us-gov-west-1"  : { "PV" : "ami-854828a6", "HVM" : "ami-874828a4" },
+      "sa-east-1"      : { "PV" : "ami-d9b839c4", "HVM" : "ami-d5b839c8" },
+      "ap-southeast-2" : { "PV" : "ami-7985fc43", "HVM" : "ami-7b85fc41" },
+      "ap-southeast-1" : { "PV" : "ami-d4033b86", "HVM" : "ami-da033b88" },
+      "us-east-1"      : { "PV" : "ami-c16583aa", "HVM" : "ami-c36583a8" },
+      "us-west-2"      : { "PV" : "ami-995f60a9", "HVM" : "ami-975f60a7" },
+      "us-west-1"      : { "PV" : "ami-877a92c3", "HVM" : "ami-857a92c1" },
+      "eu-west-1"      : { "PV" : "ami-e38cfc94", "HVM" : "ami-e18cfc96" }
     },
     "RootDevices" : {
       "HVM" : { "Name": "/dev/xvda" },

--- a/contrib/linode/provision-linode-cluster.py
+++ b/contrib/linode/provision-linode-cluster.py
@@ -413,7 +413,7 @@ if __name__ == '__main__':
                                   help='Node data center id. Use list-data-centers to find the id.')
     provision_parser.add_argument('--cloud-config', required=False, default='linode-user-data.yaml', type=file, dest='cloud_config',
                                   help='CoreOS cloud config user-data file')
-    provision_parser.add_argument('--coreos-version', required=False, default='695.2.0', dest='coreos_version',
+    provision_parser.add_argument('--coreos-version', required=False, default='647.2.0', dest='coreos_version',
                                   help='CoreOS version number to install')
     provision_parser.add_argument('--coreos-channel', required=False, default='beta', dest='coreos_channel',
                                   help='CoreOS channel to install from')

--- a/contrib/rackspace/provision-rackspace-cluster.sh
+++ b/contrib/rackspace/provision-rackspace-cluster.sh
@@ -49,7 +49,7 @@ $CONTRIB_DIR/util/check-user-data.sh
 i=1 ; while [[ $i -le $DEIS_NUM_INSTANCES ]] ; do \
     echo_yellow "Provisioning deis-$i..."
     # This image is CoreOS 633.1.0 in the stable channel
-    # TODO: Update to 681.2.0 when it's available in the stable channel
+    # TODO: Update to 647.2.0 when it's available in the stable channel
     supernova $ENV boot --image a41d8b7c-d41b-4369-a180-0734f3b1cd8c --flavor $FLAVOR --key-name $1 --user-data $CONTRIB_DIR/coreos/user-data --no-service-net --nic net-id=$NETWORK_ID --config-drive true deis-$i ; \
     ((i = i + 1)) ; \
 done

--- a/docs/installing_deis/baremetal.rst
+++ b/docs/installing_deis/baremetal.rst
@@ -104,8 +104,8 @@ Start the installation
 
 
 This will install the latest `CoreOS`_ stable release to disk. The Deis provision scripts for other
-platforms typically specify a CoreOS version - currently, ``681.2.0``. To specify a CoreOS
-version, append the ``-V`` parameter to the install command, e.g. ``-V 681.2.0``.
+platforms typically specify a CoreOS version - currently, ``647.2.0``. To specify a CoreOS
+version, append the ``-V`` parameter to the install command, e.g. ``-V 647.2.0``.
 
 After the installation has finished, reboot your server. Once your machine is back up, you should
 be able to log in as the `core` user using the `deis` ssh key.

--- a/docs/installing_deis/gce.rst
+++ b/docs/installing_deis/gce.rst
@@ -118,7 +118,7 @@ Launch 3 instances. You can choose another starting CoreOS image from the listin
       --metadata-from-file user-data=gce-user-data sshKeys=~/.ssh/deis.pub \
       --disk name=cored${num} device-name=coredocker \
       --tags deis \
-      --image coreos-stable-681-2-0-v20150618 \
+      --image coreos-stable-647-2-0-v20150528 \
       --image-project coreos-cloud;
     done
 


### PR DESCRIPTION
Newer CoreOS releases include Docker 1.6, which is fundaementally
broken for simultaneous pulls of the same filesystem layers -
see https://github.com/docker/docker/issues/9997