### PR TITLE
fix(builder): always configure SSH key

### DIFF
--- a/builder/rootfs/usr/local/src/slugbuilder/builder/build.sh
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/build.sh
@@ -69,6 +69,19 @@ export HOME="$app_dir"
 export REQUEST_ID=$(openssl rand -base64 32)
 export STACK=cedar-14
 
+## SSH key configuration
+
+if [[ -n "$SSH_KEY" ]]; then
+    mkdir -p ~/.ssh/
+    chmod 700 ~/.ssh/
+
+    echo $SSH_KEY | base64 -d > ~/.ssh/id_rsa
+    chmod 400 ~/.ssh/id_rsa
+
+    echo 'StrictHostKeyChecking=no' > ~/.ssh/config
+    chmod 600 ~/.ssh/config
+fi
+
 ## Buildpack detection
 
 buildpacks=($buildpack_root/*)
@@ -85,18 +98,6 @@ if [[ -n "$BUILDPACK_URL" ]]; then
 
     if [ "$committish" == "$url" ]; then
         committish="master"
-    fi
-
-    if [[ -n "$SSH_KEY" ]]; then
-        mkdir -p ~/.ssh/
-        chmod 700 ~/.ssh/
-
-        echo $SSH_KEY | base64 -d > ~/.ssh/id_rsa
-        chmod 400 ~/.ssh/id_rsa
-
-        echo 'StrictHostKeyChecking=no' > ~/.ssh/config
-        chmod 600 ~/.ssh/config
-
     fi
 
     set +e


### PR DESCRIPTION
SSH is now configured regardless of whether a custom buildpack was specified.

Fixes #4172.