### PR TITLE
fix(deisctl): Exit deisctl when start/stop hits state failed.

### DIFF
--- a/deisctl/backend/fleet/start.go
+++ b/deisctl/backend/fleet/start.go
@@ -86,6 +86,12 @@ func doStart(c *FleetClient, target string, wg *sync.WaitGroup, out, ew io.Write
 		}
 
 		lastSubState = currentState.SystemdSubState
+
+		if lastSubState == "failed" {
+			o := prettyprint.Colorize("{{.Red}}The service '%s' failed while starting.{{.Default}}\n")
+			fmt.Fprintf(ew, o, target)
+			return
+		}
 		time.Sleep(250 * time.Millisecond)
 	}
 }

--- a/deisctl/backend/fleet/stop.go
+++ b/deisctl/backend/fleet/stop.go
@@ -88,6 +88,13 @@ func doStop(c *FleetClient, target string, wg *sync.WaitGroup, out, ew io.Writer
 		}
 
 		lastSubState = currentState.SystemdSubState
+
+		if lastSubState == "failed" {
+			o := prettyprint.Colorize("{{.Red}}The service '%s' failed while starting.{{.Default}}\n")
+			fmt.Fprintf(ew, o, target)
+			return
+		}
+
 		time.Sleep(250 * time.Millisecond)
 	}
 }

--- a/deisctl/utils/utils_test.go
+++ b/deisctl/utils/utils_test.go
@@ -1,9 +1,7 @@
 package utils
 
 import (
-	"fmt"
 	"os"
-	"strings"
 	"testing"
 )
 
@@ -18,28 +16,5 @@ func TestResolvePath(t *testing.T) {
 		if resolved != expected {
 			t.Errorf("Test failed: expected %s, got %s", expected, resolved)
 		}
-	}
-}
-
-func TestColorize(t *testing.T) {
-	out := Colorize("{{.Red}}Hello {{.Default}}World{{.UnderGreen}}!{{.Default}}")
-	expected := "\033[0;31mHello \033[0mWorld\033[4;32m!\033[0m"
-	if out != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, out)
-	}
-}
-
-func ExampleColorize() {
-	out := Colorize("{{.Red}}Hello {{.Default}}World{{.UnderGreen}}!{{.Default}}")
-	fmt.Println(out)
-}
-
-func TestDeisIfy(t *testing.T) {
-	d := DeisIfy("Test")
-	if strings.Contains(d, "Deis1") {
-		t.Errorf("Failed to compile template")
-	}
-	if !strings.Contains(d, "Test") {
-		t.Errorf("Failed to render template")
 	}
 }

--- a/deisctl/utils/utils_test.go
+++ b/deisctl/utils/utils_test.go
@@ -1,7 +1,9 @@
 package utils
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -16,5 +18,28 @@ func TestResolvePath(t *testing.T) {
 		if resolved != expected {
 			t.Errorf("Test failed: expected %s, got %s", expected, resolved)
 		}
+	}
+}
+
+func TestColorize(t *testing.T) {
+	out := Colorize("{{.Red}}Hello {{.Default}}World{{.UnderGreen}}!{{.Default}}")
+	expected := "\033[0;31mHello \033[0mWorld\033[4;32m!\033[0m"
+	if out != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, out)
+	}
+}
+
+func ExampleColorize() {
+	out := Colorize("{{.Red}}Hello {{.Default}}World{{.UnderGreen}}!{{.Default}}")
+	fmt.Println(out)
+}
+
+func TestDeisIfy(t *testing.T) {
+	d := DeisIfy("Test")
+	if strings.Contains(d, "Deis1") {
+		t.Errorf("Failed to compile template")
+	}
+	if !strings.Contains(d, "Test") {
+		t.Errorf("Failed to render template")
 	}
 }


### PR DESCRIPTION
This fixes issue #3880. In start and stop commands, when the state hits failed (regardless of the expected state), deisctl exits.