### PR TITLE
fix(deisctl): exit when stop/start fails

### DIFF
--- a/deisctl/backend/fleet/start.go
+++ b/deisctl/backend/fleet/start.go
@@ -86,6 +86,12 @@ func doStart(c *FleetClient, target string, wg *sync.WaitGroup, out, ew io.Write
 		}
 
 		lastSubState = currentState.SystemdSubState
+
+		if lastSubState == "failed" {
+			o := prettyprint.Colorize("{{.Red}}The service '%s' failed while starting.{{.Default}}\n")
+			fmt.Fprintf(ew, o, target)
+			return
+		}
 		time.Sleep(250 * time.Millisecond)
 	}
 }

--- a/deisctl/backend/fleet/stop.go
+++ b/deisctl/backend/fleet/stop.go
@@ -88,6 +88,13 @@ func doStop(c *FleetClient, target string, wg *sync.WaitGroup, out, ew io.Writer
 		}
 
 		lastSubState = currentState.SystemdSubState
+
+		if lastSubState == "failed" {
+			o := prettyprint.Colorize("{{.Red}}The service '%s' failed while stopping.{{.Default}}\n")
+			fmt.Fprintf(ew, o, target)
+			return
+		}
+
 		time.Sleep(250 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
This fixes issue #3880, where a failed start or stop command will hang
deisctl. The fix simply prints out an error message and exits from the
resolution loop.