### PR TITLE
docs(concepts): remove unlinked 'the'

### DIFF
--- a/docs/understanding_deis/concepts.rst
+++ b/docs/understanding_deis/concepts.rst
@@ -103,7 +103,7 @@ See Also
 * :ref:`Architecture`
 * :ref:`Using Deis <using_deis>`
 * :ref:`Managing Deis <managing_deis>`
-* The `Twelve-Factor App`_
+* `Twelve-Factor App`_
 
 
 .. _`Twelve-Factor App`: http://12factor.net/


### PR DESCRIPTION
The `the` was unlinked and I think it looks better missing. Feel free to close if others think it looks better unchanged.
<img width="657" alt="screen shot 2015-07-16 at 5 01 49 pm" src="https://cloud.githubusercontent.com/assets/3526404/8737893/7ab90d8e-2bdc-11e5-8988-3cbcb07e7c6c.png">
