### PR TITLE
fix(controller): revert HTTP healthcheck feature

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -299,45 +299,6 @@ class App(UuidAuditedModel):
         if set([c.state for c in to_add]) != set(['up']):
             err = 'warning, some containers failed to start'
             log_event(self, err, logging.WARNING)
-        # if the user specified a health check, try checking to see if it's running
-        try:
-            config = self.config_set.latest()
-            if 'HEALTHCHECK_URL' in config.values.keys():
-                # check the app to see if it's healthy
-                try:
-                    self._do_healthcheck(config)
-                except Exception as e:
-                    log_event(self, str(e), logging.ERROR)
-                    self._destroy_containers(to_add)
-                    raise
-        except Config.DoesNotExist:
-            pass
-
-    def _do_healthcheck(self, config):
-        timeout = time.time() + 60  # 1 minute from now
-        while True:
-            if time.time() > timeout:
-                raise RuntimeError(
-                    'app failed to respond to health check within 60 seconds of launch')
-            try:
-                response = requests.get(
-                    'http://{}{}'.format(
-                        self.url,
-                        config.values['HEALTHCHECK_URL']),
-                    timeout=5)
-                expected_status_code = config.values['HEALTHCHECK_STATUS_CODE'] if \
-                    'HEALTHCHECK_STATUS_CODE' in config.values.keys() else \
-                    settings.DEIS_HEALTHCHECK_STATUS_CODE
-                if str(response.status_code) != str(expected_status_code):
-                    err = "aborting, app failed health check (got '{}', expected: '{}')".format(
-                        response.status_code,
-                        expected_status_code)
-                    raise RuntimeError(err)
-                break
-            except requests.exceptions.ConnectionError:
-                continue
-            except requests.exceptions.Timeout:
-                continue
 
     def _restart_containers(self, to_restart):
         """Restarts containers via the scheduler"""
@@ -1043,34 +1004,6 @@ def _etcd_purge_app(**kwargs):
         pass
 
 
-def _etcd_publish_config(**kwargs):
-    config = kwargs['instance']
-    # we purge all existing config when adding the newest instance. This is because
-    # deis config:unset would remove an existing value, but not delete the
-    # old config object
-    try:
-        _etcd_client.delete('/deis/services/{}/config'.format(config.app),
-                            prevExist=True, dir=True, recursive=True)
-    except KeyError:
-        pass
-    if kwargs['created']:
-        for k, v in config.values.iteritems():
-            _etcd_client.write(
-                '/deis/services/{}/config/{}'.format(
-                    config.app,
-                    unicode(k).encode('utf-8').lower()),
-                unicode(v).encode('utf-8'))
-
-
-def _etcd_purge_config(**kwargs):
-    config = kwargs['instance']
-    try:
-        _etcd_client.delete('/deis/services/{}/config'.format(config.app),
-                            prevExist=True, dir=True, recursive=True)
-    except KeyError:
-        pass
-
-
 def _etcd_publish_cert(**kwargs):
     cert = kwargs['instance']
     if kwargs['created']:
@@ -1136,5 +1069,3 @@ if _etcd_client:
     post_delete.connect(_etcd_purge_app, sender=App, dispatch_uid='api.models')
     post_save.connect(_etcd_publish_cert, sender=Certificate, dispatch_uid='api.models')
     post_delete.connect(_etcd_purge_cert, sender=Certificate, dispatch_uid='api.models')
-    post_save.connect(_etcd_publish_config, sender=Config, dispatch_uid='api.models')
-    post_delete.connect(_etcd_purge_config, sender=Config, dispatch_uid='api.models')

--- a/controller/deis/settings.py
+++ b/controller/deis/settings.py
@@ -290,9 +290,6 @@ DEIS_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S%Z'
 # names which apps cannot reserve for routing
 DEIS_RESERVED_NAMES = ['deis']
 
-# the default expected status code for healthchecks
-DEIS_HEALTHCHECK_STATUS_CODE = '200'
-
 # default scheduler settings
 SCHEDULER_MODULE = 'scheduler.mock'
 SCHEDULER_TARGET = ''  # path to scheduler endpoint (e.g. /var/run/fleet.sock)

