### PR TITLE
[WIP] feat(deisctl): add a verbose start option

### DIFF
--- a/deisctl/backend/backend.go
+++ b/deisctl/backend/backend.go
@@ -20,4 +20,5 @@ type Backend interface {
 	ListUnitFiles() error
 	Status(string) error
 	Journal(string) error
+	JournalBackground(string, io.Writer) []chan bool
 }

--- a/deisctl/backend/fleet/fleet.go
+++ b/deisctl/backend/fleet/fleet.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"text/tabwriter"
+	"time"
 
 	"github.com/deis/deis/deisctl/config"
 
@@ -20,10 +21,13 @@ type FleetClient struct {
 	// used to cache MachineStates
 	machineStates map[string]*machine.MachineState
 
-	templatePaths []string
-	runner        commandRunner
-	out           *tabwriter.Writer
-	errWriter     io.Writer
+	templatePaths          []string
+	runner                 commandRunner
+	runRemoteCommandString func(string, string) (string, error)
+	out                    *tabwriter.Writer
+	errWriter              io.Writer
+	journalInterval        time.Duration
+	timeNow                func() time.Time
 }
 
 // NewClient returns a client used to communicate with Fleet
@@ -44,6 +48,7 @@ func NewClient(cb config.Backend) (*FleetClient, error) {
 	out := new(tabwriter.Writer)
 	out.Init(os.Stdout, 0, 8, 1, '\t', 0)
 
-	return &FleetClient{Fleet: client, configBackend: cb, templatePaths: templatePaths, runner: sshCommandRunner{},
-		out: out, errWriter: os.Stderr}, nil
+	return &FleetClient{Fleet: client, configBackend: cb, templatePaths: templatePaths,
+		runner: sshCommandRunner{}, runRemoteCommandString: runRemoteCommandString, out: out,
+		errWriter: os.Stderr, journalInterval: time.Second, timeNow: time.Now}, nil
 }

--- a/deisctl/backend/fleet/journal.go
+++ b/deisctl/backend/fleet/journal.go
@@ -2,6 +2,8 @@ package fleet
 
 import (
 	"fmt"
+	"io"
+	"time"
 )
 
 // Journal prints the systemd journal of target unit(s)
@@ -26,4 +28,69 @@ func (c *FleetClient) runJournal(name string) (exit int) {
 
 	command := fmt.Sprintf("journalctl --unit %s --no-pager -n 40 -f", name)
 	return c.runCommand(command, machineID)
+}
+
+// JournalBackground runs Journal in the background
+func (c *FleetClient) JournalBackground(targets string, out io.Writer) []chan bool {
+	var quitChans []chan bool
+
+	expandedTargets, err := c.expandTargets([]string{targets})
+	if err != nil {
+		fmt.Fprintln(out, err)
+		return []chan bool{}
+	}
+	for _, target := range expandedTargets {
+		quit := c.runJournalBackground(target, out)
+
+		if quit != nil {
+			quitChans = append(quitChans, quit)
+		}
+	}
+	return quitChans
+}
+
+func (c *FleetClient) runJournalBackground(target string, out io.Writer) chan bool {
+	machineID, err := c.findUnit(target)
+
+	// Return if the unit can't be found.
+	if err != nil {
+		return nil
+	}
+
+	ms, err := c.machineState(machineID)
+	if err != nil || ms == nil {
+		fmt.Fprintf(out, "Error getting machine IP: %v\n", err)
+		return nil
+	}
+
+	tick := time.Tick(c.journalInterval)
+	quit := make(chan bool)
+
+	go func() {
+		for {
+			select {
+			case <-tick:
+				layout := "2006-01-02 15:04:05"
+				now := c.timeNow().Add(-c.journalInterval).UTC().Format(layout)
+				command := fmt.Sprintf(`journalctl --unit %s --no-pager -o cat --since="%s"`, target, now)
+				log, err := c.runRemoteCommandString(command, ms.PublicIP)
+
+				if err != nil {
+					fmt.Fprintf(out, "Deisctl Error: %s\n", err.Error())
+					continue
+				}
+
+				// Journalctl doesn't have logs yet
+				if log == "Failed to get data: Cannot assign requested address\n" {
+					continue
+				}
+				fmt.Fprint(out, log)
+			case <-quit:
+				close(quit)
+				return
+			}
+		}
+	}()
+
+	return quit
 }

