### PR TITLE
docs(requirements): remove old warning about clang

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -1,8 +1,5 @@
 # Deis controller requirements
 #
-# NOTE: For testing on Mac OS X Mavericks, use the following to work around a clang issue:
-# ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future pip install [args]
-#
 Django==1.6.11
 django-cors-headers==1.0.0
 # required for south migrations

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,9 +18,6 @@ Please add any issues you find with this documentation to the
     (docs)$ pip install -r docs_requirements.txt
     ```
 
-    See comments at the top of the ``docs_requirements.txt`` file if you
-    have problems with this step on Mac OS X Mavericks.
-
 2. Build the documentation and host it on a local web server:
 
     ```console

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -4,9 +4,6 @@
 # one requirements file. Please keep it up-to-date with the root
 # requirements.txt and dev_requirements.txt files.
 #
-# NOTE: For testing on Mac OS X Mavericks, use the following to work around a clang issue:
-# ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future pip install [args]
-#
 Django==1.6.11
 django-cors-headers==1.0.0
 # required for south migrations


### PR DESCRIPTION
This warning text helped to build the python gevent library
when Apple's compiler first switched to clang, but has not
been necessary to build Deis on Mavericks or Yosemite 
for a long time now.