### PR TITLE
docs(managing_deis): rename stateless platform docs

### DIFF
--- a/docs/managing_deis/index.rst
+++ b/docs/managing_deis/index.rst
@@ -21,7 +21,7 @@ Managing Deis
     platform_monitoring
     production_deployments
     recovering-ceph-quorum
-    running-stateless-cluster
+    running-deis-without-ceph
     security_considerations
     ssl-endpoints
     upgrading-deis

--- a/docs/managing_deis/production_deployments.rst
+++ b/docs/managing_deis/production_deployments.rst
@@ -9,12 +9,12 @@ Production deployments
 Many Deis users are running Deis quite successfully in production. When readying a Deis deployment
 for production workloads, there are some additional (but optional) recommendations.
 
-Running a stateless control plane
----------------------------------
+Running Deis without Ceph
+-------------------------
 
 .. include:: ../_includes/_ceph-dependency-description.rst
 
-See :ref:`running-stateless-cluster` for details on removing this operational
+See :ref:`running-deis-without-ceph` for details on removing this operational
 complexity.
 
 Preseeding containers

--- a/docs/managing_deis/running-deis-without-ceph.rst
+++ b/docs/managing_deis/running-deis-without-ceph.rst
@@ -1,10 +1,10 @@
-:title: Running a stateless cluster
+:title: Running Deis without Ceph
 :description: Configuring the cluster to remove Ceph from the control plane.
 
-.. _running-stateless-cluster:
+.. _running-deis-without-ceph:
 
-Running a stateless cluster
-===========================
+Running Deis without Ceph
+=========================
 
 .. include:: ../_includes/_ceph-dependency-description.rst
 


### PR DESCRIPTION
@gabrtv pointed out that calling it a stateless platform isn't quite yet correct. Even though the `deisctl` command is `deisctl install stateless-platform`, clarifying the documentation should be sufficient.