### PR TITLE
fix(client-go): unset token before logging in

### DIFF
--- a/client-go/cmd/auth.go
+++ b/client-go/cmd/auth.go
@@ -69,6 +69,8 @@ func Register(controller string, username string, password string, email string,
 
 	err = auth.Register(c, username, password, email)
 
+	c.Token = ""
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This could cause problem when registering with a fresh cluster before logging out of a old one. Registration doesn't care if the token is valid (it only cares when registration is set to admin only), but login requires no token or a valid token, so it has to be unset.