### PR TITLE
ref(controller): share common scheduler code

### DIFF
--- a/controller/scheduler/__init__.py
+++ b/controller/scheduler/__init__.py
@@ -1,0 +1,35 @@
+
+class AbstractSchedulerClient(object):
+    """
+    A generic interface to a scheduler backend.
+    """
+
+    def __init__(self, target, auth, options, pkey):
+        self.target = target
+        self.auth = auth
+        self.options = options
+        self.pkey = pkey
+
+    def create(self, name, image, command, **kwargs):
+        """Create a new container."""
+        raise NotImplementedError
+
+    def destroy(self, name):
+        """Destroy a container."""
+        raise NotImplementedError
+
+    def run(self, name, image, entrypoint, command):
+        """Run a one-off command."""
+        raise NotImplementedError
+
+    def start(self, name):
+        """Start a container."""
+        raise NotImplementedError
+
+    def state(self, name):
+        """Display the given job's running state."""
+        raise NotImplementedError
+
+    def stop(self, name):
+        """Stop a container."""
+        raise NotImplementedError

--- a/controller/scheduler/chaos.py
+++ b/controller/scheduler/chaos.py
@@ -1,4 +1,5 @@
 import random
+
 from .mock import MockSchedulerClient, jobs
 from .states import JobState
 
@@ -12,52 +13,38 @@ STOP_ERROR_RATE = 0
 class ChaosSchedulerClient(MockSchedulerClient):
 
     def create(self, name, image, command, **kwargs):
+        """Create a new container."""
         if random.random() < CREATE_ERROR_RATE:
-            job = jobs.get(name, {})
-            job.update({'state': JobState.error})
-            jobs[name] = job
-            return
-        return super(ChaosSchedulerClient, self).create(name, image, command, **kwargs)
+            jobs.setdefault(name, {})['state'] = JobState.error
+        else:
+            super(ChaosSchedulerClient, self).create(name, image, command, **kwargs)
 
     def destroy(self, name):
-        """
-        Destroy an existing job
-        """
+        """Destroy a container."""
         if random.random() < DESTROY_ERROR_RATE:
-            job = jobs.get(name, {})
-            job.update({'state': JobState.error})
-            jobs[name] = job
-            return
-        return super(ChaosSchedulerClient, self).destroy(name)
+            jobs.setdefault(name, {})['state'] = JobState.error
+        else:
+            super(ChaosSchedulerClient, self).destroy(name)
 
     def run(self, name, image, entrypoint, command):
-        """
-        Run a one-off command
-        """
+        """Run a one-off command."""
         if random.random() < CREATE_ERROR_RATE:
             raise RuntimeError('exit code 1')
-        return super(ChaosSchedulerClient, self).run(name, image, entrypoint, command)
+        else:
+            super(ChaosSchedulerClient, self).run(name, image, entrypoint, command)
 
     def start(self, name):
-        """
-        Start an idle job
-        """
+        """Start a container."""
         if random.random() < START_ERROR_RATE:
-            job = jobs.get(name, {})
-            job.update({'state': JobState.crashed})
-            jobs[name] = job
-            return
-        return super(ChaosSchedulerClient, self).start(name)
+            jobs.setdefault(name, {})['state'] = JobState.crashed
+        else:
+            super(ChaosSchedulerClient, self).start(name)
 
     def stop(self, name):
-        """
-        Stop a running job
-        """
+        """Stop a container."""
         if random.random() < STOP_ERROR_RATE:
-            job = jobs.get(name, {})
-            job.update({'state': JobState.error})
-            jobs[name] = job
-            return
-        return super(ChaosSchedulerClient, self).stop(name)
+            jobs.setdefault(name, {})['state'] = JobState.crashed
+        else:
+            super(ChaosSchedulerClient, self).stop(name)
 
 SchedulerClient = ChaosSchedulerClient


### PR DESCRIPTION
Defines a `SchedulerClient` class to represent the interface that schedulers should implement, and subclasses existing schedulers from that. `attach` was unimplemented anywhere, so I removed it.

Also normalizes some code comments and removes extra code.