### PR TITLE
fix(client-go): paginate over lists

### DIFF
--- a/client-go/cmd/apps.go
+++ b/client-go/cmd/apps.go
@@ -55,20 +55,24 @@ func AppCreate(id string, buildpack string, remote string, noRemote bool) error 
 }
 
 // AppsList lists apps on the Deis controller.
-func AppsList() error {
+func AppsList(results int) error {
 	c, err := client.New()
 
 	if err != nil {
 		return err
 	}
 
-	apps, err := apps.List(c)
+	if results == defaultLimit {
+		results = c.ResponseLimit
+	}
+
+	apps, count, err := apps.List(c, results)
 
 	if err != nil {
 		return err
 	}
 
-	fmt.Println("=== Apps")
+	fmt.Printf("=== Apps%s", limitCount(len(apps), count))
 
 	for _, app := range apps {
 		fmt.Println(app.ID)

--- a/client-go/cmd/builds.go
+++ b/client-go/cmd/builds.go
@@ -9,20 +9,24 @@ import (
 )
 
 // BuildsList lists an app's builds.
-func BuildsList(appID string) error {
+func BuildsList(appID string, results int) error {
 	c, appID, err := load(appID)
 
 	if err != nil {
 		return err
 	}
 
-	builds, err := builds.List(c, appID)
+	if results == defaultLimit {
+		results = c.ResponseLimit
+	}
+
+	builds, count, err := builds.List(c, appID, results)
 
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("=== %s Builds\n", appID)
+	fmt.Printf("=== %s Builds%s", appID, limitCount(len(builds), count))
 
 	for _, build := range builds {
 		fmt.Println(build.UUID, build.Created)

--- a/client-go/cmd/certs.go
+++ b/client-go/cmd/certs.go
@@ -12,14 +12,18 @@ import (
 )
 
 // CertsList lists certs registered with the controller.
-func CertsList() error {
+func CertsList(results int) error {
 	c, err := client.New()
 
 	if err != nil {
 		return err
 	}
 
-	certList, err := certs.List(c)
+	if results == defaultLimit {
+		results = c.ResponseLimit
+	}
+
+	certList, _, err := certs.List(c, results)
 
 	if err != nil {
 		return err

--- a/client-go/cmd/domains.go
+++ b/client-go/cmd/domains.go
@@ -7,20 +7,24 @@ import (
 )
 
 // DomainsList lists domains registered with an app.
-func DomainsList(appID string) error {
+func DomainsList(appID string, results int) error {
 	c, appID, err := load(appID)
 
 	if err != nil {
 		return err
 	}
 
-	domains, err := domains.List(c, appID)
+	if results == defaultLimit {
+		results = c.ResponseLimit
+	}
+
+	domains, count, err := domains.List(c, appID, results)
 
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("=== %s Domains\n", appID)
+	fmt.Printf("=== %s Domains%s", appID, limitCount(len(domains), count))
 
 	for _, domain := range domains {
 		fmt.Println(domain.Domain)

--- a/client-go/cmd/keys.go
+++ b/client-go/cmd/keys.go
@@ -14,20 +14,24 @@ import (
 )
 
 // KeysList lists a user's keys.
-func KeysList() error {
+func KeysList(results int) error {
 	c, err := client.New()
 
 	if err != nil {
 		return err
 	}
 
-	keys, err := keys.List(c)
+	if results == defaultLimit {
+		results = c.ResponseLimit
+	}
+
+	keys, count, err := keys.List(c, results)
 
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("=== %s Keys\n", c.Username)
+	fmt.Printf("=== %s Keys%s", c.Username, limitCount(len(keys), count))
 
 	for _, key := range keys {
 		fmt.Printf("%s %s...%s\n", key.ID, key.Public[:16], key.Public[len(key.Public)-10:])

--- a/client-go/cmd/perms.go
+++ b/client-go/cmd/perms.go
@@ -9,7 +9,7 @@ import (
 )
 
 // PermsList prints which users have permissions.
-func PermsList(appID string, admin bool) error {
+func PermsList(appID string, admin bool, results int) error {
 	c, appID, err := permsLoad(appID, admin)
 
 	if err != nil {
@@ -17,9 +17,13 @@ func PermsList(appID string, admin bool) error {
 	}
 
 	var users []string
+	var count int
 
 	if admin {
-		users, err = perms.ListAdmins(c)
+		if results == defaultLimit {
+			results = c.ResponseLimit
+		}
+		users, count, err = perms.ListAdmins(c, results)
 	} else {
 		users, err = perms.List(c, appID)
 	}
@@ -29,7 +33,7 @@ func PermsList(appID string, admin bool) error {
 	}
 
 	if admin {
-		fmt.Println("=== Administrators")
+		fmt.Printf("=== Administrators%s", limitCount(len(users), count))
 	} else {
 		fmt.Printf("=== %s's Users\n", appID)
 	}

--- a/client-go/cmd/ps.go
+++ b/client-go/cmd/ps.go
@@ -12,20 +12,24 @@ import (
 )
 
 // PsList lists an app's processes.
-func PsList(appID string) error {
+func PsList(appID string, results int) error {
 	c, appID, err := load(appID)
 
 	if err != nil {
 		return err
 	}
 
-	processes, err := ps.List(c, appID)
+	if results == defaultLimit {
+		results = c.ResponseLimit
+	}
+
+	processes, count, err := ps.List(c, appID, results)
 
 	if err != nil {
 		return err
 	}
 
-	printProcesses(appID, processes)
+	printProcesses(appID, processes, count)
 
 	return nil
 }
@@ -69,13 +73,13 @@ func PsScale(appID string, targets []string) error {
 
 	fmt.Printf("done in %ds\n", int(time.Since(startTime).Seconds()))
 
-	processes, err := ps.List(c, appID)
+	processes, count, err := ps.List(c, appID, c.ResponseLimit)
 
 	if err != nil {
 		return err
 	}
 
-	printProcesses(appID, processes)
+	printProcesses(appID, processes, count)
 	return nil
 }
 
@@ -119,20 +123,20 @@ func PsRestart(appID, target string) error {
 
 	fmt.Printf("done in %ds\n", int(time.Since(startTime).Seconds()))
 
-	processes, err := ps.List(c, appID)
+	processes, count, err := ps.List(c, appID, c.ResponseLimit)
 
 	if err != nil {
 		return err
 	}
 
-	printProcesses(appID, processes)
+	printProcesses(appID, processes, count)
 	return nil
 }
 
-func printProcesses(appID string, processes []api.Process) {
+func printProcesses(appID string, processes []api.Process, count int) {
 	psMap := ps.ByType(processes)
 
-	fmt.Printf("=== %s Processes\n", appID)
+	fmt.Printf("=== %s Processes%s", appID, limitCount(len(processes), count))
 
 	for psType, procs := range psMap {
 		fmt.Printf("--- %s:\n", psType)

--- a/client-go/cmd/releases.go
+++ b/client-go/cmd/releases.go
@@ -9,16 +9,20 @@ import (
 )
 
 // ReleasesList lists an app's releases.
-func ReleasesList(appID string) error {
+func ReleasesList(appID string, results int) error {
 	c, appID, err := load(appID)
 
 	if err != nil {
 		return err
 	}
 
-	releases, err := releases.List(c, appID)
+	if results == defaultLimit {
+		results = c.ResponseLimit
+	}
 
-	fmt.Printf("=== %s Releases\n", appID)
+	releases, count, err := releases.List(c, appID, results)
+
+	fmt.Printf("=== %s Releases%s", appID, limitCount(len(releases), count))
 
 	w := new(tabwriter.Writer)
 

--- a/client-go/cmd/users.go
+++ b/client-go/cmd/users.go
@@ -8,20 +8,24 @@ import (
 )
 
 // UsersList lists users registered with the controller.
-func UsersList() error {
+func UsersList(results int) error {
 	c, err := client.New()
 
 	if err != nil {
 		return err
 	}
 
-	users, err := users.List(c)
+	if results == defaultLimit {
+		results = c.ResponseLimit
+	}
+
+	users, count, err := users.List(c, results)
 
 	if err != nil {
 		return err
 	}
 
-	fmt.Println("=== Users")
+	fmt.Printf("=== Users%s", limitCount(len(users), count))
 
 	for _, user := range users {
 		fmt.Println(user.Username)

--- a/client-go/cmd/utils.go
+++ b/client-go/cmd/utils.go
@@ -10,6 +10,8 @@ import (
 	"github.com/deis/deis/client-go/pkg/git"
 )
 
+var defaultLimit = -1
+
 func progress() chan bool {
 	frames := []string{"...", "o..", ".o.", "..o"}
 	backspaces := strings.Repeat("\b", 3)
@@ -77,4 +79,12 @@ func drinkOfChoice() string {
 	}
 
 	return drink
+}
+
+func limitCount(objs, total int) string {
+	if objs == total {
+		return "\n"
+	}
+
+	return fmt.Sprintf(" (%d of %d)\n", objs, total)
 }

--- a/client-go/controller/api/apps.go
+++ b/client-go/controller/api/apps.go
@@ -10,14 +10,6 @@ type App struct {
 	UUID    string `json:"uuid"`
 }
 
-// Apps is the definition of GET /v1/apps/.
-type Apps struct {
-	Count    int   `json:"count"`
-	Next     int   `json:"next"`
-	Previous int   `json:"previous"`
-	Apps     []App `json:"results"`
-}
-
 // AppCreateRequest is the definition of POST /v1/apps/.
 type AppCreateRequest struct {
 	ID string `json:"id,omitempty"`

--- a/client-go/controller/api/builds.go
+++ b/client-go/controller/api/builds.go
@@ -13,14 +13,6 @@ type Build struct {
 	UUID       string            `json:"uuid"`
 }
 
-// Builds is the structure of GET /v1/apps/<app id>/builds/.
-type Builds struct {
-	Count    int     `json:"count"`
-	Next     int     `json:"next"`
-	Previous int     `json:"previous"`
-	Builds   []Build `json:"results"`
-}
-
 // CreateBuildRequest is the structure of POST /v1/apps/<app id>/builds/.
 type CreateBuildRequest struct {
 	Image    string            `json:"image"`

--- a/client-go/controller/api/certs.go
+++ b/client-go/controller/api/certs.go
@@ -12,14 +12,6 @@ type Cert struct {
 	ID      int    `json:"id,omitempty"`
 }
 
-// Certs is the definition of GET /v1/certs/.
-type Certs struct {
-	Count    int    `json:"count"`
-	Next     int    `json:"next"`
-	Previous int    `json:"previous"`
-	Certs    []Cert `json:"results"`
-}
-
 // CertCreateRequest is the definition of POST /v1/certs/.
 type CertCreateRequest struct {
 	Certificate string `json:"certificate"`

--- a/client-go/controller/api/domains.go
+++ b/client-go/controller/api/domains.go
@@ -9,14 +9,6 @@ type Domain struct {
 	Updated string `json:"updated"`
 }
 
-// Domains is the structure of GET /v1/app/<app id>/domains/.
-type Domains struct {
-	Count    int      `json:"count"`
-	Next     int      `json:"next"`
-	Previous int      `json:"previous"`
-	Domains  []Domain `json:"results"`
-}
-
 // DomainCreateRequest is the structure of POST /v1/app/<app id>/domains/.
 type DomainCreateRequest struct {
 	Domain string `json:"domain"`

--- a/client-go/controller/api/keys.go
+++ b/client-go/controller/api/keys.go
@@ -10,14 +10,6 @@ type Key struct {
 	UUID    string `json:"uuid"`
 }
 
-// Keys is the definition of GET /v1/keys/.
-type Keys struct {
-	Count    int   `json:"count"`
-	Next     int   `json:"next"`
-	Previous int   `json:"previous"`
-	Keys     []Key `json:"results"`
-}
-
 // KeyCreateRequest is the definition of POST /v1/keys/.
 type KeyCreateRequest struct {
 	ID     string `json:"id"`

--- a/client-go/controller/api/perms.go
+++ b/client-go/controller/api/perms.go
@@ -5,16 +5,6 @@ type PermsAppResponse struct {
 	Users []string `json:"users"`
 }
 
-// PermsAdminResponse is the definition of GET /v1/admin/perms/.
-type PermsAdminResponse struct {
-	Count    int `json:"count"`
-	Next     int `json:"next"`
-	Previous int `json:"previous"`
-	Users    []struct {
-		Username string `json:"username"`
-	} `json:"results"`
-}
-
 // PermsRequest is the definition of a requst on /perms/.
 type PermsRequest struct {
 	Username string `json:"username"`

--- a/client-go/controller/api/ps.go
+++ b/client-go/controller/api/ps.go
@@ -12,11 +12,3 @@ type Process struct {
 	Num     int    `json:"num"`
 	State   string `json:"state"`
 }
-
-// Processes defines the structure of processes.
-type Processes struct {
-	Count     int       `json:"count"`
-	Next      int       `json:"next"`
-	Previous  int       `json:"previous"`
-	Processes []Process `json:"results"`
-}

--- a/client-go/controller/api/releases.go
+++ b/client-go/controller/api/releases.go
@@ -13,14 +13,6 @@ type Release struct {
 	Version int    `json:"version"`
 }
 
-// Releases is the definition of GET /v1/apps/<app id>/releases/.
-type Releases struct {
-	Count    int       `json:"count"`
-	Next     int       `json:"next"`
-	Previous int       `json:"previous"`
-	Releases []Release `json:"results"`
-}
-
 // ReleaseRollback is the defenition of POST /v1/apps/<app id>/releases/.
 type ReleaseRollback struct {
 	Version int `json:"version"`

--- a/client-go/controller/api/users.go
+++ b/client-go/controller/api/users.go
@@ -13,11 +13,3 @@ type User struct {
 	IsActive    bool   `json:"is_active"`
 	DateJoined  string `json:"date_joined"`
 }
-
-// Users is the definition of GET /v1/users.
-type Users struct {
-	Count    int    `json:"count"`
-	Next     int    `json:"next"`
-	Previous int    `json:"previous"`
-	Users    []User `json:"results"`
-}

--- a/client-go/controller/client/client_test.go
+++ b/client-go/controller/client/client_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-const sFile string = `{"username":"t","ssl_verify":false,"controller":"http://d.t","token":"a"}`
+const sFile string = `{"username":"t","ssl_verify":false,"controller":"http://d.t","token":"a","response_limit": 50}`
 
 func createTempProfile(contents string) error {
 	name, err := ioutil.TempDir("", "client")
@@ -62,9 +62,15 @@ func TestLoadSave(t *testing.T) {
 		t.Errorf("Expected %s, Got %s", expected, client.ControllerURL.String())
 	}
 
+	expectedI := 50
+	if client.ResponseLimit != expectedI {
+		t.Errorf("Expected %d, Got %d", expectedI, client.ResponseLimit)
+	}
+
 	client.SSLVerify = true
 	client.Token = "b"
 	client.Username = "c"
+	client.ResponseLimit = 0
 
 	u, err := url.Parse("http://deis.test")
 
@@ -98,6 +104,11 @@ func TestLoadSave(t *testing.T) {
 	expected = "http://deis.test"
 	if client.ControllerURL.String() != expected {
 		t.Errorf("Expected %s, Got %s", expected, client.ControllerURL.String())
+	}
+
+	expectedI = 100
+	if client.ResponseLimit != expectedI {
+		t.Errorf("Expected %d, Got %d", expectedI, client.ResponseLimit)
 	}
 }
 

--- a/client-go/controller/models/apps/apps.go
+++ b/client-go/controller/models/apps/apps.go
@@ -11,19 +11,19 @@ import (
 )
 
 // List lists apps on a Deis controller.
-func List(c *client.Client) ([]api.App, error) {
-	body, err := c.BasicRequest("GET", "/v1/apps/", nil)
+func List(c *client.Client, results int) ([]api.App, int, error) {
+	body, count, err := c.LimitedRequest("/v1/apps/", results)
 
 	if err != nil {
-		return []api.App{}, err
+		return []api.App{}, -1, err
 	}
 
-	apps := api.Apps{}
+	var apps []api.App
 	if err = json.Unmarshal([]byte(body), &apps); err != nil {
-		return []api.App{}, err
+		return []api.App{}, -1, err
 	}
 
-	return apps.Apps, nil
+	return apps, count, nil
 }
 
 // New creates a new app.

--- a/client-go/controller/models/apps/apps_test.go
+++ b/client-go/controller/models/apps/apps_test.go
@@ -291,7 +291,7 @@ func TestAppsList(t *testing.T) {
 
 	client := client.Client{HTTPClient: httpClient, ControllerURL: *u, Token: "abc"}
 
-	actual, err := List(&client)
+	actual, _, err := List(&client, 100)
 
 	if err != nil {
 		t.Fatal(err)

--- a/client-go/controller/models/builds/builds.go
+++ b/client-go/controller/models/builds/builds.go
@@ -9,20 +9,20 @@ import (
 )
 
 // List lists an app's builds.
-func List(c *client.Client, appID string) ([]api.Build, error) {
+func List(c *client.Client, appID string, results int) ([]api.Build, int, error) {
 	u := fmt.Sprintf("/v1/apps/%s/builds/", appID)
-	body, err := c.BasicRequest("GET", u, nil)
+	body, count, err := c.LimitedRequest(u, results)
 
 	if err != nil {
-		return []api.Build{}, err
+		return []api.Build{}, -1, err
 	}
 
-	builds := api.Builds{}
+	var builds []api.Build
 	if err = json.Unmarshal([]byte(body), &builds); err != nil {
-		return []api.Build{}, err
+		return []api.Build{}, -1, err
 	}
 
-	return builds.Builds, nil
+	return builds, count, nil
 }
 
 // New creates a build for an app.

--- a/client-go/controller/models/builds/builds_test.go
+++ b/client-go/controller/models/builds/builds_test.go
@@ -122,7 +122,7 @@ func TestBuildsList(t *testing.T) {
 
 	client := client.Client{HTTPClient: httpClient, ControllerURL: *u, Token: "abc"}
 
-	actual, err := List(&client, "example-go")
+	actual, _, err := List(&client, "example-go", 100)
 
 	if err != nil {
 		t.Fatal(err)

--- a/client-go/controller/models/certs/certs.go
+++ b/client-go/controller/models/certs/certs.go
@@ -9,19 +9,19 @@ import (
 )
 
 // List certs registered with the controller.
-func List(c *client.Client) ([]api.Cert, error) {
-	body, err := c.BasicRequest("GET", "/v1/certs/", nil)
+func List(c *client.Client, results int) ([]api.Cert, int, error) {
+	body, count, err := c.LimitedRequest("/v1/certs/", results)
 
 	if err != nil {
-		return []api.Cert{}, err
+		return []api.Cert{}, -1, err
 	}
 
-	res := api.Certs{}
+	var res []api.Cert
 	if err = json.Unmarshal([]byte(body), &res); err != nil {
-		return []api.Cert{}, err
+		return []api.Cert{}, -1, err
 	}
 
-	return res.Certs, nil
+	return res, count, nil
 }
 
 // New creates a new cert.

--- a/client-go/controller/models/certs/certs_test.go
+++ b/client-go/controller/models/certs/certs_test.go
@@ -104,7 +104,7 @@ func TestCertsList(t *testing.T) {
 
 	client := client.Client{HTTPClient: httpClient, ControllerURL: *u, Token: "abc"}
 
-	actual, err := List(&client)
+	actual, _, err := List(&client, 100)
 
 	if err != nil {
 		t.Fatal(err)

--- a/client-go/controller/models/domains/domains.go
+++ b/client-go/controller/models/domains/domains.go
@@ -9,20 +9,20 @@ import (
 )
 
 // List domains registered with an app.
-func List(c *client.Client, appID string) ([]api.Domain, error) {
+func List(c *client.Client, appID string, results int) ([]api.Domain, int, error) {
 	u := fmt.Sprintf("/v1/apps/%s/domains/", appID)
-	body, err := c.BasicRequest("GET", u, nil)
+	body, count, err := c.LimitedRequest(u, results)
 
 	if err != nil {
-		return []api.Domain{}, err
+		return []api.Domain{}, -1, err
 	}
 
-	domains := api.Domains{}
+	var domains []api.Domain
 	if err = json.Unmarshal([]byte(body), &domains); err != nil {
-		return []api.Domain{}, err
+		return []api.Domain{}, -1, err
 	}
 
-	return domains.Domains, nil
+	return domains, count, nil
 }
 
 // New adds a domain to an app.

--- a/client-go/controller/models/domains/domains_test.go
+++ b/client-go/controller/models/domains/domains_test.go
@@ -110,7 +110,7 @@ func TestDomainsList(t *testing.T) {
 
 	client := client.Client{HTTPClient: httpClient, ControllerURL: *u, Token: "abc"}
 
-	actual, err := List(&client, "example-go")
+	actual, _, err := List(&client, "example-go", 100)
 
 	if err != nil {
 		t.Fatal(err)

--- a/client-go/controller/models/keys/keys.go
+++ b/client-go/controller/models/keys/keys.go
@@ -9,19 +9,19 @@ import (
 )
 
 // List keys on a controller.
-func List(c *client.Client) ([]api.Key, error) {
-	body, err := c.BasicRequest("GET", "/v1/keys/", nil)
+func List(c *client.Client, results int) ([]api.Key, int, error) {
+	body, count, err := c.LimitedRequest("/v1/keys/", results)
 
 	if err != nil {
-		return []api.Key{}, err
+		return []api.Key{}, -1, err
 	}
 
-	keys := api.Keys{}
+	var keys []api.Key
 	if err = json.Unmarshal([]byte(body), &keys); err != nil {
-		return []api.Key{}, err
+		return []api.Key{}, -1, err
 	}
 
-	return keys.Keys, nil
+	return keys, count, nil
 }
 
 // New creates a new key.

--- a/client-go/controller/models/keys/keys_test.go
+++ b/client-go/controller/models/keys/keys_test.go
@@ -113,7 +113,7 @@ func TestKeysList(t *testing.T) {
 
 	client := client.Client{HTTPClient: httpClient, ControllerURL: *u, Token: "abc"}
 
-	actual, err := List(&client)
+	actual, _, err := List(&client, 100)
 
 	if err != nil {
 		t.Fatal(err)

--- a/client-go/controller/models/perms/perms_test.go
+++ b/client-go/controller/models/perms/perms_test.go
@@ -170,7 +170,7 @@ func TestListAdmins(t *testing.T) {
 
 	client := client.Client{HTTPClient: httpClient, ControllerURL: *u, Token: "abc"}
 
-	actual, err := ListAdmins(&client)
+	actual, _, err := ListAdmins(&client, 100)
 
 	if err != nil {
 		t.Fatal(err)

--- a/client-go/controller/models/ps/ps.go
+++ b/client-go/controller/models/ps/ps.go
@@ -10,20 +10,20 @@ import (
 )
 
 // List an app's processes.
-func List(c *client.Client, appID string) ([]api.Process, error) {
+func List(c *client.Client, appID string, results int) ([]api.Process, int, error) {
 	u := fmt.Sprintf("/v1/apps/%s/containers/", appID)
-	body, err := c.BasicRequest("GET", u, nil)
+	body, count, err := c.LimitedRequest(u, results)
 
 	if err != nil {
-		return []api.Process{}, err
+		return []api.Process{}, -1, err
 	}
 
-	procs := api.Processes{}
+	var procs []api.Process
 	if err = json.Unmarshal([]byte(body), &procs); err != nil {
-		return []api.Process{}, err
+		return []api.Process{}, -1, err
 	}
 
-	return procs.Processes, nil
+	return procs, count, nil
 }
 
 // Scale an app's processes.

--- a/client-go/controller/models/ps/ps_test.go
+++ b/client-go/controller/models/ps/ps_test.go
@@ -163,7 +163,7 @@ func TestProcessesList(t *testing.T) {
 
 	client := client.Client{HTTPClient: httpClient, ControllerURL: *u, Token: "abc"}
 
-	actual, err := List(&client, "example-go")
+	actual, _, err := List(&client, "example-go", 100)
 
 	if err != nil {
 		t.Fatal(err)

--- a/client-go/controller/models/releases/releases.go
+++ b/client-go/controller/models/releases/releases.go
@@ -9,21 +9,21 @@ import (
 )
 
 // List lists an app's releases.
-func List(c *client.Client, appID string) ([]api.Release, error) {
+func List(c *client.Client, appID string, results int) ([]api.Release, int, error) {
 	u := fmt.Sprintf("/v1/apps/%s/releases/", appID)
 
-	body, err := c.BasicRequest("GET", u, nil)
+	body, count, err := c.LimitedRequest(u, results)
 
 	if err != nil {
-		return []api.Release{}, err
+		return []api.Release{}, -1, err
 	}
 
-	releases := api.Releases{}
+	var releases []api.Release
 	if err = json.Unmarshal([]byte(body), &releases); err != nil {
-		return []api.Release{}, err
+		return []api.Release{}, -1, err
 	}
 
-	return releases.Releases, nil
+	return releases, count, nil
 }
 
 // Get a release of an app.

--- a/client-go/controller/models/releases/releases_test.go
+++ b/client-go/controller/models/releases/releases_test.go
@@ -151,7 +151,7 @@ func TestReleasesList(t *testing.T) {
 
 	client := client.Client{HTTPClient: httpClient, ControllerURL: *u, Token: "abc"}
 
-	actual, err := List(&client, "example-go")
+	actual, _, err := List(&client, "example-go", 100)
 
 	if err != nil {
 		t.Fatal(err)

--- a/client-go/controller/models/users/users.go
+++ b/client-go/controller/models/users/users.go
@@ -8,17 +8,17 @@ import (
 )
 
 // List users registered with the controller.
-func List(c *client.Client) ([]api.User, error) {
-	body, err := c.BasicRequest("GET", "/v1/users/", nil)
+func List(c *client.Client, results int) ([]api.User, int, error) {
+	body, count, err := c.LimitedRequest("/v1/users/", results)
 
 	if err != nil {
-		return []api.User{}, err
+		return []api.User{}, -1, err
 	}
 
-	users := api.Users{}
+	var users []api.User
 	if err = json.Unmarshal([]byte(body), &users); err != nil {
-		return []api.User{}, err
+		return []api.User{}, -1, err
 	}
 
-	return users.Users, nil
+	return users, count, nil
 }

--- a/client-go/controller/models/users/users_test.go
+++ b/client-go/controller/models/users/users_test.go
@@ -83,7 +83,7 @@ func TestUsersList(t *testing.T) {
 
 	client := client.Client{HTTPClient: httpClient, ControllerURL: *u, Token: "abc"}
 
-	actual, err := List(&client)
+	actual, _, err := List(&client, 100)
 
 	if err != nil {
 		t.Fatal(err)

--- a/client-go/parser/apps.go
+++ b/client-go/parser/apps.go
@@ -91,13 +91,25 @@ func appsList(argv []string) error {
 	usage := `
 Lists applications visible to the current user.
 
-Usage: deis apps:list
+Usage: deis apps:list [options]
+
+Options:
+  -l --limit=<num>
+    the maximum number of results to display, defaults to config setting
 `
-	if _, err := docopt.Parse(usage, argv, true, "", false, true); err != nil {
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+
+	if err != nil {
 		return err
 	}
 
-	return cmd.AppsList()
+	results, err := responseLimit(safeGetValue(args, "--limit"))
+
+	if err != nil {
+		return err
+	}
+
+	return cmd.AppsList(results)
 }
 
 func appInfo(argv []string) error {

--- a/client-go/parser/builds.go
+++ b/client-go/parser/builds.go
@@ -44,6 +44,8 @@ Usage: deis builds:list [options]
 Options:
   -a --app=<app>
     the uniquely identifiable name for the application.
+  -l --limit=<num>
+    the maximum number of results to display, defaults to config setting
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
@@ -52,7 +54,13 @@ Options:
 		return err
 	}
 
-	return cmd.BuildsList(safeGetValue(args, "--app"))
+	results, err := responseLimit(safeGetValue(args, "--limit"))
+
+	if err != nil {
+		return err
+	}
+
+	return cmd.BuildsList(safeGetValue(args, "--app"), results)
 }
 
 func buildsCreate(argv []string) error {

--- a/client-go/parser/certs.go
+++ b/client-go/parser/certs.go
@@ -42,14 +42,26 @@ func certsList(argv []string) error {
 	usage := `
 Show certificate information for an SSL application.
 
-Usage: deis certs:list
+Usage: deis certs:list [options]
+
+Options:
+  -l --limit=<num>
+    the maximum number of results to display, defaults to config setting
 `
 
-	if _, err := docopt.Parse(usage, argv, true, "", false, true); err != nil {
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+
+	if err != nil {
 		return err
 	}
 
-	return cmd.CertsList()
+	results, err := responseLimit(safeGetValue(args, "--limit"))
+
+	if err != nil {
+		return err
+	}
+
+	return cmd.CertsList(results)
 }
 
 func certAdd(argv []string) error {

--- a/client-go/parser/domains.go
+++ b/client-go/parser/domains.go
@@ -69,8 +69,10 @@ Lists domains bound to an application.
 Usage: deis domains:list [options]
 
 Options:
-	-a --app=<app>
-		the uniquely identifiable name for the application.
+  -a --app=<app>
+    the uniquely identifiable name for the application.
+  -l --limit=<num>
+    the maximum number of results to display, defaults to config setting
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
@@ -79,7 +81,13 @@ Options:
 		return err
 	}
 
-	return cmd.DomainsList(safeGetValue(args, "--app"))
+	results, err := responseLimit(safeGetValue(args, "--limit"))
+
+	if err != nil {
+		return err
+	}
+
+	return cmd.DomainsList(safeGetValue(args, "--app"), results)
 }
 
 func domainsRemove(argv []string) error {

--- a/client-go/parser/keys.go
+++ b/client-go/parser/keys.go
@@ -42,14 +42,26 @@ func keysList(argv []string) error {
 	usage := `
 Lists SSH keys for the logged in user.
 
-Usage: deis keys:list
+Usage: deis keys:list [options]
+
+Options:
+  -l --limit=<num>
+    the maximum number of results to display, defaults to config setting
 `
 
-	if _, err := docopt.Parse(usage, argv, true, "", false, true); err != nil {
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+
+	if err != nil {
 		return err
 	}
 
-	return cmd.KeysList()
+	results, err := responseLimit(safeGetValue(args, "--limit"))
+
+	if err != nil {
+		return err
+	}
+
+	return cmd.KeysList(results)
 }
 
 func keyAdd(argv []string) error {

--- a/client-go/parser/perms.go
+++ b/client-go/parser/perms.go
@@ -43,7 +43,7 @@ func permsList(argv []string) error {
 Lists all users with permission to use an app, or lists all users with system
 administrator privileges.
 
-Usage: deis perms:list [-a --app=<app>|--admin]
+Usage: deis perms:list [-a --app=<app>|--admin|--admin --limit=<num>]
 
 Options:
   -a --app=<app>
@@ -51,6 +51,8 @@ Options:
     for the application.
   --admin
     lists all users with system administrator privileges.
+  -l --limit=<num>
+    the maximum number of results to display, defaults to config setting
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
@@ -61,7 +63,13 @@ Options:
 
 	admin := args["--admin"].(bool)
 
-	return cmd.PermsList(safeGetValue(args, "--app"), admin)
+	results, err := responseLimit(safeGetValue(args, "--limit"))
+
+	if err != nil {
+		return err
+	}
+
+	return cmd.PermsList(safeGetValue(args, "--app"), admin, results)
 }
 
 func permCreate(argv []string) error {

--- a/client-go/parser/ps.go
+++ b/client-go/parser/ps.go
@@ -47,6 +47,8 @@ Usage: deis ps:list [options]
 Options:
   -a --app=<app>
     the uniquely identifiable name for the application.
+  -l --limit=<num>
+    the maximum number of results to display, defaults to config setting
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
@@ -55,7 +57,13 @@ Options:
 		return err
 	}
 
-	return cmd.PsList(safeGetValue(args, "--app"))
+	results, err := responseLimit(safeGetValue(args, "--limit"))
+
+	if err != nil {
+		return err
+	}
+
+	return cmd.PsList(safeGetValue(args, "--app"), results)
 }
 
 func psRestart(argv []string) error {

--- a/client-go/parser/releases.go
+++ b/client-go/parser/releases.go
@@ -48,6 +48,8 @@ Usage: deis releases:list [options]
 Options:
   -a --app=<app>
     the uniquely identifiable name for the application.
+  -l --limit=<num>
+    the maximum number of results to display, defaults to config setting
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
@@ -56,7 +58,13 @@ Options:
 		return err
 	}
 
-	return cmd.ReleasesList(safeGetValue(args, "--app"))
+	results, err := responseLimit(safeGetValue(args, "--limit"))
+
+	if err != nil {
+		return err
+	}
+
+	return cmd.ReleasesList(safeGetValue(args, "--app"), results)
 }
 
 func releasesInfo(argv []string) error {

--- a/client-go/parser/users.go
+++ b/client-go/parser/users.go
@@ -37,12 +37,24 @@ func usersList(argv []string) error {
 Lists all registered users.
 Requires admin privilages.
 
-Usage: deis users:list
+Usage: deis users:list [options]
+
+Options:
+  -l --limit=<num>
+    the maximum number of results to display, defaults to config setting
 `
 
-	if _, err := docopt.Parse(usage, argv, true, "", false, true); err != nil {
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+
+	if err != nil {
 		return err
 	}
 
-	return cmd.UsersList()
+	results, err := responseLimit(safeGetValue(args, "--limit"))
+
+	if err != nil {
+		return err
+	}
+
+	return cmd.UsersList(results)
 }

--- a/client-go/parser/utils.go
+++ b/client-go/parser/utils.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"strconv"
 )
 
 // docopt expects commands to be in the proper format, but we split them apart for
@@ -19,6 +20,14 @@ func safeGetValue(args map[string]interface{}, key string) string {
 		return ""
 	}
 	return args[key].(string)
+}
+
+func responseLimit(limit string) (int, error) {
+	if limit == "" {
+		return -1, nil
+	}
+
+	return strconv.Atoi(limit)
 }
 
 // PrintUsage runs if no matching command is found.

--- a/controller/deis/settings.py
+++ b/controller/deis/settings.py
@@ -199,6 +199,7 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.JSONRenderer',
     ),
     'PAGINATE_BY': 100,
+    'PAGINATE_BY_PARAM': 'page_size',
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 

--- a/docs/reference/api-v1.6.rst
+++ b/docs/reference/api-v1.6.rst
@@ -16,6 +16,8 @@ What's New
 
 **New!** administrators no longer have to supply a password when deleting another user.
 
+**New!** ``?page_size`` query parameter for paginated requests to set the number of results per page.
+
 Authentication
 --------------
 


### PR DESCRIPTION
Right now, if you have over 100 apps, deis only lists the first 100, now all of the apps are displayed.

Fixes #3911