### PR TITLE
fix(controller): remove extra bracketing

### DIFF
--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -28,7 +28,7 @@ function etcd_set_default {
 	set +e
 	ERROR="$(etcdctl --no-sync -C "$ETCD" mk "$ETCD_PATH/$1" "$2" 2>&1 >/dev/null)"
 
-	if [[ $? -ne 0 ]] && echo "$ERROR" | grep -iqve "key already exists" ]]; then
+	if [[ $? -ne 0 ]] && echo "$ERROR" | grep -iqve "key already exists"; then
 		echo "etcd_set_default: an etcd error occurred ($ERROR)"
 		echo "aborting..."
 		exit 1


### PR DESCRIPTION
Corrects an error that crept in to bin/boot from #4126 which I saw in the controller logs:
```
Jul 30 19:29:23 deis-01 sh[15058]: grep: ]]: No such file or directory
Jul 30 19:29:23 deis-01 sh[15058]: grep: ]]: No such file or directory
Jul 30 19:29:23 deis-01 sh[15058]: grep: ]]: No such file or directory
Jul 30 19:29:23 deis-01 sh[15058]: grep: ]]: No such file or directory
Jul 30 19:29:24 deis-01 sh[15058]: grep: ]]: No such file or directory
Jul 30 19:29:24 deis-01 sh[15058]: grep: ]]: No such file or directory
```