### PR TITLE
feat(client-go): add minimal windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ cache/image/bin/
 client/dist/
 client/makeself/
 client-go/deis
+client-go/deis.exe
 contrib/azure/azure-user-data
 contrib/bumpver/bumpver
 deisctl/deisctl

--- a/client-go/cmd/auth.go
+++ b/client-go/cmd/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"syscall"
 
 	"github.com/deis/deis/client-go/controller/client"
 	"golang.org/x/crypto/ssh/terminal"
@@ -191,7 +192,7 @@ func Regenerate(username string, all bool) error {
 }
 
 func readPassword() (string, error) {
-	password, err := terminal.ReadPassword(0)
+	password, err := terminal.ReadPassword(int(syscall.Stdin))
 
 	return string(password), err
 }

--- a/client-go/cmd/keys.go
+++ b/client-go/cmd/keys.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"regexp"
 	"strconv"
@@ -129,7 +128,7 @@ func chooseKey() (api.KeyCreateRequest, error) {
 }
 
 func listKeys() ([]api.KeyCreateRequest, error) {
-	folder := path.Join(os.Getenv("HOME"), ".ssh")
+	folder := path.Join(client.FindHome(), ".ssh")
 	files, err := ioutil.ReadDir(folder)
 
 	if err != nil {

--- a/client-go/controller/client/client.go
+++ b/client-go/controller/client/client.go
@@ -78,7 +78,7 @@ func (c Client) Save() error {
 		return err
 	}
 
-	if err = os.MkdirAll(path.Join(os.Getenv("HOME"), "/.deis/"), 0775); err != nil {
+	if err = os.MkdirAll(path.Join(FindHome(), "/.deis/"), 0775); err != nil {
 		return err
 	}
 

--- a/client-go/controller/client/home_unix.go
+++ b/client-go/controller/client/home_unix.go
@@ -1,0 +1,12 @@
+// +build linux darwin
+
+package client
+
+import (
+	"os"
+)
+
+// FindHome returns the HOME directory of the current user
+func FindHome() string {
+	return os.Getenv("HOME")
+}

--- a/client-go/controller/client/home_windows.go
+++ b/client-go/controller/client/home_windows.go
@@ -1,0 +1,10 @@
+package client
+
+import (
+	"os"
+)
+
+// FindHome returns the HOME directory of the current user
+func FindHome() string {
+	return os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+}

--- a/client-go/controller/client/utils.go
+++ b/client-go/controller/client/utils.go
@@ -15,7 +15,7 @@ func locateSettingsFile() string {
 		filename = "client"
 	}
 
-	return path.Join(os.Getenv("HOME"), ".deis", filename+".json")
+	return path.Join(FindHome(), ".deis", filename+".json")
 }
 
 func deleteSettings() error {

--- a/client-go/controller/client/webbrowser_windows.go
+++ b/client-go/controller/client/webbrowser_windows.go
@@ -1,0 +1,11 @@
+package client
+
+import (
+	"os/exec"
+)
+
+// Webbrowser opens a URL with the default browser.
+func Webbrowser(u string) (err error) {
+	_, err = exec.Command("cmd", "/c", "start", u).Output()
+	return
+}

--- a/client-go/make.bat
+++ b/client-go/make.bat
@@ -1,0 +1,1 @@
+godep go build -a -installsuffix cgo -ldflags '-s' -o deis.exe .


### PR DESCRIPTION
This PR adds very minimal windows support to client-go.

1. Add a batchfile so it can be built on windows.
2. `apps:open` launches the default web browser.
3. Uses `%HOMEDRIVE%` and `%HOMEPATH%` on windows instead of `$HOME`.

Current issues:

1. Test will not pass on windows, as tests expect unix behavior.