### PR TITLE
[WIP] chore(*): use etcd2

### DIFF
--- a/contrib/azure/azure-coreos-cluster
+++ b/contrib/azure/azure-coreos-cluster
@@ -68,7 +68,7 @@ coreos:
     addr: $private_ipv4:4001
     peer-addr: $private_ipv4:7001
   units:
-    - name: etcd.service
+    - name: etcd2.service
       command: start
     - name: fleet.service
       command: start

--- a/contrib/azure/create-azure-user-data
+++ b/contrib/azure/create-azure-user-data
@@ -62,7 +62,7 @@ def main():
     configuration = combine_dicts(configuration_coreos_template,
                                   configuration_azure_template)
 
-    configuration["coreos"]["etcd"]["discovery"] = url
+    configuration["coreos"]["etcd2"]["discovery"] = url
 
     with azure_user_data as outfile:
         try:

--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -1,16 +1,17 @@
 #cloud-config
 ---
 coreos:
-  etcd:
+  etcd2:
     # generate a new token for each unique cluster from https://discovery.etcd.io/new
     # uncomment the following line and replace it with your discovery URL
     # discovery: https://discovery.etcd.io/12345693838asdfasfadf13939923
-    addr: $private_ipv4:4001
-    peer-addr: $private_ipv4:7001
     # give etcd more time if it's under heavy load - prevent leader election thrashing
-    peer-election-timeout: 2000
-    # heartbeat interval should ideally be 1/4 or 1/5 of peer election timeout
-    peer-heartbeat-interval: 500
+    election-timeout: 2000
+    heartbeat-interval: 200
+    listen-peer-urls: "http://$private_ipv4:2380,http://$private_ipv4:7001"
+    listen-client-urls: "http://localhost:2379,http://localhost:4001,http://$private_ipv4:2379,http://$private_ipv4:4001"
+    advertise-client-urls: "http://$private_ipv4:2379,http://$private_ipv4:4001"
+    initial-advertise-peer-urls: "http://$private_ipv4:2380,http://$private_ipv4:7001"
   fleet:
     # We have to set the public_ip here so this works on Vagrant -- otherwise, Vagrant VMs
     # will all publish the same private IP. This is harmless for cloud providers.
@@ -19,6 +20,8 @@ coreos:
     etcd_request_timeout: 3.0
   units:
   - name: etcd.service
+    mask: true
+  - name: etcd2.service
     command: start
   - name: docker-tcp.socket
     command: start
@@ -48,8 +51,8 @@ coreos:
       [Unit]
       Description=Clean up
       DefaultDependencies=no
-      After=fleet.service etcd.service docker.service docker.socket deis-store-admin.service deis-store-daemon.service deis-store-volume.service deis-store-monitor.service
-      Requires=fleet.service etcd.service deis-store-admin.service deis-store-daemon.service deis-store-volume.service docker.service docker.socket deis-store-monitor.service
+      After=fleet.service etcd2.service docker.service docker.socket deis-store-admin.service deis-store-daemon.service deis-store-volume.service deis-store-monitor.service
+      Requires=fleet.service etcd2.service deis-store-admin.service deis-store-daemon.service deis-store-volume.service docker.service docker.socket deis-store-monitor.service
 
       [Install]
       WantedBy=shutdown.target halt.target reboot.target

--- a/contrib/ec2/gen-json.py
+++ b/contrib/ec2/gen-json.py
@@ -59,7 +59,7 @@ PREPARE_ETCD_DATA_DIRECTORY = '''
   Description=Prepares the etcd data directory
   Requires=media-etcd.mount
   After=media-etcd.mount
-  Before=etcd.service
+  Before=etcd2.service
   [Service]
   Type=oneshot
   RemainAfterExit=yes
@@ -88,7 +88,7 @@ data = yaml.load(file(os.path.join(CURR_DIR, '..', 'coreos', 'user-data'), 'r'))
 data['coreos']['units'] = new_units + data['coreos']['units']
 
 # configure etcd to use its EBS volume
-data['coreos']['etcd']['data-dir'] = '/media/etcd'
+data['coreos']['etcd2']['data-dir'] = '/media/etcd'
 
 header = ["#cloud-config", "---"]
 dump = yaml.dump(data, default_flow_style=False)

--- a/contrib/gce/create-gce-user-data
+++ b/contrib/gce/create-gce-user-data
@@ -62,7 +62,7 @@ def main():
     configuration = combine_dicts(configuration_coreos_template,
                                   configuration_gce_template)
 
-    configuration["coreos"]["etcd"]["discovery"] = url
+    configuration["coreos"]["etcd2"]["discovery"] = url
 
     with gce_user_data as outfile:
         try:

--- a/contrib/util/check-user-data.sh
+++ b/contrib/util/check-user-data.sh
@@ -26,7 +26,7 @@ function parse_yaml {
 }
 
 if [[ $NUM_INSTANCES -ne 1 ]] ; then
-    parse_yaml $USER_DATA | grep -q coreos_etcd_discovery
+    parse_yaml $USER_DATA | grep -q coreos_etcd2_discovery
     if [[ $? -ne 0 ]]; then
         echo "No etcd discovery URL set in $USER_DATA"
         exit 1

--- a/deisctl/units/deis-logspout.service
+++ b/deisctl/units/deis-logspout.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=deis-logspout
-Requires=docker.socket etcd.service
-After=docker.socket etcd.service
+Requires=docker.socket etcd2.service
+After=docker.socket etcd2.service
 
 [Service]
 EnvironmentFile=/etc/environment

--- a/deisctl/units/deis-publisher.service
+++ b/deisctl/units/deis-publisher.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=deis-publisher
-Requires=docker.socket etcd.service
-After=docker.socket etcd.service
+Requires=docker.socket etcd2.service
+After=docker.socket etcd2.service
 
 [Service]
 EnvironmentFile=/etc/environment


### PR DESCRIPTION
This commit configures hosts to use etcd2. Note that it doesn't
yet have upgrade logic between the versions. We also don't run
etcd2 in a container (even though it's recommended by
@kelseyhightower) because of the following reasons:

* An additional network dependency on startup until host is operational
  (pulling the container from Quay)
* Additional complexity customizing the unit to bind-mount different
  etcd data locations depending on the provider
* The version of etcdctl on the host won't necessarily match the
  version of etcd (relatively minor)

replaces #3748
closes #3564