### PR TITLE
feat(database): backup the db on unit stop

### DIFF
--- a/deisctl/units/deis-database.service
+++ b/deisctl/units/deis-database.service
@@ -8,6 +8,7 @@ ExecStartPre=/bin/sh -c "docker inspect deis-database-data >/dev/null 2>&1 || do
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-database >/dev/null 2>&1 && docker rm -f deis-database >/dev/null 2>&1 || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker run --name deis-database --rm --volumes-from=deis-database-data -p 5432:5432 -e EXTERNAL_PORT=5432 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
+ExecStopPost=-/usr/bin/docker exec deis-database sudo -u postgres envdir /etc/wal-e.d/env wal-e backup-push /var/lib/postgresql/9.3/main
 ExecStopPost=-/usr/bin/docker exec deis-database sudo service postgresql stop
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
When performing an upgrade, any db records added since the last backup are lost. This becomes obvious when testing upgrades, but should occur anytime the database is stopped and started.

The thought here is that a backup be done proactively on stop to avoid it. Maybe theres a better place for it, but this does "work".