### PR TITLE
fix(vagrant): fix too many redirects problem

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -146,6 +146,12 @@ Vagrant.configure("2") do |config|
       ip = "172.17.8.#{i+99}"
       config.vm.network :private_network, ip: ip
 
+      # Use the same nameserver as the host machine in order to avoid the "too many redirects" problem.
+      config.vm.provider :virtualbox do |vb|
+        vb.customize ["modifyvm", :id, "--natdnshostresolver1", "off"]
+        vb.customize ["modifyvm", :id, "--natdnsproxy1", "off"]
+      end
+
       # Uncomment below to enable NFS for sharing the host machine into the coreos-vagrant VM.
       #config.vm.synced_folder ".", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
       $shared_folders.each_with_index do |(host_folder, guest_folder), index|


### PR DESCRIPTION
This fixes the "too many redirects" problem that seems to occur (particularly on Yosemite) during `docker pull`-- particularly when `deis-builder` is building the slugbuilder.

This issue discusses the problem and solution with respect to `boot2docker`:

https://github.com/boot2docker/boot2docker/issues/451

This PR merely applies the same fix to all our Vagrant-managed VMs via the `Vagrantfile`.

Ping @jchauncey-- I think you said you were having this issue too.  Can you confirm this helps you as well?