--- a/docs/managing_deis/backing_up_data.rst
+++ b/docs/managing_deis/backing_up_data.rst
@@ -212,7 +212,6 @@ use in the ``export`` command should correspond to the IP of the host machine wh
     [a.save() for a in App.objects.all()]
     [d.save() for d in Domain.objects.all()]
     [c.save() for c in Certificate.objects.all()]
-    [c.save() for c in Config.objects.all()]
     EOF
     $ exit
 

--- a/docs/using_deis/config-application.rst
+++ b/docs/using_deis/config-application.rst
@@ -91,27 +91,6 @@ appname to the old one:
     an application, however you can work around this by pointing the @ record to the
     address of the load balancer (if any).
 
-Custom Health Checks
---------------------
-
-By default, Deis checks if the container is running for health checks. You can change both
-the healthcheck URL and the expected status code by setting custom config:
-
-.. code-block:: console
-
-    $ deis config:set HEALTHCHECK_URL=/404.html
-    === peachy-waxworks
-    HEALTHCHECK_URL: /404.html
-    $ deis config:set HEALTHCHECK_STATUS_CODE=404
-    === peachy-waxworks
-    HEALTHCHECK_STATUS_CODE: 404
-    HEALTHCHECK_URL: /404.html
-
-If a new release does not pass the healthcheck, the application will be rolled back to the previous
-release. Beyond that, if an application container responds to a heartbeat check with a different
-status than is expected, the :ref:`router` will mark that container as down and stop sending
-requests to that container.
-
 Track Changes
 -------------
 Each time a build or config change is made to your application, a new :ref:`release` is created.

--- a/publisher/server/publisher.go
+++ b/publisher/server/publisher.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"net/http"
 	"regexp"
 	"strconv"
 	"sync"
