### PR TITLE
feat(platform): add overlay network

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -90,7 +90,13 @@ Vagrant.configure("2") do |config|
   end
 
   config.trigger.before :up do
-    if !File.exists?(CLOUD_CONFIG_PATH) || File.readlines(CLOUD_CONFIG_PATH).grep(/\s*discovery #DISCOVERY_URL/).any?
+    if File.exists?(CLOUD_CONFIG_PATH) && !File.readlines(CLOUD_CONFIG_PATH).grep(/\s*discovery #DISCOVERY_URL/).any?
+      # Vagrant binds the VMs IP in VirtualBox's bridge network to the eth1 interface instead of eth0.
+      # This necessitates the substitution below, which is not required anywhere except in Vagrant.
+      user_data = File.read(CLOUD_CONFIG_PATH)
+      new_userdata = user_data.gsub("--iface=eth0", "--iface=eth1")
+      File.open(CLOUD_CONFIG_PATH, "w") {|file| file.puts new_userdata }
+    else
       raise Vagrant::Errors::VagrantError.new, "Run 'make discovery-url' first to create user-data."
     end
   end

--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -63,6 +63,41 @@ coreos:
       Service=docker.service
       [Install]
       WantedBy=sockets.target
+  - name: flanneld.service
+    command: start
+    content: |
+      [Unit]
+      Description=Network fabric for containers
+      Documentation=https://github.com/coreos/flannel
+      Requires=early-docker.service etcd.service
+      After=etcd.service early-docker.service
+      Before=early-docker.target
+
+      [Service]
+      Type=notify
+      Restart=always
+      RestartSec=5
+      Environment="TMPDIR=/var/tmp/"
+      Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
+      Environment="FLANNEL_VER=0.5.1"
+      LimitNOFILE=40000
+      LimitNPROC=1048576
+      ExecStartPre=/sbin/modprobe ip_tables
+      ExecStartPre=/usr/bin/mkdir -p /run/flannel
+      ExecStartPre=/usr/bin/touch /run/flannel/options.env
+      ExecStartPre=-/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"10.244.0.0/16", "SubnetLen": 24, "SubnetMin":"10.244.0.0", "Backend": {"Type": "vxlan"}}'
+      ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
+        /usr/bin/docker run --net=host --privileged=true --rm \
+        --volume=/run/flannel:/run/flannel \
+        --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
+        --env-file=/run/flannel/options.env \
+        --volume=/usr/share/ca-certificates:/etc/ssl/certs:ro \
+        quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --iface=eth0 --ip-masq=true
+
+      # Update docker options
+      ExecStartPost=/usr/bin/docker run --net=host --rm -v /run:/run \
+        quay.io/coreos/flannel:${FLANNEL_VER} \
+        /opt/bin/mk-docker-opts.sh -d /run/flannel_docker_opts.env -i
   - name: stop-update-engine.service
     command: start
     content: |
@@ -143,9 +178,13 @@ write_files:
       }
   - path: /etc/systemd/system/docker.service.d/50-insecure-registry.conf
     content: |
-        [Service]
-        EnvironmentFile=/etc/environment_proxy
-        Environment="DOCKER_OPTS=--insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 --insecure-registry 100.64.0.0/10"
+      [Unit]
+      Requires=flanneld.service
+      After=flanneld.service
+
+      [Service]
+      EnvironmentFile=/etc/environment_proxy
+      Environment="DOCKER_OPTS=--insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 --insecure-registry 100.64.0.0/10"
   - path: /run/deis/bin/get_image
     permissions: '0755'
     content: |


### PR DESCRIPTION
This is a minimal subset of #3868 with one critical difference: `--iptables=false` has been omitted from the drop-in for `docker.service`.  The result is that docker manages iptables rules _in addition_ to those that are managed by flannel.  The result is that port mappings continue to function as they always have-- the benefit of which is that no changes are required to any Deis components.  With no changes to components required, upgrades should work smoothly.

I'd appreciate any help I can get in verifying / validating those finding and / or making swiss cheese out of this approach.  :)

Majority credit to @aledbf!