--- a/deisctl/backend/fleet/journal_test.go
+++ b/deisctl/backend/fleet/journal_test.go
@@ -21,7 +21,7 @@ func (mockJournalCommandRunner) LocalCommand(string) (int, error) {
 
 func (m mockJournalCommandRunner) RemoteCommand(cmd string, addr string, timeout time.Duration) (int, error) {
 	if addr != "1.1.1.1" || timeout != 0 {
-		return -1, fmt.Errorf("Got %s %d, which is unexpected", cmd, addr, timeout)
+		return -1, fmt.Errorf("Got %s %s %d, which is unexpected", cmd, addr, timeout)
 	}
 
 	for _, unit := range m.validUnits {
@@ -74,5 +74,105 @@ func TestJournal(t *testing.T) {
 
 	if commandErr != "" {
 		t.Error(commandErr)
+	}
+}
+
+var ITERATIONS int
+var done chan bool
+
+func testBackgroundRunner(cmd string, IP string) (string, error) {
+
+	if IP != "1.1.1.1" {
+		if done != nil {
+			close(done)
+		}
+		return "", fmt.Errorf("Bad IP: %s", IP)
+	}
+
+	if cmd != `journalctl --unit deis-router@1.service --no-pager -o cat --since="2006-01-02 15:04:00"` {
+		if done != nil {
+			close(done)
+		}
+		return "", fmt.Errorf("Bad Command: %s", cmd)
+	}
+
+	defer func() { ITERATIONS++ }()
+
+	switch ITERATIONS {
+	case 0:
+		return "Failed to get data: Cannot assign requested address\n", nil
+	case 1:
+		return "test\n", nil
+	case 2:
+		return "foo\n", nil
+	case 3:
+		defer func() {
+			if done != nil {
+				close(done)
+			}
+		}()
+		return "bar\n", nil
+	default:
+		return "", nil
+	}
+}
+
+func timeStub() time.Time {
+	timeStub, _ := time.Parse("2006-01-02 15:04:05 UTC", "2006-01-02 15:04:01 UTC")
+	return timeStub
+}
+
+func TestJournalBackground(t *testing.T) {
+	t.Parallel()
+
+	done = make(chan bool)
+
+	testMachines := []machine.MachineState{
+		machine.MachineState{
+			ID:       "test-1",
+			PublicIP: "1.1.1.1",
+			Metadata: nil,
+			Version:  "",
+		},
+	}
+
+	testUnits := []*schema.Unit{
+		&schema.Unit{
+			Name:         "deis-router@1.service",
+			CurrentState: "loaded",
+			MachineID:    "test-1",
+		},
+		&schema.Unit{
+			Name:         "deis-router@2.service",
+			CurrentState: "loaded",
+			MachineID:    "test-1",
+		},
+	}
+
+	testWriter := bytes.Buffer{}
+
+	c := &FleetClient{Fleet: &stubFleetClient{testUnits: testUnits, testMachineStates: testMachines,
+		unitsMutex: &sync.Mutex{}}, errWriter: &testWriter, journalInterval: time.Nanosecond,
+		runRemoteCommandString: testBackgroundRunner, timeNow: timeStub}
+
+	expected := "test\nfoo\nbar\n"
+	quitChans := c.JournalBackground("router@1", &testWriter)
+	if done != nil {
+		<-done
+	}
+
+	if len(quitChans) != 1 {
+		t.Errorf("Expected 1 quit channel, Got %d", len(quitChans))
+	}
+
+	for _, quit := range quitChans {
+		quit <- true
+		<-quit
+	}
+
+	actual := testWriter.String()
+
+	if actual != expected {
+		t.Errorf("Expected %s, Got %s", expected, actual)
 	}
 }

--- a/deisctl/backend/fleet/start.go
+++ b/deisctl/backend/fleet/start.go
@@ -75,13 +75,11 @@ func doStart(c *FleetClient, target string, wg *sync.WaitGroup, out, ew io.Write
 
 		// if subState changed, send it across the output channel
 		if lastSubState != currentState.SystemdSubState {
-			l := prettyprint.Overwritef(stateFmt, name, currentState.SystemdActiveState, currentState.SystemdSubState)
-			fmt.Fprintf(out, l)
+			fmt.Fprintf(out, stateFmt+"\n", name, currentState.SystemdActiveState, currentState.SystemdSubState)
 		}
 
 		// break when desired state is reached
 		if currentState.SystemdSubState == desiredState {
-			fmt.Fprintln(out)
 			return
 		}
 

--- a/deisctl/backend/fleet/status_test.go
+++ b/deisctl/backend/fleet/status_test.go
@@ -84,7 +84,7 @@ func TestStatus(t *testing.T) {
 	err = c.Status("foo")
 
 	actualErr := err.Error()
-	expectedErr := "could not find unit: foo"
+	expectedErr := "could not find unit: foo\n"
 
 	if actualErr != expectedErr {
 		t.Errorf("Expected %s, Got %s", expectedErr, actualErr)

--- a/deisctl/backend/fleet/unit.go
+++ b/deisctl/backend/fleet/unit.go
@@ -58,7 +58,7 @@ func (c *FleetClient) Units(target string) (units []string, err error) {
 	}
 	// If still nothing is found, then we have an error on our hands.
 	if len(units) == 0 {
-		err = fmt.Errorf("could not find unit: %s", target)
+		err = fmt.Errorf("could not find unit: %s\n", target)
 	}
 	return
 }

--- a/deisctl/backend/fleet/utils.go
+++ b/deisctl/backend/fleet/utils.go
@@ -100,6 +100,10 @@ func (c *FleetClient) expandTargets(targets []string) (expandedTargets []string,
 			}
 			expandedTargets = append(expandedTargets, targets...)
 		} else {
+			if !strings.HasSuffix(t, ".service") {
+				t += ".service"
+			}
+
 			expandedTargets = append(expandedTargets, t)
 		}
 

--- a/deisctl/backend/fleet/utils_test.go
+++ b/deisctl/backend/fleet/utils_test.go
@@ -194,8 +194,8 @@ func TestExpandTargets(t *testing.T) {
 	expectedTargets := []string{
 		"deis-router@1.service",
 		"deis-router@2.service",
-		"deis-store-gateway@1",
-		"deis-controller",
+		"deis-store-gateway@1.service",
+		"deis-controller.service",
 		"deis-registry@1.service",
 	}
 	if !reflect.DeepEqual(expandedTargets, expectedTargets) {

--- a/deisctl/client/client.go
+++ b/deisctl/client/client.go
@@ -357,6 +357,10 @@ func (c *Client) Start(argv []string) error {
 
 Usage:
   deisctl start [<target>...] [options]
+
+Options:
+  -v --verbose
+    Print logs of starting components.
 `
 	// parse command-line arguments
 	args, err := docopt.Parse(usage, argv, true, "", false)
@@ -364,7 +368,7 @@ Usage:
 		return err
 	}
 
-	return cmd.Start(args["<target>"].([]string), c.Backend)
+	return cmd.Start(args["<target>"].([]string), args["--verbose"].(bool), c.Backend)
 }
 
 // Status prints the current status of components.

--- a/deisctl/cmd/platform.go
+++ b/deisctl/cmd/platform.go
@@ -43,13 +43,13 @@ func InstallPlatform(b backend.Backend, cb config.Backend, checkKeys func(config
 }
 
 // StartPlatform activates all components.
-func StartPlatform(b backend.Backend, stateless bool) error {
+func StartPlatform(b backend.Backend, stateless bool, verbose bool) error {
 
 	var wg sync.WaitGroup
 
 	io.WriteString(Stdout, prettyprint.DeisIfy("Starting Deis..."))
 
-	startDefaultServices(b, stateless, &wg, Stdout, Stderr)
+	startDefaultServices(b, stateless, verbose, &wg, Stdout, Stderr)
 
 	wg.Wait()
 

--- a/deisctl/cmd/swarm.go
+++ b/deisctl/cmd/swarm.go
@@ -25,12 +25,15 @@ func InstallSwarm(b backend.Backend) error {
 }
 
 //StartSwarm starts Swarm Schduler
-func StartSwarm(b backend.Backend) error {
+func StartSwarm(b backend.Backend, verbose bool) error {
 	var wg sync.WaitGroup
 	io.WriteString(Stdout, prettyprint.DeisIfy("Starting Swarm..."))
 	fmt.Fprintln(Stdout, "Swarm control plane...")
 	b.Start([]string{"swarm-manager"}, &wg, Stdout, Stderr)
+	var quitChans []chan bool
+	startLogging(b, verbose, &quitChans, "swarm-mananger", Stdout)
 	wg.Wait()
+	stopLogging(&quitChans)
 	fmt.Fprintln(Stdout, "Swarm data plane...")
 	b.Start([]string{"swarm-node"}, &wg, Stdout, Stderr)
 	wg.Wait()

--- a/deisctl/cmd/upgrade.go
+++ b/deisctl/cmd/upgrade.go
@@ -101,7 +101,7 @@ func doUpgradeTakeOver(b backend.Backend, cb config.Backend) error {
 	installDefaultServices(b, false, &wg, Stdout, Stderr) // @fixme: hax?
 	wg.Wait()
 
-	startDefaultServices(b, false, &wg, Stdout, Stderr) // @fixme: hax?
+	startDefaultServices(b, false, false, &wg, Stdout, Stderr) // @fixme: hax?
 	wg.Wait()
 	return nil
 }


### PR DESCRIPTION
Running `deisctl start -v` will print component logs while starting up, showing the progress of things loke downloading docker images.

Why is this WIP?

I believe that I'm leaking ssh connections, but can't find the source. For components that take longer to startup, I start to get `ssh: handshake failed: read tcp 172.17.8.100:22: connection reset by peer` and when I panic I see an enormous amount of `gossh` goroutines. If anybody knows what I'm forgetting to clean up I'd be very appreciative.