### PR TITLE
ref(user-data): remove load-overlay-module

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -153,15 +153,6 @@ coreos:
       Type=oneshot
       ExecStartPre=/usr/sbin/modprobe nf_conntrack
       ExecStart=/bin/sh -c "sysctl -w net.netfilter.nf_conntrack_max=262144"
-  - name: load-overlay-module.service
-    command: start
-    content: |
-      [Unit]
-      Description=Load overlay module before docker start
-      Before=docker.service
-
-      [Service]
-      ExecStart=/bin/bash -c "lsmod | grep overlay || modprobe overlay"
   - name: fleet.service
     command: start
 write_files:


### PR DESCRIPTION
Current versions of CoreOS (including 647.2.0) don't need any help: docker starts with overlayfs as its backend storage driver regardless. I verified this on Vagrant and AWS.

Replaces #4128. It's easier to do this as smaller PRs.

Refs #3975, since we need to shrink user-data a bit to accomodate those changes. *Edit*: never mind, #3975 shrunk itself enough to pass without other changes.