### PR TITLE
fix(contrib): fix debug-etcd

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -142,7 +142,7 @@ coreos:
       [Service]
       ExecStartPre=/usr/bin/curl -sSL -o /opt/bin/jq http://stedolan.github.io/jq/download/linux64/jq
       ExecStartPre=/usr/bin/chmod +x /opt/bin/jq
-      ExecStart=/usr/bin/bash -c "while true; do curl -sL http://127.0.0.1:4001/v2/stats/leader | /opt/bin/jq . ; sleep 1 ; done"
+      ExecStart=/usr/bin/bash -c "while true; do curl -sL http://127.0.0.1:4001/v2/stats/self | /opt/bin/jq . ; sleep 1 ; done"
   - name: increase-nf_conntrack-connections.service
     command: start
     content: |


### PR DESCRIPTION
Hitting the /v2/stats/leader endpoint would only work on the etcd
leader. Instead, we hit /v2/stats/self which will always work.This
doesn't show stats from the other members, but a user could start
the service on all hosts.