### PR TITLE
chore(tests): bump etcd to v2.0.13

### DIFF
--- a/tests/fixtures/test-etcd/Dockerfile
+++ b/tests/fixtures/test-etcd/Dockerfile
@@ -3,11 +3,11 @@ FROM alpine:3.1
 # install common packages
 RUN apk add --update-cache curl tar && rm -rf /var/cache/apk/*
 
-ENV ETCD_VERSION v0.4.9
+ENV ETCD_VERSION v2.0.13
 
 # install etcd and etcdctl
 RUN curl -sSL https://github.com/coreos/etcd/releases/download/$ETCD_VERSION/etcd-$ETCD_VERSION-linux-amd64.tar.gz \
   | tar -vxz -C /usr/local/bin --strip=1
 
-EXPOSE 4001 7001
+EXPOSE 4001 7001 2379 2380
 CMD ["/usr/local/bin/etcd"]


### PR DESCRIPTION
We bumped the platform to etcd 2 in #4090. We should probably be testing against this version of etcd.

/cc @mboersma @sgoings 