### PR TITLE
fix(controller): prevent < 1 gunicorn workers

### DIFF
--- a/controller/templates/gconf.py
+++ b/controller/templates/gconf.py
@@ -1,6 +1,8 @@
 bind = '0.0.0.0'
 try:
     workers = int({{ if exists "/deis/controller/workers" }}{{ getv "/deis/controller/workers" }}{{ else }}"not set"{{end}})
+    if workers < 1:
+        raise ValueError()
 except (NameError, ValueError):
     import multiprocessing
     try:


### PR DESCRIPTION
This prevents a negative number being used for deis-controller gunicorn workers:
```console
$ deisctl config controller set workers=-1
```
Otherwise, the above command leads to the controller spawning no workers and effectively becoming unresponsive:
```
Jul 30 19:28:04 deis-01 sh[9745]: [2015-07-30 19:28:04 +0000] [119] [INFO] Handling signal: hup
Jul 30 19:28:04 deis-01 sh[9745]: [2015-07-30 19:28:04 +0000] [119] [INFO] Hang up: Master
Jul 30 19:28:04 deis-01 sh[9745]: Invalid value for workers: -1
Jul 30 19:28:04 deis-01 sh[9745]: Error: Value must be positive: -1
```
