### PR TITLE
fix(controller): don't check permissions with @permissions_classes

### DIFF
--- a/controller/api/fixtures/test_sharing.json
+++ b/controller/api/fixtures/test_sharing.json
@@ -54,6 +54,24 @@
   }
 },
 {
+  "pk": 4,
+  "model": "auth.user",
+  "fields": {
+    "username": "autotest-3",
+    "first_name": "",
+    "last_name": "",
+    "is_active": true,
+    "is_superuser": false,
+    "is_staff": false,
+    "last_login": "2013-11-25T21:59:31.404Z",
+    "groups": [],
+    "user_permissions": [],
+    "password": "pbkdf2_sha256$10000$FrfwTVAtWPMD$HUfDokMeY37YshdyS3uhDZ+d/r8galU7kNuBfZxJl2s=",
+    "email": "autotest@deis.io",
+    "date_joined": "2013-11-25T21:59:30.760Z"
+  }
+},
+{
   "pk": "5a09a1e0-a27e-4839-928b-449310ed90f0",
   "model": "api.app",
   "fields": {

--- a/tests/perms_test.go
+++ b/tests/perms_test.go
@@ -66,8 +66,7 @@ func permsDeleteAdminTest(t *testing.T, params *utils.DeisTestConfig) {
 
 func permsDeleteAppTest(t *testing.T, params, user *utils.DeisTestConfig) {
 	utils.Execute(t, authLoginCmd, user, false, "")
-	utils.Execute(t, permsDeleteAppCmd, user, true, "403 FORBIDDEN")
+	utils.Execute(t, permsDeleteAppCmd, user, false, "")
 	utils.Execute(t, authLoginCmd, params, false, "")
-	utils.Execute(t, permsDeleteAppCmd, params, false, "")
 	utils.CheckList(t, permsListAppCmd, params, "test1", true)
 }


### PR DESCRIPTION
This allows finer grained control over permission checking, with the added side effect of allowing users to remove their own app access.