### PR TITLE
fix(mesos): build images with prefix and tag

### DIFF
--- a/mesos/Makefile
+++ b/mesos/Makefile
@@ -2,9 +2,7 @@ include ../includes.mk
 
 REPO = deis
 MESOS = 0.22.1-1.0.ubuntu1404
-MESOS_VERSION = v1.9.0
 ZOOKEEPER_VERSION = 3.5.0
-
 MARATHON_VERSION = 0.8.2-RC3
 
 repo_path = github.com/deis/deis/mesos
@@ -83,21 +81,21 @@ mesos-go: setup-gotools
 
 mesos-template:
 	sed "s/#VERSION#/$(MESOS)/g" template > Dockerfile
-	docker build -t $(IMAGE_PREFIX)$@:$(MESOS_VERSION) .
+	docker build -t $(IMAGE_PREFIX)$@:$(BUILD_TAG) .
 	rm -f Dockerfile
 
 mesos-master: mesos-go mesos-template
-	sed "s/#VERSION#/$(MESOS_VERSION)/g" master > Dockerfile
+	sed "s@#PREFIX#@$(IMAGE_PREFIX)@;s/#VERSION#/$(BUILD_TAG)/g" master > Dockerfile
 	docker build -t $(IMAGE_PREFIX)$@:$(BUILD_TAG) .
 	rm -f Dockerfile
 
 mesos-slave: mesos-go mesos-template
-	sed "s/#VERSION#/$(MESOS_VERSION)/g" slave > Dockerfile
+	sed "s@#PREFIX#@$(IMAGE_PREFIX)@;s/#VERSION#/$(BUILD_TAG)/g" slave > Dockerfile
 	docker build -t $(IMAGE_PREFIX)$@:$(BUILD_TAG) .
 	rm -f Dockerfile
 
 build-mesos-marathon: mesos-template
-	sed "s/#MARATHON_VERSION#/$(MARATHON_VERSION)/;s/#VERSION#/$(MESOS_VERSION)/" build-marathon > Dockerfile
+	sed "s/#MARATHON_VERSION#/$(MARATHON_VERSION)/;s@#PREFIX#@$(IMAGE_PREFIX)@;s/#VERSION#/$(BUILD_TAG)/g" build-marathon > Dockerfile
 	docker build -t $(IMAGE_PREFIX)$@:$(BUILD_TAG) .
 	rm -f Dockerfile
 
@@ -105,7 +103,7 @@ mesos-marathon: mesos-go build-mesos-marathon
 	cp marathon Dockerfile
 	docker cp `docker create $(IMAGE_PREFIX)build-mesos-marathon:$(BUILD_TAG) /bin/bash`:/marathon/target/marathon-assembly-$(MARATHON_VERSION).jar .
 	mv marathon-assembly-$(MARATHON_VERSION).jar marathon-assembly.jar
-	sed "s/#MARATHON_VERSION#/$(MARATHON_VERSION)/;s/#VERSION#/$(MESOS_VERSION)/" marathon > Dockerfile
+	sed "s/#MARATHON_VERSION#/$(MARATHON_VERSION)/;s@#PREFIX#@$(IMAGE_PREFIX)@;s/#VERSION#/$(BUILD_TAG)/" marathon > Dockerfile
 	docker build -t $(IMAGE_PREFIX)$@:$(BUILD_TAG) .
 	rm -f Dockerfile
 

--- a/mesos/build-marathon
+++ b/mesos/build-marathon
@@ -1,4 +1,4 @@
-FROM deis/mesos-template:#VERSION#
+FROM #PREFIX#mesos-template:#VERSION#
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV MARATHON_VERSION=#MARATHON_VERSION#

--- a/mesos/marathon
+++ b/mesos/marathon
@@ -1,4 +1,4 @@
-FROM deis/mesos-template:#VERSION#
+FROM #PREFIX#mesos-template:#VERSION#
 
 EXPOSE 8080
 

--- a/mesos/master
+++ b/mesos/master
@@ -1,4 +1,4 @@
-FROM deis/mesos-template:#VERSION#
+FROM #PREFIX#mesos-template:#VERSION#
 
 COPY bin/master-boot /app/bin/boot
 

--- a/mesos/slave
+++ b/mesos/slave
@@ -1,4 +1,4 @@
-FROM deis/mesos-template:#VERSION#
+FROM #PREFIX#mesos-template:#VERSION#
 
 COPY bin/slave-boot /app/bin/boot
 

--- a/mesos/template
+++ b/mesos/template
@@ -5,3 +5,5 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY build-mesos.sh /tmp/build.sh
 
 RUN DOCKER_BUILD=true MESOS="#VERSION#" /tmp/build.sh
+
+ENV DEIS_RELEASE 1.9.0-dev

--- a/mesos/zookeeper/Dockerfile
+++ b/mesos/zookeeper/Dockerfile
@@ -15,3 +15,4 @@ VOLUME ["/opt/zookeeper-data"]
 
 ENTRYPOINT ["/app/bin/boot"]
 
+ENV DEIS_RELEASE 1.9.0-dev


### PR DESCRIPTION
Ensure that the mesos-* and zookeeper images honor the same env vars used in other "make build" targets, and add the `DEIS_RELEASE` variable.

The `IMAGE_PREFIX` variable contains a trailing slash, so I used `@` as an alternate separator for `sed`.

ping @smothiki 