### PR TITLE
fix(deisctl/units): stop k8s services without errors

### DIFF
--- a/deisctl/units/deis-kube-apiserver.service
+++ b/deisctl/units/deis-kube-apiserver.service
@@ -3,6 +3,7 @@ Description=Kubernetes API Server
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 Requires=fleet.service docker.service flanneld.service
 After=fleet.service docker.service flanneld.service
+
 [Service]
 EnvironmentFile=/etc/environment
 ExecStartPre=-/bin/sh -c "etcdctl get /deis/scheduler/k8s/master >/dev/null 2>&1 || etcdctl mk /deis/scheduler/k8s/master"
@@ -26,5 +27,7 @@ ExecStart=/bin/bash -c "/opt/bin/kube-apiserver \
 ExecStartPost=/bin/bash -c "fleetctl stop deis-kube-scheduler deis-kube-controller-manager deis-kube-kubelet deis-kube-proxy; sleep 2; fleetctl start deis-kube-scheduler deis-kube-controller-manager deis-kube-kubelet deis-kube-proxy"
 Restart=always
 RestartSec=10
+SuccessExitStatus=2
+
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-kube-controller-manager.service
+++ b/deisctl/units/deis-kube-controller-manager.service
@@ -3,6 +3,7 @@ Description=Kubernetes Controller Manager
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 Requires=deis-kube-apiserver.service
 After=deis-kube-apiserver.service
+
 [Service]
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/bash -c "/opt/bin/download-k8s-binary kube-controller-manager"
@@ -14,6 +15,7 @@ ExecStart=/opt/bin/kube-controller-manager \
   --logtostderr=true
 Restart=always
 RestartSec=10
+SuccessExitStatus=2
 
 [X-Fleet]
 MachineOf=deis-kube-apiserver.service

--- a/deisctl/units/deis-kube-kubelet.service
+++ b/deisctl/units/deis-kube-kubelet.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Kubernetes Kubelet
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+
 [Service]
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/bash -c "/opt/bin/download-k8s-binary kubelet"
@@ -10,7 +11,7 @@ ExecStart=/bin/bash -c '/opt/bin/kubelet --address=0.0.0.0 --port=10250 --hostna
 Restart=always
 RestartSec=10
 WorkingDirectory=/root/
-
+SuccessExitStatus=2
 
 [X-Fleet]
 Global=true

--- a/deisctl/units/deis-kube-proxy.service
+++ b/deisctl/units/deis-kube-proxy.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Kubernetes Proxy
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+
 [Service]
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/bash -c "/opt/bin/download-k8s-binary kube-proxy"
@@ -8,5 +9,7 @@ ExecStartPre=/bin/bash -c "/opt/bin/wupiao $(/usr/bin/etcdctl get /deis/schedule
 ExecStart=/bin/bash -c '/opt/bin/kube-proxy --master=`/usr/bin/etcdctl get /deis/scheduler/k8s/master`:8080 --logtostderr=true'
 Restart=always
 RestartSec=10
+SuccessExitStatus=2
+
 [X-Fleet]
 Global=true

--- a/deisctl/units/deis-kube-scheduler.service
+++ b/deisctl/units/deis-kube-scheduler.service
@@ -3,6 +3,7 @@ Description=Kubernetes Scheduler
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 Requires=deis-kube-apiserver.service
 After=deis-kube-apiserver.service
+
 [Service]
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/bash -c "/opt/bin/download-k8s-binary kube-scheduler"
@@ -12,5 +13,7 @@ ExecStart=/opt/bin/kube-scheduler \
   --policy-config-file=/opt/bin/scheduler-policy.json
 Restart=always
 RestartSec=10
+SuccessExitStatus=2
+
 [X-Fleet]
 MachineOf=deis-kube-apiserver.service


### PR DESCRIPTION
The various kube-* binaries all exit with a return code of 2 on CTRL+C / SIGQUIT|TERM|KILL. This change considers 2 to be a successful k8s service exit as well, to avoid systemd failures on `deisctl stop k8s`.

See http://www.freedesktop.org/software/systemd/man/systemd.service.html#SuccessExitStatus= for background docs.

Closes #4213.