### PR TITLE
feature(deisctl) allow for graceful in-place upgrades

### DIFF
--- a/deisctl/backend/backend.go
+++ b/deisctl/backend/backend.go
@@ -12,6 +12,7 @@ type Backend interface {
 	Start([]string, *sync.WaitGroup, io.Writer, io.Writer)
 	Stop([]string, *sync.WaitGroup, io.Writer, io.Writer)
 	Scale(string, int, *sync.WaitGroup, io.Writer, io.Writer)
+	RollingRestart(string, *sync.WaitGroup, io.Writer, io.Writer)
 	SSH(string) error
 	SSHExec(string, string) error
 	ListUnits() error

--- a/deisctl/backend/fleet/rolling_restart.go
+++ b/deisctl/backend/fleet/rolling_restart.go
@@ -1,0 +1,37 @@
+package fleet
+
+import (
+	"fmt"
+	"io"
+	"sync"
+)
+
+// RollingRestart for instance units
+func (c *FleetClient) RollingRestart(component string, wg *sync.WaitGroup, out, ew io.Writer) {
+	if component != "router" {
+		fmt.Fprint(ew, "invalid component. supported for: router")
+		return
+	}
+
+	components, err := c.Units(component)
+	if err != nil {
+		io.WriteString(ew, err.Error())
+		return
+	}
+	if len(components) < 1 {
+		fmt.Fprint(ew, "rolling restart requires at least 1 component")
+		return
+	}
+	for num := range components {
+		unitName := fmt.Sprintf("%s@%v", component, num+1)
+
+		c.Stop([]string{unitName}, wg, out, ew)
+		wg.Wait()
+		c.Destroy([]string{unitName}, wg, out, ew)
+		wg.Wait()
+		c.Create([]string{unitName}, wg, out, ew)
+		wg.Wait()
+		c.Start([]string{unitName}, wg, out, ew)
+		wg.Wait()
+	}
+}

--- a/deisctl/client/client.go
+++ b/deisctl/client/client.go
@@ -28,6 +28,9 @@ type DeisCtlClient interface {
 	Status(argv []string) error
 	Stop(argv []string) error
 	Uninstall(argv []string) error
+	UpgradePrep(argv []string) error
+	UpgradeTakeover(argv []string) error
+	RollingRestart(argv []string) error
 }
 
 // Client uses a backend to implement the DeisCtlClient interface.
@@ -55,6 +58,49 @@ func NewClient(requestedBackend string) (*Client, error) {
 		return nil, errors.New("invalid backend")
 	}
 	return &Client{Backend: backend}, nil
+}
+
+// UpgradePrep prepares a running cluster to be upgraded
+func (c *Client) UpgradePrep(argv []string) error {
+	usage := `Prepare platform for graceful upgrade.
+
+Usage:
+  deisctl upgrade-prep [options]
+`
+	if _, err := docopt.Parse(usage, argv, true, "", false); err != nil {
+		return err
+	}
+
+	return cmd.UpgradePrep(c.Backend)
+}
+
+// UpgradeTakeover gracefully restarts a cluster prepared with upgrade-prep
+func (c *Client) UpgradeTakeover(argv []string) error {
+	usage := `Complete the upgrade of a prepped cluster.
+
+Usage:
+  deisctl upgrade-takeover [options]
+`
+	if _, err := docopt.Parse(usage, argv, true, "", false); err != nil {
+		return err
+	}
+
+	return cmd.UpgradeTakeover(c.Backend)
+}
+
+// RollingRestart attempts a rolling restart of an instance unit
+func (c *Client) RollingRestart(argv []string) error {
+	usage := `Perform a rolling restart of an instance unit.
+
+Usage:
+  deisctl rolling-restart <target>
+`
+	args, err := docopt.Parse(usage, argv, true, "", false)
+	if err != nil {
+		return err
+	}
+
+	return cmd.RollingRestart(args["<target>"].(string), c.Backend)
 }
 
 // Config gets or sets a configuration value from the cluster.

--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -97,6 +97,16 @@ func Start(targets []string, b backend.Backend) error {
 	return nil
 }
 
