### PR TITLE
fix(builder):wait until push-images script exists

### DIFF
--- a/builder/rootfs/bin/boot
+++ b/builder/rootfs/bin/boot
@@ -119,6 +119,12 @@ function gen_host_keys {
 
 gen_host_keys
 
+# wait until confd generates the push-images script
+while [[ ! -e /usr/local/bin/push-images ]]; do
+	echo "waiting for confd to generate '/usr/local/bin/push-images'..."
+	sleep 1
+done
+
 # start an SSH daemon to process `git push` requests
 /usr/sbin/sshd -D -e &
 SSHD_PID=$!


### PR DESCRIPTION
Fix for random error:
```
Jul 21 22:46:12 ip-10-21-2-14.us-west-2.compute.internal systemd[1]: Starting deis-builder...
Jul 21 22:46:12 ip-10-21-2-14.us-west-2.compute.internal sh[26341]: deis-builder
Jul 21 22:46:12 ip-10-21-2-14.us-west-2.compute.internal sh[26370]: /dev/loop0
Jul 21 22:46:12 ip-10-21-2-14.us-west-2.compute.internal sh[26374]: Waiting for builder on 2223/tcp...
Jul 21 22:46:13 ip-10-21-2-14.us-west-2.compute.internal docker[26493]: 2015/07/21 22:46:13 docker-exec: failed to exec: exec: "/usr/local/bin/push-images": stat /usr/local/bin/push-images: no such file or directory
Jul 21 22:46:13 ip-10-21-2-14.us-west-2.compute.internal systemd[1]: deis-builder.service: control process exited, code=exited status=1
Jul 21 22:46:13 ip-10-21-2-14.us-west-2.compute.internal systemd[1]: Failed to start deis-builder.
Jul 21 22:46:13 ip-10-21-2-14.us-west-2.compute.internal systemd[1]: Unit deis-builder.service entered failed state.
Jul 21 22:46:13 ip-10-21-2-14.us-west-2.compute.internal systemd[1]: deis-builder.service failed.
Jul 21 22:46:18 ip-10-21-2-14.us-west-2.compute.internal systemd[1]: deis-builder.service holdoff time over, scheduling restart.
```