### PR TITLE
fix(tests): fixup deis binary lookup

### DIFF
--- a/tests/utils/itutils.go
+++ b/tests/utils/itutils.go
@@ -23,7 +23,7 @@ import (
 var Deis = os.Getenv("DEIS_BINARY") + " "
 
 func init() {
-	if Deis == "" {
+	if Deis == " " {
 		Deis = "deis "
 	}
 }


### PR DESCRIPTION
var Deis will always have at least one space.