### PR TITLE
fix(router): add set-misc module to nginx build

### DIFF
--- a/router/build.sh
+++ b/router/build.sh
@@ -16,7 +16,7 @@ function get_src {
   f=$(basename $url)
 
   curl -sSL $url -o $f
-  echo "$hash $f" | sha256sum -c - || exit 10
+  echo "$hash  $f" | sha256sum -c - || exit 10
   tar xzf $f
   rm $f
 }

--- a/router/build.sh
+++ b/router/build.sh
@@ -10,9 +10,21 @@ if [[ -z $DOCKER_BUILD ]]; then
   exit 1
 fi
 
+function get_src {
+  hash=$1
+  url=$2
+  f=$(basename $url)
+
+  curl -sSL $url -o $f
+  echo "$hash $f" | sha256sum -c - || exit 10
+  tar xzf $f
+  rm $f
+}
+
 export VERSION_NGINX=nginx-1.9.2
-export SHA256_NGINX=80b6425be14a005c8cb15115f3c775f4bc06bf798aa1affaee84ed9cf641ed78
 export VERSION_NAXSI=0d53a64ed856e694fcb4038748c8cf6d5551a603
+export VERSION_NDK=0.2.19
+export VERSION_SETMISC=0.29
 
 export BUILD_PATH=/tmp/build
 
@@ -38,14 +50,18 @@ apk add --update-cache \
   zlib \
   zlib-dev
 
-# grab the source files
-curl -sSL http://nginx.org/download/$VERSION_NGINX.tar.gz -o $BUILD_PATH/$VERSION_NGINX.tar.gz
-echo "$SHA256_NGINX *$VERSION_NGINX.tar.gz" | sha256sum -c - || exit 10
-curl -sSL https://github.com/nbs-system/naxsi/archive/$VERSION_NAXSI.tar.gz -o $BUILD_PATH/$VERSION_NAXSI.tar.gz
+# download, verify and extract the source files
+get_src 80b6425be14a005c8cb15115f3c775f4bc06bf798aa1affaee84ed9cf641ed78 \
+        http://nginx.org/download/$VERSION_NGINX.tar.gz
 
-# expand the source files
-tar xzf $VERSION_NGINX.tar.gz
-tar xzf $VERSION_NAXSI.tar.gz
+get_src 128b56873eedbd3f240dc0f88a8b260d791321db92f14ba2fc5c49fc5307e04d \
+        https://github.com/nbs-system/naxsi/archive/$VERSION_NAXSI.tar.gz
+
+get_src 501f299abdb81b992a980bda182e5de5a4b2b3e275fbf72ee34dd7ae84c4b679 \
+        https://github.com/simpl/ngx_devel_kit/archive/v$VERSION_NDK.tar.gz
+
+get_src 8d280fc083420afb41dbe10df9a8ceec98f1d391bd2caa42ebae67d5bc9295d8 \
+        https://github.com/openresty/set-misc-nginx-module/archive/v$VERSION_SETMISC.tar.gz
 
 # build nginx
 cd $BUILD_PATH/$VERSION_NGINX
@@ -70,6 +86,8 @@ cd $BUILD_PATH/$VERSION_NGINX
   --with-mail_ssl_module \
   --with-stream \
   --add-module=$BUILD_PATH/naxsi-$VERSION_NAXSI/naxsi_src \
+  --add-module=$BUILD_PATH/ngx_devel_kit-$VERSION_NDK \
+  --add-module=$BUILD_PATH/set-misc-nginx-module-$VERSION_SETMISC \
   && make && make install
 
 mv /tmp/firewall /opt/nginx/firewall


### PR DESCRIPTION
The commit c7c895c fixes the affinityArg hashing issue by using the
`set_random` directive on the nginx configuration, but forgets to
include the module in which it is declared. This commit fixes this,
while also tries to make the build script a little cleaner and
include integrity checks for all downloads.

Closes #3964.

Replaces #4008.

Includes (and extends) verifications added by #3954.