@@ -116,19 +115,6 @@ func (s *Server) publishContainer(container *docker.APIContainers, ttl time.Dura
 			port := strconv.Itoa(int(p.PublicPort))
 			hostAndPort := s.host + ":" + port
 			if s.IsPublishableApp(containerName) && s.IsPortOpen(hostAndPort) {
-				configKey := fmt.Sprintf("/deis/services/%s/config/", appName)
-				// check if the user specified an upcheck URL
-				healthcheckURL := s.getEtcd(configKey + "healthcheck_url")
-				var healthcheckStatusCode int
-				healthcheckStatusCode, err := strconv.Atoi(s.getEtcd(configKey + "healthcheck_status_code"))
-				if err != nil {
-					healthcheckStatusCode = 200
-				}
-				if healthcheckURL != "" {
-					if !s.HealthCheckOK("http://"+hostAndPort+healthcheckURL, healthcheckStatusCode) {
-						continue
-					}
-				}
 				s.setEtcd(keyPath, hostAndPort, uint64(ttl.Seconds()))
 				safeMap.Lock()
 				safeMap.data[container.ID] = appPath
@@ -183,19 +169,6 @@ func (s *Server) IsPortOpen(hostAndPort string) bool {
 	return portOpen
 }
 
-func (s *Server) HealthCheckOK(url string, expectedStatusCode int) bool {
-	resp, err := http.Get(url)
-	if err != nil {
-		log.Printf("healthcheck failed for %s (%v)\n", url, err)
-		return false
-	}
-	if resp.StatusCode == expectedStatusCode {
-		return true
-	}
-	log.Printf("healthcheck failed for %s (expected %d, got %d)\n", url, expectedStatusCode, resp.StatusCode)
-	return false
-}
-
 // latestRunningVersion retrieves the highest version of the application published
 // to etcd. If no app has been published, returns 0.
 func latestRunningVersion(client *etcd.Client, appName string) int {
@@ -238,21 +211,6 @@ func max(n []int) int {
 		}
 	}
 	return val
-}
-
-// getEtcd retrieves the etcd key's value. Returns an empty string if the key was not found.
-func (s *Server) getEtcd(key string) string {
-	if s.logLevel == "debug" {
-		log.Println("get", key)
-	}
-	resp, err := s.EtcdClient.Get(key, false, false)
-	if err != nil {
-		return ""
-	}
-	if resp != nil && resp.Node != nil {
-		return resp.Node.Value
-	}
-	return ""
 }
 
 // setEtcd sets the corresponding etcd key with the value and ttl

--- a/publisher/server/publisher_test.go
+++ b/publisher/server/publisher_test.go
@@ -1,10 +1,7 @@
 package server
 
 import (
-	"fmt"
 	"net"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
@@ -46,20 +43,5 @@ func TestIsPortOpen(t *testing.T) {
 	}
 	if s.IsPortOpen("127.0.0.1:-1") {
 		t.Errorf("Port should be closed")
-	}
-}
-
-func TestHealthCheckOK(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "Hello, client")
-	}))
-	defer ts.Close()
-
-	s := &Server{}
-	if !s.HealthCheckOK(ts.URL, 200) {
-		t.Errorf("Health check should be OK")
-	}
-	if s.HealthCheckOK("127.0.0.1:-1", 200) {
-		t.Errorf("Health check should be NOT OK")
 	}
 }

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -11,13 +11,12 @@ import (
 )
 
 var (
-	configListCmd           = "config:list --app={{.AppName}}"
-	configSetCmd            = "config:set FOO=讲台 --app={{.AppName}}"
-	configSet2Cmd           = "config:set FOO=10 --app={{.AppName}}"
-	configSet3Cmd           = "config:set POWERED_BY=\"the Deis team\" --app={{.AppName}}"
-	configSetBuildpackCmd   = "config:set BUILDPACK_URL=$BUILDPACK_URL --app={{.AppName}}"
-	configSetHealthcheckCmd = "config:set HEALTHCHECK_URL=/ --app={{.AppName}}"
-	configUnsetCmd          = "config:unset FOO --app={{.AppName}}"
+	configListCmd         = "config:list --app={{.AppName}}"
+	configSetCmd          = "config:set FOO=讲台 --app={{.AppName}}"
+	configSet2Cmd         = "config:set FOO=10 --app={{.AppName}}"
+	configSet3Cmd         = "config:set POWERED_BY=\"the Deis team\" --app={{.AppName}}"
+	configSetBuildpackCmd = "config:set BUILDPACK_URL=$BUILDPACK_URL --app={{.AppName}}"
+	configUnsetCmd        = "config:unset FOO --app={{.AppName}}"
 )
 
 var buildpacks = map[string]string{
@@ -91,8 +90,6 @@ func configSetTest(t *testing.T, params *utils.DeisTestConfig) {
 	utils.CheckList(t, appsInfoCmd, params, "(v5)", false)
 	utils.Execute(t, configSet2Cmd, params, false, "10")
 	utils.CheckList(t, appsInfoCmd, params, "(v6)", false)
-	utils.Execute(t, configSetHealthcheckCmd, params, false, "/")
-	utils.CheckList(t, appsInfoCmd, params, "(v7)", false)
 }
 
 func configPushTest(t *testing.T, params *utils.DeisTestConfig) {
@@ -104,7 +101,7 @@ func configPushTest(t *testing.T, params *utils.DeisTestConfig) {
 		t.Fatal(err)
 	}
 	utils.Execute(t, "config:push --app {{.AppName}}", params, false, "Deis")
-	utils.CheckList(t, appsInfoCmd, params, "(v8)", false)
+	utils.CheckList(t, appsInfoCmd, params, "(v7)", false)
 	if err := utils.Chdir(".."); err != nil {
 		t.Fatal(err)
 	}
@@ -112,6 +109,6 @@ func configPushTest(t *testing.T, params *utils.DeisTestConfig) {
 
 func configUnsetTest(t *testing.T, params *utils.DeisTestConfig) {
 	utils.Execute(t, configUnsetCmd, params, false, "")
-	utils.CheckList(t, appsInfoCmd, params, "(v9)", false)
+	utils.CheckList(t, appsInfoCmd, params, "(v8)", false)
 	utils.CheckList(t, "run env --app={{.AppName}}", params, "FOO", true)
 }


### PR DESCRIPTION
this new feature does not give the user a true zero-downtime effect as what was expected from #3813, so in order to ship 1.8 we're pulling it out and going to try again for v1.9. I'll also be closing #3982 and re-introducing a new PR for this.

re-opens #3813.