### PR TITLE
fix(client-go): fall back on directory name if remote can't be detected

### DIFF
--- a/client-go/pkg/git/git.go
+++ b/client-go/pkg/git/git.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
+	"path"
 	"strings"
 )
 
@@ -72,8 +74,10 @@ func remoteNameFromAppID(appID string) (string, error) {
 func DetectAppName(host string) (string, error) {
 	remote, err := findRemote(host)
 
+	// Don't return an error if remote can't be found, return directory name instead.
 	if err != nil {
-		return "", err
+		dir, err := os.Getwd()
+		return strings.ToLower(path.Base(dir)), err
 	}
 
 	ss := strings.Split(remote, "/")


### PR DESCRIPTION
This matches the behavior of the python client, required to pass integration tests.