### PR TITLE
fix(commit-msg): ignore comments in line count

### DIFF
--- a/contrib/util/commit-msg
+++ b/contrib/util/commit-msg
@@ -67,7 +67,7 @@ fi
 cnt=${#MESSAGE[@]}
 for (( i = 3 ; i <= cnt ; i++ ))
 do
-		if [[ ${#MESSAGE[$i]} -gt 72 ]]; then
+		if [[ ${#MESSAGE[$i]} -gt 72 ]] && [[ ${MESSAGE[$i]:0:1} != '#' ]]; then
 			echo "${RED}ERROR on line $i -  can't be longer than 72 characters."
 			echo ""
 			echo "Read more at http://docs.deis.io/en/latest/contributing/standards/$NORMAL"
@@ -75,6 +75,6 @@ do
 		fi
 done
 
-echo "Your commit message follows the deis commit style"
+echo "Your commit message follows the deis commit style."
 
 exit 0


### PR DESCRIPTION
`git commit ammend` has comments about the files changed. If you had a comment longer than the limit the hook would throw an error. Now the hook ignores comments.