### PR TITLE
fix(store): block metadata start until confd runs

### DIFF
--- a/store/metadata/bin/boot
+++ b/store/metadata/bin/boot
@@ -47,6 +47,11 @@ if ! etcdctl --no-sync -C $ETCD get ${ETCD_PATH}/filesystemSetupComplete >/dev/n
   fi
 fi
 
+until confd -onetime -node $ETCD --confdir /app --log-level error; do
+  echo "store-metadata: waiting for confd to write initial templates..."
+  sleep 5
+done
+
 # Check to see if we are a new MDS
 if [ ! -e /var/lib/ceph/mds/ceph-$MDS_NAME/keyring ]; then
   mkdir -p /var/lib/ceph/mds/ceph-${MDS_NAME}


### PR DESCRIPTION
We faced a race condition where the MDS could start and initialize
with an invalid keyring file, since it hadn't yet been templated
by confd.

closes #4115 