### PR TITLE
ref(tests): default to new golang deis CLI

### DIFF
--- a/client-go/cmd/apps.go
+++ b/client-go/cmd/apps.go
@@ -102,6 +102,20 @@ func AppInfo(appID string) error {
 	fmt.Println("owner:   ", app.Owner)
 	fmt.Println("id:      ", app.ID)
 
+	fmt.Println()
+	// print the app processes
+	if err = PsList(app.ID, defaultLimit); err != nil {
+		return err
+	}
+
+	fmt.Println()
+	// print the app domains
+	if err = DomainsList(app.ID, defaultLimit); err != nil {
+		return err
+	}
+
+	fmt.Println()
+
 	return nil
 }
 

--- a/client-go/cmd/auth.go
+++ b/client-go/cmd/auth.go
@@ -72,6 +72,7 @@ func Register(controller string, username string, password string, email string,
 	c.Token = ""
 
 	if err != nil {
+		fmt.Print("Registration failed: ")
 		return err
 	}
 
@@ -186,6 +187,7 @@ func Passwd(username string, password string, newPassword string) error {
 	err = auth.Passwd(c, username, password, newPassword)
 
 	if err != nil {
+		fmt.Print("Password change failed: ")
 		return err
 	}
 

--- a/client-go/cmd/config.go
+++ b/client-go/cmd/config.go
@@ -94,7 +94,7 @@ func ConfigSet(appID string, configVars []string) error {
 
 	quit := progress()
 	configObj := api.Config{Values: configMap}
-	_, err = config.Set(c, appID, configObj)
+	configObj, err = config.Set(c, appID, configObj)
 
 	quit <- true
 	<-quit
@@ -103,7 +103,11 @@ func ConfigSet(appID string, configVars []string) error {
 		return err
 	}
 
-	fmt.Print("done\n\n")
+	if release, ok := configObj.Values["DEIS_RELEASE"]; ok {
+		fmt.Printf("done, %s\n\n", release)
+	} else {
+		fmt.Print("done\n\n")
+	}
 
 	return ConfigList(appID, false)
 }

--- a/client-go/cmd/config.go
+++ b/client-go/cmd/config.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/deis/deis/pkg/prettyprint"
@@ -28,9 +29,15 @@ func ConfigList(appID string, oneLine bool) error {
 		return err
 	}
 
+	var keys []string
+	for k := range config.Values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	if oneLine {
-		for key, value := range config.Values {
-			fmt.Printf("%s=%s ", key, value)
+		for _, key := range keys {
+			fmt.Printf("%s=%s ", key, config.Values[key])
 		}
 		fmt.Println()
 	} else {
@@ -39,11 +46,11 @@ func ConfigList(appID string, oneLine bool) error {
 		configMap := make(map[string]string)
 
 		// config.Values is type interface, so it needs to be converted to a string
-		for key, value := range config.Values {
-			configMap[key] = value.(string)
+		for _, key := range keys {
+			configMap[key] = config.Values[key].(string)
 		}
 
-		fmt.Print(prettyprint.PrettyTabs(configMap, 5))
+		fmt.Print(prettyprint.PrettyTabs(configMap, 6))
 	}
 
 	return nil

--- a/client-go/cmd/limits.go
+++ b/client-go/cmd/limits.go
@@ -145,7 +145,7 @@ func parseLimits(limits []string) map[string]interface{} {
 }
 
 func parseLimit(limit string) (string, string, error) {
-	regex := regexp.MustCompile("^([A-z]+)=([0-9]+[BKMG]{1}|[0-9]{1,4})$")
+	regex := regexp.MustCompile("^([A-z]+)=([0-9]+[bkmgBKMG]{1,2}|[0-9]{1,4})$")
 
 	if !regex.MatchString(limit) {
 		return "", "", fmt.Errorf(`%s doesn't fit format type=#unit or type=#

--- a/client-go/cmd/perms.go
+++ b/client-go/cmd/perms.go
@@ -56,10 +56,10 @@ func PermCreate(appID string, username string, admin bool) error {
 
 	if admin {
 		fmt.Printf("Adding %s to system administrators... ", username)
-		perms.NewAdmin(c, username)
+		err = perms.NewAdmin(c, username)
 	} else {
 		fmt.Printf("Adding %s to %s collaborators... ", username, appID)
-		perms.New(c, appID, username)
+		err = perms.New(c, appID, username)
 	}
 
 	if err != nil {
@@ -82,10 +82,10 @@ func PermDelete(appID string, username string, admin bool) error {
 
 	if admin {
 		fmt.Printf("Removing %s from system administrators... ", username)
-		perms.DeleteAdmin(c, username)
+		err = perms.DeleteAdmin(c, username)
 	} else {
 		fmt.Printf("Removing %s from %s collaborators... ", username, appID)
-		perms.Delete(c, appID, username)
+		err = perms.Delete(c, appID, username)
 	}
 
 	if err != nil {

--- a/client-go/controller/client/http.go
+++ b/client-go/controller/client/http.go
@@ -19,7 +19,8 @@ import (
 // CreateHTTPClient creates a HTTP Client with proper SSL options.
 func CreateHTTPClient(sslVerify bool) *http.Client {
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: !sslVerify},
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: !sslVerify},
+		DisableKeepAlives: true,
 	}
 	return &http.Client{Transport: tr}
 }

--- a/pkg/prettyprint/colorizer.go
+++ b/pkg/prettyprint/colorizer.go
@@ -4,6 +4,7 @@ package prettyprint
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 	"text/template"
 )
@@ -174,24 +175,28 @@ func Overwritef(msg string, args ...interface{}) string {
 //
 // This will return a formatted string.
 // The previous example would return:
-// test     testing
 // foo      bar
+// test     testing
 func PrettyTabs(msg map[string]string, spaces int) string {
+	// find the longest key so we know how much padding to use
 	max := 0
-
 	for key := range msg {
 		if len(key) > max {
 			max = len(key)
 		}
 	}
-
 	max += spaces
 
-	var output string
-
-	for key, value := range msg {
-		output += fmt.Sprintf("%s%s%s\n", key, strings.Repeat(" ", max-len(key)), value)
+	// sort the map keys so we can print them alphabetically
+	var keys []string
+	for k := range msg {
+		keys = append(keys, k)
 	}
+	sort.Strings(keys)
 
+	var output string
+	for _, k := range keys {
+		output += fmt.Sprintf("%s%s%s\n", k, strings.Repeat(" ", max-len(k)), msg[k])
+	}
 	return output
 }

--- a/pkg/prettyprint/colorizer_test.go
+++ b/pkg/prettyprint/colorizer_test.go
@@ -37,6 +37,7 @@ func ExampleColorize() {
 	out := Colorize("{{.Red}}Hello {{.Default}}World{{.UnderGreen}}!{{.Default}}")
 	fmt.Println(out)
 }
+
 func ExampleColorizeVars() {
 	vars := map[string]string{"Who": "World"}
 	tpl := "{{.C.Red}}Hello {{.C.Default}}{{.V.Who}}!"
@@ -67,16 +68,13 @@ func TestPrettyTabs(t *testing.T) {
 		"foo":  "bar",
 	}
 
-	expected := `test testing
-foo  bar
-`
-	otherExpected := `foo  bar
+	expected := `foo  bar
 test testing
 `
 
 	output := PrettyTabs(test, 1)
 
-	if !(output == expected || output == otherExpected) {
+	if output != expected {
 		t.Errorf("Expected '%s', Got '%s'", expected, output)
 	}
 }

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -49,8 +49,8 @@ func authCancel(t *testing.T, params *utils.DeisTestConfig) {
 	admin := utils.GetGlobalConfig()
 	utils.Execute(t, authLoginCmd, admin, false, "")
 	utils.Execute(t, authCancelAdminCmd, user, false, "Account cancelled")
-	// Make sure the admin is still logged in
-	utils.CheckList(t, authWhoamiCmd, admin, admin.UserName, false)
+	// Make sure the user's config was purged after auth:cancel
+	utils.Execute(t, authWhoamiCmd, admin, true, "Error: Not logged in")
 }
 
 func authLoginTest(t *testing.T, params *utils.DeisTestConfig) {

--- a/tests/bin/test-acceptance.sh
+++ b/tests/bin/test-acceptance.sh
@@ -103,5 +103,4 @@ wait update1 update2 update3
 
 log_phase "Running end-to-end integration test with Python client"
 
-export DEIS_BINARY="$DEIS_ROOT/client/dist/deis"
 time make test-integration

--- a/tests/bin/test-integration-aws.sh
+++ b/tests/bin/test-integration-aws.sh
@@ -197,5 +197,4 @@ done
 
 log_phase "Running integration suite with Python Client"
 
-export DEIS_BINARY="$DEIS_ROOT/client/dist/deis"
 time make test-integration

--- a/tests/bin/test-integration.sh
+++ b/tests/bin/test-integration.sh
@@ -83,5 +83,4 @@ time deisctl start platform
 
 log_phase "Running integration suite with Python Client"
 
-export DEIS_BINARY="$DEIS_ROOT/client/dist/deis"
 time make test-integration

--- a/tests/bin/test-setup.sh
+++ b/tests/bin/test-setup.sh
@@ -14,6 +14,10 @@ log_phase "Preparing test environment"
 export DEIS_ROOT=${GOPATH?}/src/github.com/deis/deis
 echo "DEIS_ROOT=$DEIS_ROOT"
 
+# the "deis" binary CLI to use in testing
+export DEIS_BINARY=${DEIS_BINARY:-$DEIS_ROOT/client-go/deis}
+echo "DEIS_BINARY=$DEIS_BINARY"
+
 # prepend GOPATH/bin to PATH
 export PATH=${GOPATH}/bin:$PATH
 


### PR DESCRIPTION
This makes client-go/deis the default `deis` binary used in tests. 

Once it is merged, we can decide how to deprecate the old CLI and promote the new one within the codebase to make it obvious--that will be a separate PR. (See #4341.)