### PR TITLE
fix(Dockerfiles): silence apt-get TTY warnings

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:3.1
 
-ENV DEBIAN_FRONTEND noninteractive
-
 # install common packages
 RUN apk add --update-cache curl bash sudo && rm -rf /var/cache/apk/*
 

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:3.1
 
-ENV DEBIAN_FRONTEND noninteractive
-
 # install common packages
 RUN apk add --update-cache curl bash sudo && rm -rf /var/cache/apk/*
 

--- a/mesos/build-marathon
+++ b/mesos/build-marathon
@@ -1,5 +1,6 @@
 FROM deis/mesos-template:#VERSION#
 
+ENV DEBIAN_FRONTEND noninteractive
 ENV MARATHON_VERSION=#MARATHON_VERSION#
 
 COPY build-marathon-jar.sh /tmp/build.sh

--- a/mesos/template
+++ b/mesos/template
@@ -1,5 +1,7 @@
 FROM ubuntu-debootstrap:14.04
 
+ENV DEBIAN_FRONTEND noninteractive
+
 COPY build-mesos.sh /tmp/build.sh
 
 RUN DOCKER_BUILD=true MESOS="#VERSION#" /tmp/build.sh

--- a/router/image/Dockerfile
+++ b/router/image/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:3.1
 
-ENV DEBIAN_FRONTEND noninteractive
-
 # install common packages
 RUN apk add --update-cache curl bash sudo && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
The mesos components didn't all set `DEBIAN_FRONTEND` to `noninteractive`, so there were several build warnings about not finding a TTY. Additionally, some Alpine images still had a vestigial `DEBIAN_FRONTEND` statement.