### PR TITLE
fix(client-go): fix webbrowser merge error

### DIFF
--- a/client-go/pkg/webbrowser/webbrowser_windows.go
+++ b/client-go/pkg/webbrowser/webbrowser_windows.go
@@ -1,4 +1,4 @@
-package client
+package webbrowser
 
 import (
 	"os/exec"


### PR DESCRIPTION
The webbrowser code was moved to it's own package, but the windows fix pr was created from a point in time before that, so while the PR merged properly it didn't take the move into account.