### PR TITLE
fix(Makefiles): silence static binary check

### DIFF
--- a/builder/Makefile
+++ b/builder/Makefile
@@ -16,7 +16,9 @@ BINARY_DEST_DIR := rootfs/usr/bin
 build: check-docker
 	for i in $(BINARIES); do \
 		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix cgo -ldflags '-s' -o $(BINARY_DEST_DIR)/$$i src/$$i.go || exit 1; \
-		$(call check-static-binary,$(BINARY_DEST_DIR)/$$i) \
+	done
+	@for i in $(BINARIES); do \
+		$(call check-static-binary,$(BINARY_DEST_DIR)/$$i); \
 	done
 	docker build -t $(IMAGE) rootfs
 

--- a/cache/Makefile
+++ b/cache/Makefile
@@ -13,7 +13,7 @@ BINARY_DEST_DIR = image/bin
 
 build: check-docker
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix cgo -ldflags '-s' -o $(BINARY_DEST_DIR)/boot main.go || exit 1
-	$(call check-static-binary,$(BINARY_DEST_DIR)/boot)
+	@$(call check-static-binary,$(BINARY_DEST_DIR)/boot)
 	docker build -t $(IMAGE) image
 
 clean: check-docker check-registry

--- a/logger/Makefile
+++ b/logger/Makefile
@@ -15,7 +15,7 @@ BINARY_DEST_DIR = image/bin
 
 build: check-docker
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix cgo -ldflags '-s' -o $(BINARY_DEST_DIR)/logger github.com/deis/deis/logger || exit 1
-	$(call check-static-binary,$(BINARY_DEST_DIR)/logger)
+	@$(call check-static-binary,$(BINARY_DEST_DIR)/logger)
 	docker build -t $(IMAGE) image
 
 clean: check-docker check-registry

--- a/logspout/Makefile
+++ b/logspout/Makefile
@@ -14,7 +14,7 @@ DEV_DOCKER_IMAGE := $(REGISTRY)$(RELEASE_IMAGE)
 
 build: check-docker
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix cgo -ldflags '-s' -o image/logspout
-	$(call check-static-binary,image/logspout)
+	@$(call check-static-binary,image/logspout)
 	docker build -t $(RELEASE_IMAGE) image
 
 clean:

--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -15,7 +15,7 @@ BINARY_DEST_DIR = image/bin
 
 build: check-docker
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix cgo -ldflags '-s' -o $(BINARY_DEST_DIR)/publisher github.com/deis/deis/publisher || exit 1
-	$(call check-static-binary,$(BINARY_DEST_DIR)/publisher)
+	@$(call check-static-binary,$(BINARY_DEST_DIR)/publisher)
 	docker build -t $(RELEASE_IMAGE) image
 
 clean: check-docker check-registry

--- a/router/Makefile
+++ b/router/Makefile
@@ -18,7 +18,7 @@ build: check-docker
 	docker build -t $(BUILD_IMAGE) .
 	docker cp `docker run -d $(BUILD_IMAGE) /bin/bash`:/nginx.tgz image/
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix -v -ldflags '-s' -o $(BINARY_DEST_DIR)/boot boot.go || exit 1
-	$(call check-static-binary,image/bin/boot)
+	@$(call check-static-binary,image/bin/boot)
 	docker build -t $(IMAGE) image
 	rm image/nginx.tgz
 	rm image/bin/boot


### PR DESCRIPTION
The [`check-static-binary`](https://github.com/deis/deis/blob/master/includes.mk#L55) Makefile function echoes itself to stdout with every invocation. This silences it unless it actually finds an error.

ping @technosophos