### PR TITLE
fix(client-go): defer deferred closing of body until after error check.

### DIFF
--- a/client-go/controller/client/auth.go
+++ b/client-go/controller/client/auth.go
@@ -37,11 +37,11 @@ func Register(controllerURL url.URL, username string, password string, email str
 	addUserAgent(&headers)
 
 	res, err := rawRequest(client, "POST", controllerURL.String(), bytes.NewBuffer(body), headers, 201)
-	defer res.Body.Close()
 
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
 
 	fmt.Printf("Registered %s\n", username)
 
@@ -72,11 +72,11 @@ func Login(controllerURL url.URL, username string, password string, sslVerify bo
 	addUserAgent(&headers)
 
 	res, err := rawRequest(client, "POST", controllerURL.String(), bytes.NewBuffer(body), headers, 200)
-	defer res.Body.Close()
 
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
 
 	resBody, err := ioutil.ReadAll(res.Body)
 

--- a/client-go/controller/client/http.go
+++ b/client-go/controller/client/http.go
@@ -87,9 +87,9 @@ func (c Client) BasicRequest(method string, path string, body []byte) (string, i
 	if err != nil {
 		return "", -1, err
 	}
+	defer res.Body.Close()
 
 	resBody, err := ioutil.ReadAll(res.Body)
-	defer res.Body.Close()
 
 	if err != nil {
 		return "", -1, err
@@ -114,12 +114,12 @@ Make sure that the Controller URI is correct and the server is running.`
 	}
 
 	res, err := client.Do(req)
-	defer res.Body.Close()
 
 	if err != nil {
 		fmt.Printf(errorMessage+"\n", baseURL)
 		return err
 	}
+	defer res.Body.Close()
 
 	if res.StatusCode != 401 {
 		return fmt.Errorf(errorMessage, baseURL)


### PR DESCRIPTION
If the request aborted due to an error the body didn't exist and
the deferred function would throw a nil pointer exception.

Reported by yebyen on IRC.

Example panic: http://pastebin.com/NsjfvEWf