### PR TITLE
fix(logger): use one ticker for all time-related operations

### DIFF
--- a/logger/main.go
+++ b/logger/main.go
@@ -47,7 +47,6 @@ func main() {
 	ticker := time.NewTicker(time.Duration(publishInterval) * time.Second)
 	signalChan := make(chan os.Signal, 1)
 	drainChan := make(chan string)
-	stopChan := make(chan bool)
 	exitChan := make(chan bool)
 	cleanupChan := make(chan bool)
 	signal.Notify(signalChan, syscall.SIGTERM, syscall.SIGINT)
@@ -82,7 +81,6 @@ func main() {
 			}
 		case <-signalChan:
 			close(exitChan)
-			stopChan <- true
 		case <-cleanupChan:
 			ticker.Stop()
 			return


### PR DESCRIPTION
In a separate goroutine, we were sleeping for the exact same time as
publishInterval was set to. As @kalbasit mentioned in [a comment][1],
it's better to use a ticker anyways. This removes one extra underlying
system call to clock_gettime() by making both publishKeys() and the
log drain poll share the same ticker event.

refs #4030, as I found this using the .scap dump. I don't think this will
drop the CPU usage significantly, but it's a start.

[1]: https://github.com/deis/deis/pull/3795#discussion_r31878237