### PR TITLE
fix(deisctl): allow help for ssh and dock

### DIFF
--- a/deisctl/client/client.go
+++ b/deisctl/client/client.go
@@ -252,12 +252,19 @@ Usage:
 		return err
 	}
 
+	target := args["<target>"].(string)
+	// handle help explicitly since docopt parsing is relaxed
+	if target == "--help" {
+		fmt.Println(usage)
+		os.Exit(0)
+	}
+
 	var vargs []string
 	if v, ok := args["<command>"]; ok {
 		vargs = v.([]string)
 	}
 
-	return cmd.SSH(args["<target>"].(string), vargs, c.Backend)
+	return cmd.SSH(target, vargs, c.Backend)
 }
 
 func (c *Client) Dock(argv []string) error {
@@ -274,12 +281,19 @@ Usage:
 		return err
 	}
 
+	target := args["<target>"].(string)
+	// handle help explicitly since docopt parsing is relaxed
+	if target == "--help" {
+		fmt.Println(usage)
+		os.Exit(0)
+	}
+
 	var vargs []string
 	if v, ok := args["<command>"]; ok {
 		vargs = v.([]string)
 	}
 
-	return cmd.Dock(args["<target>"].(string), vargs, c.Backend)
+	return cmd.Dock(target, vargs, c.Backend)
 }
 
 // Start activates the specified components.


### PR DESCRIPTION
"deisctl ssh" and "deisctl dock" need open-ended command-line parsing to allow unquoted commands to be run. But this short-circuits the normal way docopt would print the usage string.

Currently `deisctl help dock` or `deisctl --help ssh` or variants won't display their detailed usage strings. This fixes that, but still allows those two commands to swallow everything that follows on the command line.

The code compares `target` only to "--help" because earlier parsing code translated "help" and "-h" to "--help"