### PR TITLE
feat(controller): allow users to transfer app ownership.

### DIFF
--- a/client/cmd/apps.go
+++ b/client/cmd/apps.go
@@ -240,3 +240,24 @@ func AppDestroy(appID, confirm string) error {
 
 	return nil
 }
+
+// AppTransfer transfers app ownership to another user.
+func AppTransfer(appID, username string) error {
+	c, appID, err := load(appID)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Transferring %s to %s... ", appID, username)
+
+	err = apps.Transfer(c, appID, username)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("done")
+
+	return nil
+}

--- a/client/controller/api/apps.go
+++ b/client/controller/api/apps.go
@@ -15,6 +15,11 @@ type AppCreateRequest struct {
 	ID string `json:"id,omitempty"`
 }
 
+// AppUpdateRequest is the definition of POST /v1/apps/<app id>/.
+type AppUpdateRequest struct {
+	Owner string `json:"owner,omitempty"`
+}
+
 // AppRunRequest is the definition of POST /v1/apps/<app id>/run.
 type AppRunRequest struct {
 	Command string `json:"command"`

--- a/client/controller/models/apps/apps.go
+++ b/client/controller/models/apps/apps.go
@@ -123,3 +123,18 @@ func Delete(c *client.Client, appID string) error {
 	_, err := c.BasicRequest("DELETE", u, nil)
 	return err
 }
+
+// Transfer an app to another user.
+func Transfer(c *client.Client, appID string, username string) error {
+	u := fmt.Sprintf("/v1/apps/%s/", appID)
+
+	req := api.AppUpdateRequest{Owner: username}
+	body, err := json.Marshal(req)
+
+	if err != nil {
+		return err
+	}
+
+	_, err = c.BasicRequest("POST", u, body)
+	return err
+}

--- a/client/parser/apps.go
+++ b/client/parser/apps.go
@@ -8,7 +8,7 @@ import (
 	docopt "github.com/docopt/docopt-go"
 )
 
-// Apps routes app commands to the specific function
+// Apps routes app commands to their specific function.
 func Apps(argv []string) error {
 	usage := `
 Valid commands for apps:
@@ -20,6 +20,7 @@ apps:open          open the application in a browser
 apps:logs          view aggregated application logs
 apps:run           run a command in an ephemeral app container
 apps:destroy       destroy an application
+apps:transfer      transfer app ownership to another user
 
 Use 'deis help [command]' to learn more.
 `
@@ -39,6 +40,8 @@ Use 'deis help [command]' to learn more.
 		return appRun(argv)
 	case "apps:destroy":
 		return appDestroy(argv)
+	case "apps:transfer":
+		return appTransfer(argv)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -243,4 +246,27 @@ Options:
 	confirm := safeGetValue(args, "--confirm")
 
 	return cmd.AppDestroy(app, confirm)
+}
+
+func appTransfer(argv []string) error {
+	usage := `
+Transfer app ownership to another user.
+
+Usage: deis apps:transfer <username> [options]
+
+Arguments:
+  <username>
+    the user that the app will be transfered to.
+
+Options:
+  -a --app=<app>
+    the uniquely identifiable name for the application.
+`
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+
+	if err != nil {
+		return err
+	}
+
+	return cmd.AppTransfer(safeGetValue(args, "--app"), safeGetValue(args, "<username>"))
 }

--- a/controller/api/__init__.py
+++ b/controller/api/__init__.py
@@ -2,4 +2,4 @@
 The **api** Django app presents a RESTful web API for interacting with the **deis** system.
 """
 
-__version__ = '1.6.0'
+__version__ = '1.7.0'

--- a/controller/api/fixtures/tests.json
+++ b/controller/api/fixtures/tests.json
@@ -34,5 +34,23 @@
         "email": "autotest2@deis.io",
         "date_joined": "2013-05-10T16:08:09.357Z"
     }
+},
+{
+    "pk": 9,
+    "model": "auth.user",
+    "fields": {
+        "username": "autotest3",
+        "first_name": "Otto",
+        "last_name": "Test",
+        "is_active": true,
+        "is_superuser": false,
+        "is_staff": false,
+        "last_login": "2013-05-10T16:08:09.357Z",
+        "groups": [],
+        "user_permissions": [],
+        "password": "pbkdf2_sha256$10000$5Uoq7dl61vnN$gQhDpc2q2Rkn16VdPC+pNNEQcKpy+LGe29Zkad+2/m4=",
+        "email": "autotest3@deis.io",
+        "date_joined": "2013-05-10T16:08:09.357Z"
+    }
 }
 ]

--- a/controller/api/tests/test_users.py
+++ b/controller/api/tests/test_users.py
@@ -21,9 +21,7 @@ class TestUsers(TestCase):
                                    HTTP_AUTHORIZATION='token {}'.format(token))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data['results']), 2)
-        self.assertEqual(response.data['results'][0]['username'], 'autotest')
-        self.assertEqual(response.data['results'][1]['username'], 'autotest2')
+        self.assertEqual(len(response.data['results']), 3)
 
     def test_non_super_user_cannot_list(self):
         url = '/v1/users/'

--- a/controller/api/urls.py
+++ b/controller/api/urls.py
@@ -63,7 +63,7 @@ urlpatterns = patterns(
         views.AppPermsViewSet.as_view({'get': 'list', 'post': 'create'})),
     # apps base endpoint
     url(r"^apps/(?P<id>{})/?".format(settings.APP_URL_REGEX),
-        views.AppViewSet.as_view({'get': 'retrieve', 'delete': 'destroy'})),
+        views.AppViewSet.as_view({'get': 'retrieve', 'post': 'update', 'delete': 'destroy'})),
     url(r'^apps/?',
         views.AppViewSet.as_view({'get': 'list', 'post': 'create'})),
     # key

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -224,6 +224,17 @@ class AppViewSet(BaseDeisViewSet):
         return Response(output_and_rc, status=status.HTTP_200_OK,
                         content_type='text/plain')
 
+    def update(self, request, **kwargs):
+        app = self.get_object()
+
+        if request.data.get('owner'):
+            if self.request.user != app.owner and not self.request.user.is_superuser:
+                raise PermissionDenied()
+            new_owner = get_object_or_404(User, username=request.data['owner'])
+            app.owner = new_owner
+        app.save()
+        return Response(status=status.HTTP_200_OK)
+
 
 class BuildViewSet(ReleasableViewSet):
     """A viewset for interacting with Build objects."""

--- a/docs/reference/api-v1.7.rst
+++ b/docs/reference/api-v1.7.rst
@@ -1,20 +1,18 @@
-:title: Controller API v1.6
-:description: The v1.6 REST API for Deis' Controller
+:title: Controller API v1.7
+:description: The v1.7 REST API for Deis' Controller
 
-Controller API v1.6
+.. _controller_api_v1:
+
+Controller API v1.7
 ===================
 
-This is the v1.6 REST API for the :ref:`Controller`.
+This is the v1.7 REST API for the :ref:`Controller`.
 
 
 What's New
 ----------
 
-**New!** administrators no longer have to supply a password when changing another user's password.
-
-**New!** administrators no longer have to supply a password when deleting another user.
-
-**New!** ``?page_size`` query parameter for paginated requests to set the number of results per page.
+**New!** apps can now be updated ``POST /v1/apps/<app id>``.
 
 
 Authentication
@@ -52,7 +50,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -90,7 +88,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -113,7 +111,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
 
 Regenerate Token
@@ -145,7 +143,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -183,7 +181,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
 
 
@@ -207,7 +205,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -253,7 +251,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -284,7 +282,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
 
 
@@ -304,7 +302,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -318,6 +316,33 @@ Example Response:
         "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
     }
 
+Update Application Details
+``````````````````````````
+
+Example Request:
+
+.. code-block:: console
+
+    POST /v1/apps/example-go/ HTTP/1.1
+    Host: deis.example.com
+    Authorization: token abc123
+
+Optional parameters:
+
+.. code-block:: console
+
+    {
+      "owner": "test"
+    }
+
+Example Response:
+
+.. code-block:: console
+
+    HTTP/1.1 200 OK
+    DEIS_API_VERSION: 1.7
+    DEIS_PLATFORM_VERSION: 1.8.0
+    Content-Type: application/json
 
 Retrieve Application Logs
 `````````````````````````
@@ -341,7 +366,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: text/plain
 
@@ -365,7 +390,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -392,7 +417,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -425,7 +450,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -470,7 +495,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -500,7 +525,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
 
 
@@ -524,7 +549,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -564,7 +589,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -604,7 +629,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -639,7 +664,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -674,7 +699,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -712,7 +737,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
 
 
@@ -736,7 +761,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -774,7 +799,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
     X-Deis-Release: 3
@@ -817,7 +842,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
     X-Deis-Release: 4
@@ -859,7 +884,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -897,7 +922,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -927,7 +952,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
 
 
@@ -951,7 +976,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -1006,7 +1031,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
     X-Deis-Release: 4
@@ -1044,7 +1069,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -1106,7 +1131,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -1142,7 +1167,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -1169,7 +1194,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -1211,7 +1236,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -1241,7 +1266,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
 
 
@@ -1269,7 +1294,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -1299,7 +1324,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
 
 
@@ -1319,7 +1344,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
 
 List Administrators
@@ -1338,7 +1363,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 
@@ -1381,7 +1406,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 201 CREATED
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
 
 Remove User's Administrative Privileges
@@ -1404,7 +1429,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 204 NO CONTENT
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
 
 Users
@@ -1430,7 +1455,7 @@ Example Response:
 .. code-block:: console
 
     HTTP/1.1 200 OK
-    DEIS_API_VERSION: 1.6
+    DEIS_API_VERSION: 1.7
     DEIS_PLATFORM_VERSION: 1.10.0
     Content-Type: application/json
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -20,3 +20,4 @@ Reference Guide
     api-v1.4
     api-v1.5
     api-v1.6
+    api-v1.7

--- a/tests/utils/itutils.go
+++ b/tests/utils/itutils.go
@@ -37,6 +37,7 @@ type DeisTestConfig struct {
 	UserName           string
 	Password           string
 	NewPassword        string
+	NewOwner           string
 	Email              string
 	ExampleApp         string
 	AppDomain          string

--- a/version/version.go
+++ b/version/version.go
@@ -4,4 +4,4 @@ package version
 const Version = "1.11.0-dev"
 
 // API identifies the latest Deis api verison
-const APIVersion = "1.6"
+const APIVersion = "1.7"


### PR DESCRIPTION
This is really useful if a user needs to delete their account, but they have apps that their company depends on attached to it. A user can use `apps:transfer` to transfer ownership of the app before deleting their account.