### PR TITLE
chore(deisctl): update vendored fleet code to 0.9.2

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -30,53 +30,53 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/fleet/client",
-			"Comment": "v0.9.0",
-			"Rev": "2d5c6bb0751ad3a50c0a219158439071a59e549f"
+			"Comment": "v0.9.2",
+			"Rev": "e0f7a2316dc6ae610979598c4efe127ac8ff1ae9"
 		},
 		{
 			"ImportPath": "github.com/coreos/fleet/etcd",
-			"Comment": "v0.9.0",
-			"Rev": "2d5c6bb0751ad3a50c0a219158439071a59e549f"
+			"Comment": "v0.9.2",
+			"Rev": "e0f7a2316dc6ae610979598c4efe127ac8ff1ae9"
 		},
 		{
 			"ImportPath": "github.com/coreos/fleet/job",
-			"Comment": "v0.9.0",
-			"Rev": "2d5c6bb0751ad3a50c0a219158439071a59e549f"
+			"Comment": "v0.9.2",
+			"Rev": "e0f7a2316dc6ae610979598c4efe127ac8ff1ae9"
 		},
 		{
 			"ImportPath": "github.com/coreos/fleet/log",
-			"Comment": "v0.9.0",
-			"Rev": "2d5c6bb0751ad3a50c0a219158439071a59e549f"
+			"Comment": "v0.9.2",
+			"Rev": "e0f7a2316dc6ae610979598c4efe127ac8ff1ae9"
 		},
 		{
 			"ImportPath": "github.com/coreos/fleet/machine",
-			"Comment": "v0.9.0",
-			"Rev": "2d5c6bb0751ad3a50c0a219158439071a59e549f"
+			"Comment": "v0.9.2",
+			"Rev": "e0f7a2316dc6ae610979598c4efe127ac8ff1ae9"
 		},
 		{
 			"ImportPath": "github.com/coreos/fleet/pkg",
-			"Comment": "v0.9.0",
-			"Rev": "2d5c6bb0751ad3a50c0a219158439071a59e549f"
+			"Comment": "v0.9.2",
+			"Rev": "e0f7a2316dc6ae610979598c4efe127ac8ff1ae9"
 		},
 		{
 			"ImportPath": "github.com/coreos/fleet/registry",
-			"Comment": "v0.9.0",
-			"Rev": "2d5c6bb0751ad3a50c0a219158439071a59e549f"
+			"Comment": "v0.9.2",
+			"Rev": "e0f7a2316dc6ae610979598c4efe127ac8ff1ae9"
 		},
 		{
 			"ImportPath": "github.com/coreos/fleet/schema",
-			"Comment": "v0.9.0",
-			"Rev": "2d5c6bb0751ad3a50c0a219158439071a59e549f"
+			"Comment": "v0.9.2",
+			"Rev": "e0f7a2316dc6ae610979598c4efe127ac8ff1ae9"
 		},
 		{
 			"ImportPath": "github.com/coreos/fleet/ssh",
-			"Comment": "v0.9.0",
-			"Rev": "2d5c6bb0751ad3a50c0a219158439071a59e549f"
+			"Comment": "v0.9.2",
+			"Rev": "e0f7a2316dc6ae610979598c4efe127ac8ff1ae9"
 		},
 		{
 			"ImportPath": "github.com/coreos/fleet/unit",
-			"Comment": "v0.9.0",
-			"Rev": "2d5c6bb0751ad3a50c0a219158439071a59e549f"
+			"Comment": "v0.9.2",
+			"Rev": "e0f7a2316dc6ae610979598c4efe127ac8ff1ae9"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-etcd/etcd",

--- a/Godeps/_workspace/src/github.com/coreos/fleet/unit/fake.go
+++ b/Godeps/_workspace/src/github.com/coreos/fleet/unit/fake.go
@@ -39,6 +39,10 @@ func (fum *FakeUnitManager) Load(name string, u UnitFile) error {
 	return nil
 }
 
+func (fum *FakeUnitManager) ReloadUnitFiles() error {
+	return nil
+}
+
 func (fum *FakeUnitManager) Unload(name string) {
 	fum.Lock()
 	defer fum.Unlock()

--- a/Godeps/_workspace/src/github.com/coreos/fleet/unit/manager.go
+++ b/Godeps/_workspace/src/github.com/coreos/fleet/unit/manager.go
@@ -23,6 +23,7 @@ import (
 type UnitManager interface {
 	Load(string, UnitFile) error
 	Unload(string)
+	ReloadUnitFiles() error
 
 	TriggerStart(string)
 	TriggerStop(string)


### PR DESCRIPTION
Doesn't seem like anything too important, but it's probably a good idea to keep the vendored fleet up to date with the version on CoreOS.