### PR TITLE
feat(deisctl): extend SSH to allow exec and docker

### DIFF
--- a/deisctl/backend/backend.go
+++ b/deisctl/backend/backend.go
@@ -13,6 +13,7 @@ type Backend interface {
 	Stop([]string, *sync.WaitGroup, io.Writer, io.Writer)
 	Scale(string, int, *sync.WaitGroup, io.Writer, io.Writer)
 	SSH(string) error
+	SSHExec(string, string) error
 	ListUnits() error
 	ListUnitFiles() error
 	Status(string) error

--- a/deisctl/client/client.go
+++ b/deisctl/client/client.go
@@ -229,16 +229,45 @@ Usage:
 func (c *Client) SSH(argv []string) error {
 	usage := `Open an interactive shell on a machine in the cluster given a unit or machine id.
 
+If an optional <command> is provided, that command is run remotely, and the results returned.
+
 Usage:
-  deisctl ssh <target>
+  deisctl ssh <target> [<command>...]
 `
 	// parse command-line arguments
-	args, err := docopt.Parse(usage, argv, true, "", false)
+	args, err := docopt.Parse(usage, argv, true, "", true)
 	if err != nil {
 		return err
 	}
 
-	return cmd.SSH(args["<target>"].(string), c.Backend)
+	var vargs []string
+	if v, ok := args["<command>"]; ok {
+		vargs = v.([]string)
+	}
+
+	return cmd.SSH(args["<target>"].(string), vargs, c.Backend)
+}
+
+func (c *Client) Dock(argv []string) error {
+	usage := `Connect to the named docker container and run commands on it.
+
+This is equivalent to running 'docker exec -it <target> <command>'.
+
+Usage:
+  deisctl dock <target> [<command>...]
+`
+	// parse command-line arguments
+	args, err := docopt.Parse(usage, argv, true, "", true)
+	if err != nil {
+		return err
+	}
+
+	var vargs []string
+	if v, ok := args["<command>"]; ok {
+		vargs = v.([]string)
+	}
+
+	return cmd.Dock(args["<target>"].(string), vargs, c.Backend)
 }
 
 // Start activates the specified components.

--- a/deisctl/cmd/cmd.go
+++ b/deisctl/cmd/cmd.go
@@ -451,10 +451,24 @@ func RefreshUnits(dir, tag, url string) error {
 }
 
 // SSH opens an interactive shell on a machine in the cluster
-func SSH(target string, b backend.Backend) error {
-	if err := b.SSH(target); err != nil {
-		return err
+func SSH(target string, cmd []string, b backend.Backend) error {
+
+	if len(cmd) > 0 {
+		return b.SSHExec(target, strings.Join(cmd, " "))
 	}
 
-	return nil
+	return b.SSH(target)
+}
+
+// Dock connects to the appropriate host and runs 'docker exec -it'.
+func Dock(target string, cmd []string, b backend.Backend) error {
+
+	c := "sh"
+	if len(cmd) > 0 {
+		c = strings.Join(cmd, " ")
+	}
+
+	execit := fmt.Sprintf("docker exec -it %s %s", target, c)
+
+	return b.SSHExec(target, execit)
 }

--- a/deisctl/cmd/cmd_test.go
+++ b/deisctl/cmd/cmd_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/deis/deis/deisctl/backend"
 	"github.com/deis/deis/deisctl/units"
 )
 
@@ -69,6 +70,14 @@ func (backend *backendStub) SSH(target string) error {
 	}
 	return errors.New("Error")
 }
+func (backend *backendStub) SSHExec(target, command string) error {
+	if target == "controller" && command == "sh" {
+		return nil
+	}
+	return errors.New("Error")
+}
+
+var _ backend.Backend = &backendStub{}
 
 func fakeCheckKeys() error {
 	return nil
@@ -332,7 +341,17 @@ func TestSSH(t *testing.T) {
 	t.Parallel()
 
 	b := backendStub{}
-	err := SSH("controller", &b)
+	err := SSH("controller", []string{}, &b)
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+func TestSSHExec(t *testing.T) {
+	t.Parallel()
+
+	b := backendStub{}
+	err := SSH("controller", []string{"sh"}, &b)
 
 	if err != nil {
 		t.Error(err)
@@ -343,7 +362,7 @@ func TestSSHError(t *testing.T) {
 	t.Parallel()
 
 	b := backendStub{}
-	err := SSH("registry", &b)
+	err := SSH("registry", []string{}, &b)
 
 	if err == nil {
 		t.Error("Error expected")

--- a/deisctl/deisctl.go
+++ b/deisctl/deisctl.go
@@ -112,6 +112,8 @@ Options:
 		err = c.RefreshUnits(argv)
 	case "ssh":
 		err = c.SSH(argv)
+	case "dock":
+		err = c.Dock(argv)
 	case "help":
 		fmt.Print(usage)
 		return 0

--- a/docs/troubleshooting_deis/index.rst
+++ b/docs/troubleshooting_deis/index.rst
@@ -24,6 +24,33 @@ To open a interactive shell on a machine in your cluster:
 
     $ deisctl ssh <unit>
 
+For example, to open a shell session on the machine that is running Controller,
+you can run this:
+
+.. code-block:: console
+
+    $ deisctl ssh controller
+
+You can execute just a single command instead of opening a shell:
+
+.. code-block:: console
+
+    $ deisctl ssh <unit> <command>
+
+You can also connect directly to the Docker instance of that unit:
+
+.. code-block:: console
+
+    $ deisctl dock <unit> <command>
+
+For example, to start a Bash session on the Builder Docker container, you can
+run the following command:
+
+.. code-block:: console
+
+    $ deisctl dock builder bash`
+
+
 Troubleshooting etcd
 --------------------
 


### PR DESCRIPTION
This feature extends 'deis ssh' to allow for an arbitrary command.
If specified, the command will be run as an SSH Exec call, instead
of opening a new shell.

Further, this adds 'deis dock', which is a convenience wrapper
for 'deis ssh THING docker exec -it THING COMMAND'. This now
becomes 'deis dock THING COMMAND'.

Testing:

After installation, you should be able to run all of the following commands:

- `deis ssh deis-builder`: Works as normal.
- `deis ssh deis-builder ls -la`: Runs `ls -la` on the host that is running builder.
- `deis dock deis-builder sh`: Starts a shell on the `deis-builder` container. 