### PR TITLE
fix(contrib): remove manage_etc_hosts from example user-data

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -354,4 +354,3 @@ write_files:
           "predicates": [{"name": "PodFitsPorts"},{"name": "PodFitsResources"},{"name": "NoDiskConflict"},{"name": "MatchNodeSelector"},{"name": "HostName"}],
           "priorities": [{"name": "LeastRequestedPriority","weight": 1},{"name": "BalancedResourceAllocation","weight": 1},{"name": "ServiceSpreadingPriority","weight": 2},{"name": "EqualPriority","weight": 1}]
       }
-manage_etc_hosts: localhost


### PR DESCRIPTION
The manage_etc_hosts cloud config was added so that instances with hostnames that did not resolve correctly could still use the graceful shutdown logic. I personally only observed this issue with vagrant.

This seems to cause issues on GCE though, and should probably be removed.

https://github.com/coreos/bugs/issues/425