+// RollingRestart restart instance unit in a rolling manner
+func RollingRestart(target string, b backend.Backend) error {
+	var wg sync.WaitGroup
+
+	b.RollingRestart(target, &wg, Stdout, Stderr)
+	wg.Wait()
+
+	return nil
+}
+
 // CheckRequiredKeys exist in etcd
 func CheckRequiredKeys() error {
 	if err := config.CheckConfig("/deis/platform/", "domain"); err != nil {

--- a/deisctl/cmd/upgrade.go
+++ b/deisctl/cmd/upgrade.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/deis/deis/deisctl/backend"
+	"github.com/deis/deis/deisctl/etcdclient"
+)
+
+// UpgradePrep stops and uninstalls all components except router and publisher
+func UpgradePrep(b backend.Backend) error {
+	var wg sync.WaitGroup
+
+	b.Stop([]string{"database", "registry@*", "controller", "builder", "logger", "logspout"}, &wg, Stdout, Stderr)
+	wg.Wait()
+	b.Destroy([]string{"database", "registry@*", "controller", "builder", "logger", "logspout"}, &wg, Stdout, Stderr)
+	wg.Wait()
+
+	b.Stop([]string{"store-volume", "store-gateway@*"}, &wg, Stdout, Stderr)
+	wg.Wait()
+	b.Destroy([]string{"store-volume", "store-gateway@*"}, &wg, Stdout, Stderr)
+	wg.Wait()
+
+	b.Stop([]string{"store-metadata"}, &wg, Stdout, Stderr)
+	wg.Wait()
+	b.Destroy([]string{"store-metadata"}, &wg, Stdout, Stderr)
+	wg.Wait()
+
+	b.Stop([]string{"store-daemon"}, &wg, Stdout, Stderr)
+	wg.Wait()
+	b.Destroy([]string{"store-daemon"}, &wg, Stdout, Stderr)
+	wg.Wait()
+
+	b.Stop([]string{"store-monitor"}, &wg, Stdout, Stderr)
+	wg.Wait()
+	b.Destroy([]string{"store-monitor"}, &wg, Stdout, Stderr)
+	wg.Wait()
+
+	fmt.Fprintln(Stdout, "The platform has been stopped, but applications are still serving traffic as normal.")
+	fmt.Fprintln(Stdout, "Your cluster is now ready for upgrade. Install a new deisctl version and run `deisctl upgrade-takeover`.")
+	fmt.Fprintln(Stdout, "For more details, see: http://docs.deis.io/en/latest/managing_deis/upgrading-deis/#graceful-upgrade")
+	return nil
+}
+
+func listPublishedServices(etcdClient etcdclient.Client) ([]*etcdclient.ServiceKey, error) {
+	nodes, err := etcdClient.GetRecursive("deis/services")
+	if err != nil {
+		return nil, err
+	}
+
+	return nodes, nil
+}
+
+func republishServices(ttl uint64, nodes []*etcdclient.ServiceKey, etcdClient etcdclient.Client) error {
+	for _, node := range nodes {
+		_, err := etcdClient.Update(node.Key, node.Value, ttl)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// UpgradeTakeover gracefully starts a platform stopped with UpgradePrep
+func UpgradeTakeover(b backend.Backend) error {
+	etcdClient, err := etcdclient.GetEtcdClient()
+	if err != nil {
+		return err
+	}
+
+	if err := doUpgradeTakeOver(b, etcdClient); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func doUpgradeTakeOver(b backend.Backend, etcdClient etcdclient.Client) error {
+	var wg sync.WaitGroup
+
+	nodes, err := listPublishedServices(etcdClient)
+	if err != nil {
+		return err
+	}
+
+	b.Stop([]string{"publisher"}, &wg, Stdout, Stderr)
+	wg.Wait()
+	b.Destroy([]string{"publisher"}, &wg, Stdout, Stderr)
+	wg.Wait()
+
+	if err := republishServices(1800, nodes, etcdClient); err != nil {
+		return err
+	}
+
+	b.RollingRestart("router", &wg, Stdout, Stderr)
+	wg.Wait()
+	b.Create([]string{"publisher"}, &wg, Stdout, Stderr)
+	wg.Wait()
+	b.Start([]string{"publisher"}, &wg, Stdout, Stderr)
+	wg.Wait()
+
+	installDefaultServices(b, false, &wg, Stdout, Stderr) // @fixme: hax?
+	wg.Wait()
+
+	startDefaultServices(b, false, &wg, Stdout, Stderr) // @fixme: hax?
+	wg.Wait()
+	return nil
+}

--- a/deisctl/config/api.go
+++ b/deisctl/config/api.go
@@ -1,8 +1,0 @@
-package config
-
-// Client interface used for configuration
-type Client interface {
-	Get(string) (string, error)
-	Set(string, string) (string, error)
-	Delete(string) error
-}

--- a/deisctl/config/config.go
+++ b/deisctl/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/deis/deis/deisctl/etcdclient"
 	"github.com/deis/deis/deisctl/utils"
 )
 
@@ -23,7 +24,7 @@ var b64Keys = []string{"/deis/platform/sshPrivateKey"}
 
 // Config runs the config subcommand
 func Config(target string, action string, key []string) error {
-	client, err := getEtcdClient()
+	client, err := etcdclient.GetEtcdClient()
 	if err != nil {
 		return err
 	}
@@ -35,7 +36,7 @@ func Config(target string, action string, key []string) error {
 // and returns an error if a value is not found
 func CheckConfig(root string, k string) error {
 
-	client, err := getEtcdClient()
+	client, err := etcdclient.GetEtcdClient()
 	if err != nil {
 		return err
 	}
@@ -48,7 +49,7 @@ func CheckConfig(root string, k string) error {
 	return nil
 }
 
-func doConfig(target string, action string, key []string, client Client, w io.Writer) error {
+func doConfig(target string, action string, key []string, client etcdclient.Client, w io.Writer) error {
 	rootPath := "/deis/" + target + "/"
 
 	var vals []string
@@ -73,7 +74,7 @@ func doConfig(target string, action string, key []string, client Client, w io.Wr
 	return nil
 }
 
-func doConfigSet(client Client, root string, kvs []string) ([]string, error) {
+func doConfigSet(client etcdclient.Client, root string, kvs []string) ([]string, error) {
 	var result []string
 
 	for _, kv := range kvs {
@@ -100,7 +101,7 @@ func doConfigSet(client Client, root string, kvs []string) ([]string, error) {
 	return result, nil
 }
 
-func doConfigGet(client Client, root string, keys []string) ([]string, error) {
+func doConfigGet(client etcdclient.Client, root string, keys []string) ([]string, error) {
 	var result []string
 	for _, k := range keys {
 		val, err := client.Get(root + k)
@@ -112,7 +113,7 @@ func doConfigGet(client Client, root string, keys []string) ([]string, error) {
 	return result, nil
 }
 
-func doConfigRm(client Client, root string, keys []string) ([]string, error) {
+func doConfigRm(client etcdclient.Client, root string, keys []string) ([]string, error) {
 	var result []string
 	for _, k := range keys {
 		err := client.Delete(root + k)

--- a/deisctl/config/config_test.go
+++ b/deisctl/config/config_test.go
@@ -7,50 +7,15 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/deis/deis/deisctl/etcdclient"
+	"github.com/deis/deis/deisctl/test/mock"
 )
-
-type KVPair struct {
-	key   string
-	value string
-}
-
-type MockStore []KVPair
-
-type mockClient struct {
-	expected MockStore
-}
-
-func (m mockClient) Get(key string) (value string, err error) {
-	for _, expect := range m.expected {
-		if expect.key == key {
-			return expect.value, nil
-		}
-	}
-	return "", fmt.Errorf("%s does not exist", m.expected)
-}
-
-func (m mockClient) Set(key, value string) (returnedValue string, err error) {
-	for _, expect := range m.expected {
-		if expect.key == key {
-			return value, nil
-		}
-	}
-	return "", fmt.Errorf("%s does not exist", m.expected)
-}
-
-func (m mockClient) Delete(key string) (err error) {
-	for _, expect := range m.expected {
-		if expect.key == key {
-			return nil
-		}
-	}
-	return fmt.Errorf("%s does not exist", m.expected)
-}
 
 func TestGetConfig(t *testing.T) {
 	t.Parallel()
 
-	testMock := mockClient{expected: MockStore{{key: "/deis/controller/testing", value: "foo"}, {key: "/deis/controller/port", value: "8000"}}}
+	testMock := mock.Client{Expected: []*etcdclient.ServiceKey{{Key: "/deis/controller/testing", Value: "foo"}, {Key: "/deis/controller/port", Value: "8000"}}}
 	testWriter := bytes.Buffer{}
 
 	err := doConfig("controller", "get", []string{"testing", "port"}, testMock, &testWriter)
@@ -69,7 +34,7 @@ func TestGetConfig(t *testing.T) {
 func TestGetConfigError(t *testing.T) {
 	t.Parallel()
 
-	testMock := mockClient{expected: MockStore{{key: "/deis/controller/testing", value: "foo"}}}
+	testMock := mock.Client{Expected: []*etcdclient.ServiceKey{{Key: "/deis/controller/testing", Value: "foo"}}}
 	testWriter := bytes.Buffer{}
 
 	err := doConfig("controller", "get", []string{"port"}, testMock, &testWriter)
@@ -82,7 +47,7 @@ func TestGetConfigError(t *testing.T) {
 func TestSetConfig(t *testing.T) {
 	t.Parallel()
 
-	testMock := mockClient{expected: MockStore{{key: "/deis/controller/testing", value: "foo"}, {key: "/deis/controller/port", value: "8000"}}}
+	testMock := mock.Client{Expected: []*etcdclient.ServiceKey{{Key: "/deis/controller/testing", Value: "foo"}, {Key: "/deis/controller/port", Value: "8000"}}}
 	testWriter := bytes.Buffer{}
 
 	err := doConfig("controller", "set", []string{"testing=bar", "port=1000"}, testMock, &testWriter)
@@ -101,7 +66,7 @@ func TestSetConfig(t *testing.T) {
 func TestDeleteConfig(t *testing.T) {
 	t.Parallel()
 
-	testMock := mockClient{expected: MockStore{{key: "/deis/controller/testing", value: "foo"}, {key: "/deis/controller/port", value: "8000"}}}
+	testMock := mock.Client{Expected: []*etcdclient.ServiceKey{{Key: "/deis/controller/testing", Value: "foo"}, {Key: "/deis/controller/port", Value: "8000"}}}
 	testWriter := bytes.Buffer{}
 
 	err := doConfig("controller", "rm", []string{"testing", "port"}, testMock, &testWriter)

--- a/deisctl/deisctl.go
+++ b/deisctl/deisctl.go
@@ -41,6 +41,9 @@ Commands, use "deisctl help <command>" to learn more:
   refresh-units     refresh unit files from GitHub
   ssh               open an interacive shell on a machine in the cluster
   help              show the help screen for a command
+  upgrade-prep      prepare a running cluster for upgrade
+  upgrade-takeover  allow an upgrade to gracefully takeover a running cluster
+  rolling-restart   perform a rolling restart of a Deis component (currently only router is supported)
 
 Options:
   -h --help                   show this help screen
@@ -114,6 +117,12 @@ Options:
 		err = c.SSH(argv)
 	case "dock":
 		err = c.Dock(argv)
+	case "upgrade-prep":
+		err = c.UpgradePrep(argv)
+	case "upgrade-takeover":
+		err = c.UpgradeTakeover(argv)
+	case "rolling-restart":
+		err = c.RollingRestart(argv)
 	case "help":
 		fmt.Print(usage)
 		return 0

--- a/deisctl/etcdclient/api.go
+++ b/deisctl/etcdclient/api.go
@@ -1,0 +1,10 @@
+package etcdclient
+
+// Client for etcd
+type Client interface {
+	Get(string) (string, error)
+	Set(string, string) (string, error)
+	Delete(string) error
+	GetRecursive(string) ([]*ServiceKey, error)
+	Update(string, string, uint64) (string, error)
+}

--- a/deisctl/test/mock/etcd.go
+++ b/deisctl/test/mock/etcd.go
@@ -1,0 +1,70 @@
+package mock
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/deis/deis/deisctl/etcdclient"
+)
+
+// Store for a mocked etcd
+type Store []*etcdclient.ServiceKey
+
+// Client for the mocked etcd
+type Client struct {
+	Expected Store
+}
+
+// GetRecursive mocks returning a slice of all nodes under an etcd directory
+func (m Client) GetRecursive(key string) ([]*etcdclient.ServiceKey, error) {
+	r, _ := regexp.Compile(`^deis/services\s+`)
+	var serviceKeys []*etcdclient.ServiceKey
+
+	for _, expect := range m.Expected {
+		if r.MatchString(expect.Key) {
+			serviceKeys = append(serviceKeys, expect)
+		}
+	}
+	return serviceKeys, nil
+}
+
+// Update a mocked etcd key
+func (m Client) Update(key string, value string, ttl uint64) (string, error) {
+	for _, expect := range m.Expected {
+		if expect.Key == key {
+			expect.TTL = int64(ttl)
+			return expect.Key, nil
+		}
+	}
+	return "", fmt.Errorf("%s does not exist", m.Expected)
+}
+
+// Get a mocked etcd key
+func (m Client) Get(key string) (value string, err error) {
+	for _, expect := range m.Expected {
+		if expect.Key == key {
+			return expect.Value, nil
+		}
+	}
+	return "", fmt.Errorf("%s does not exist", m.Expected)
+}
+
+// Set a mocked etcd key
+func (m Client) Set(key, value string) (returnedValue string, err error) {
+	for _, expect := range m.Expected {
+		if expect.Key == key {
+			return value, nil
+		}
+	}
+	return "", fmt.Errorf("%s does not exist", m.Expected)
+}
+
+// Delete a mocked etcd key
+func (m Client) Delete(key string) (err error) {
+	for _, expect := range m.Expected {
+		if expect.Key == key {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s does not exist", m.Expected)
+}

--- a/docs/managing_deis/upgrading-deis.rst
+++ b/docs/managing_deis/upgrading-deis.rst
@@ -63,6 +63,64 @@ Finally, update ``deisctl`` to the new version and reinstall:
     enable PROXY protocol for ports 80 and 443 on the ELB, add a ``TCP 443:443`` listener, and
     change existing targets and health checks from HTTP to TCP.
 
+
+Graceful Upgrade
+----------------
+
+Alternatively, an experimental feature exists to provide the ability to perform a graceful upgrade. This process is
+available for version 1.9.0 moving foward and is intended to facilitate upgrades within a major version - upgrading
+between major versions is not supported. Unlike the in-place process above, this process keeps the platforms
+routers and publishers up during the upgrade process. This means that there should only be a maximum of around 1-2
+seconds of downtime while the routers boot up. Many times, there will be no downtime at all.
+
+Your loadbalancer configuration is the determining factor for how much downtime will occur during a successful upgrade.
+If your loadbalancer is configured to quickly reactivate failed hosts to its pool of active hosts, its quite possible to
+achieve zero downtime upgrades. If your loadbalancer is configured to more pessimistic, such as requiring multiple
+successful healthchecks before reactiving a node, then the chance for downtime increases. You should review your
+loadbalancers configuration to determine what to expect during the upgrade process.
+
+The process involves two deisctl commands, upgrade-prep and upgrade-takeover in coordination with a few important commands.
+
+First, a new deisctl version should be installed to a temporary location, reflecting the desired version to upgrade
+to. Care should be taken not to overwrite the existing deisctl version.
+
+.. code-block:: console
+
+    $ mkdir /tmp/upgrade
+    $ curl -sSL http://deis.io/deisctl/install.sh | sh -s 1.8.0 /tmp/upgrade
+    $ /tmp/upgrade/deisctl --version  # should match the desired platform
+    1.8.0
+    $ /tmp/upgrade/deisctl refresh-units
+    $ /tmp/upgrade/deisctl config platform set version=v1.8.0
+
+Now it is possible to prepare the cluster for the upgrade using the old deisctl binary. This command will shutdown
+and uninstall all components of the cluster except the router and publisher. This means your services should still be
+serving traffic afterwords, but nothing else in the cluster will be functional.
+
+.. code-block:: console
+
+    $ /opt/bin/deisctl upgrade-prep
+
+Finally, the rest of the components are brought up by the new binary. First, a rolling restart is done on the routers,
+replacing them one by one. Then the rest of the components are brought up. The end result should be an upgraded cluster.
+
+.. code-block:: console
+
+    $ /tmp/upgrade/deisctl upgrade-takeover
+
+It is recommended to move the newer deisctl into /opt/bin once the procedure is complete.
+
+If the process were to fail, the old version can be restored manually by reinstalling and starting the old components.
+
+.. code-block:: console
+
+    $ /tmp/upgrade/deisctl stop platform
+    $ /tmp/upgrade/deisctl uninstall platform
+    $ /tmp/upgrade/deisctl config platform set version=v1.8.0
+    $ /opt/bin/deisctl refresh-units
+    $ /opt/bin/deisctl install platform
+    $ /opt/bin/deisctl start platform
+
 Upgrade Deis clients
 ^^^^^^^^^^^^^^^^^^^^
 As well as upgrading ``deisctl``, make sure to upgrade the :ref:`deis client <install-client>` to


### PR DESCRIPTION
First pass at adding upgrade functionality to deisctl.

The whole thing needs :eyes:, but the following things especially.
- [ ] The service keys are persisted by a workaround which resets them with a 30 minute TTL. Is this the best way to keep the services up while the publishers cycle?
- [x] TestUpgradeTakeover fails due to the etcd stuff. If we keep that stuff in there, how should it be tested, a mocked etcd endpoint?
- [x] It would be nice if the command names were better, but its the best Ive come up with so far.
- [x] The docs indicate a deisctl install command that does not yet work - https://github.com/deis/deis.io/pull/114