### PR TITLE
[WIP] feat(controller): fine grained permissions for normal users through etcd

### DIFF
--- a/controller/api/fixtures/test_sharing.json
+++ b/controller/api/fixtures/test_sharing.json
@@ -72,7 +72,7 @@
   }
 },
 {
-  "pk": "5a09a1e0-a27e-4839-928b-449310ed90f0",
+  "pk": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
   "model": "api.app",
   "fields": {
     "updated": "2013-11-25T22:09:36.726Z",
@@ -89,6 +89,28 @@
     "created": "2013-11-25T22:09:36.726Z",
     "owner": 3,
     "id": "autotest-2-app"
+  }
+},
+{
+  "pk": "5a09a1e0-a27e-4839-928b-449310ed90f2",
+  "model": "api.release",
+  "fields": {
+    "updated": "2013-11-25T22:09:36.726Z",
+    "created": "2013-11-25T22:09:36.726Z",
+    "owner": 2,
+    "app": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
+    "version": 1,
+    "config": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1"
+  }
+},
+{
+  "pk": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+  "model": "api.config",
+  "fields": {
+    "updated": "2013-11-25T22:09:36.726Z",
+    "created": "2013-11-25T22:09:36.726Z",
+    "owner": 2,
+    "app": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2"
   }
 }
 ]

--- a/controller/api/permissions.py
+++ b/controller/api/permissions.py
@@ -8,7 +8,9 @@ from api import models
 
 
 def is_app_user(request, obj):
-    if request.user.is_superuser or \
+    if settings.DEFAULT_PERMISSIONS_APP_MANAGEMENT:
+        return True
+    elif request.user.is_superuser or \
             isinstance(obj, models.App) and obj.owner == request.user or \
             hasattr(obj, 'app') and obj.app.owner == request.user:
         return True
@@ -17,6 +19,41 @@ def is_app_user(request, obj):
         return request.method != 'DELETE'
     else:
         return False
+
+
+def can_push(request, obj):
+        if not is_app_user(request, obj):
+            return False
+        elif settings.DEFAULT_PERMISSIONS_APP_MANAGEMENT:
+            return True
+        elif request.user.is_superuser:
+            return True
+        elif hasattr(obj, 'owner') and obj.owner == request.user:
+            return True
+        else:
+            return settings.DEFAULT_PERMISSIONS_PUSH
+
+
+def can_scale(request, obj):
+        if settings.DEFAULT_PERMISSIONS_APP_MANAGEMENT:
+            return True
+        elif request.user.is_superuser:
+            return True
+        elif hasattr(obj, 'owner') and obj.owner == request.user:
+            return True
+        else:
+            return settings.DEFAULT_PERMISSIONS_SCALE
+
+
+def can_run(request, obj):
+        if settings.DEFAULT_PERMISSIONS_APP_MANAGEMENT:
+            return True
+        elif request.user.is_superuser:
+            return True
+        elif hasattr(obj, 'owner') and obj.owner == request.user:
+            return True
+        else:
+            return settings.DEFAULT_PERMISSIONS_RUN
 
 
 class IsAnonymous(permissions.BasePermission):
@@ -146,3 +183,71 @@ class CanRegenerateToken(permissions.BasePermission):
             return request.user.is_superuser
         else:
             return True
+
+
+class Apps(permissions.BasePermission):
+    """
+    Checks if a user can create an app.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Return `True` if permission is granted, `False` otherwise.
+        """
+        if request.user.is_superuser:
+            return True
+        else:
+            return settings.DEFAULT_PERMISSIONS_APPS
+
+
+class Certs(permissions.BasePermission):
+    """
+    Checks if a user can access certs.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Return `True` if permission is granted, `False` otherwise.
+        """
+        if request.user.is_superuser:
+            return True
+        else:
+            return settings.DEFAULT_PERMISSIONS_CERTS
+
+
+class Config(permissions.BasePermission):
+    """
+    Checks if collaborators can access config.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Return `True` if permission is granted, `False` otherwise.
+        """
+        if settings.DEFAULT_PERMISSIONS_APP_MANAGEMENT:
+            return True
+        elif request.user.is_superuser:
+            return True
+        elif hasattr(obj, 'owner') and obj.owner == request.user:
+            return True
+        else:
+            return settings.DEFAULT_PERMISSIONS_CONFIG
+
+
+class Domains(permissions.BasePermission):
+    """
+    Checks if collaborators can access domains.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Return `True` if permission is granted, `False` otherwise.
+        """
+        if settings.DEFAULT_PERMISSIONS_APP_MANAGEMENT:
+            return True
+        elif request.user.is_superuser:
+            return True
+        elif hasattr(obj, 'owner') and obj.owner == request.user:
+            return True
+        else:
+            return settings.DEFAULT_PERMISSIONS_DOMAINS

--- a/controller/api/tests/test_api_middleware.py
+++ b/controller/api/tests/test_api_middleware.py
@@ -6,6 +6,7 @@ Run the tests with "./manage.py test api"
 from __future__ import unicode_literals
 
 from django.contrib.auth.models import User
+from django.conf import settings
 from django.test import TestCase
 from rest_framework.authtoken.models import Token
 
@@ -21,6 +22,7 @@ class APIMiddlewareTest(TestCase):
     def setUp(self):
         self.user = User.objects.get(username='autotest')
         self.token = Token.objects.get(user=self.user).key
+        settings.DEFAULT_PERMISSIONS_APP_MANAGEMENT = False
 
     def test_deis_version_header_good(self):
         """

--- a/controller/api/tests/test_config.py
+++ b/controller/api/tests/test_config.py
@@ -12,6 +12,8 @@ import logging
 import requests
 
 from django.contrib.auth.models import User
+from django.conf import settings
+from django.test.utils import override_settings
 from django.test import TransactionTestCase
 import etcd
 import mock
@@ -60,6 +62,7 @@ class ConfigTest(TransactionTestCase):
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         self.app = App.objects.all()[0]
+        settings.DEFAULT_PERMISSIONS_APP_MANAGEMENT = False
 
     @mock.patch('requests.post', mock_status_ok)
     def test_config(self):
@@ -253,6 +256,7 @@ class ConfigTest(TransactionTestCase):
         self.assertEqual(str(config), "{}-{}".format(config5['app'], config5['uuid'][:7]))
 
     @mock.patch('requests.post', mock_status_ok)
+    @override_settings(DEFAULT_PERMISSIONS_APPS=True)
     def test_valid_config_keys(self):
         """Test that valid config keys are accepted.
         """
@@ -271,6 +275,7 @@ class ConfigTest(TransactionTestCase):
             self.assertIn(k, resp.data['values'])
 
     @mock.patch('requests.post', mock_status_ok)
+    @override_settings(DEFAULT_PERMISSIONS_APPS=True)
     def test_invalid_config_keys(self):
         """Test that invalid config keys are rejected.
         """
@@ -288,6 +293,7 @@ class ConfigTest(TransactionTestCase):
             self.assertEqual(resp.status_code, 400)
 
     @mock.patch('requests.post', mock_status_ok)
+    @override_settings(DEFAULT_PERMISSIONS_APPS=True)
     def test_admin_can_create_config_on_other_apps(self):
         """If a non-admin creates an app, an administrator should be able to set config
         values for that app.
@@ -543,6 +549,7 @@ class ConfigTest(TransactionTestCase):
         response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 405)
 
+    @override_settings(DEFAULT_PERMISSIONS_APPS=True)
     def test_config_owner_is_requesting_user(self):
         """
         Ensure that setting the config value is owned by the requesting user

--- a/controller/api/tests/test_domain.py
+++ b/controller/api/tests/test_domain.py
@@ -8,8 +8,10 @@ from __future__ import unicode_literals
 
 import json
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.test.utils import override_settings
 from rest_framework.authtoken.models import Token
 
 from api.models import Domain
@@ -28,6 +30,7 @@ class DomainTest(TestCase):
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         self.app_id = response.data['id']  # noqa
+        settings.DEFAULT_PERMISSIONS_APP_MANAGEMENT = False
 
     def test_response_data(self):
         """Test that the serialized response contains only relevant data."""
@@ -142,6 +145,7 @@ class DomainTest(TestCase):
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 400)
 
+    @override_settings(DEFAULT_PERMISSIONS_APPS=True)
     def test_admin_can_add_domains_to_other_apps(self):
         """If a non-admin user creates an app, an administrator should be able to add
         domains to it.

--- a/controller/api/tests/test_release.py
+++ b/controller/api/tests/test_release.py
@@ -11,6 +11,8 @@ import json
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
 import mock
+from django.conf import settings
+from django.test.utils import override_settings
 from rest_framework.authtoken.models import Token
 
 from api.models import Release
@@ -27,6 +29,8 @@ class ReleaseTest(TransactionTestCase):
     def setUp(self):
         self.user = User.objects.get(username='autotest')
         self.token = Token.objects.get(user=self.user).key
+
+        settings.DEFAULT_PERMISSIONS_APP_MANAGEMENT = False
 
     @mock.patch('requests.post', mock_status_ok)
     def test_release(self):
@@ -243,6 +247,7 @@ class ReleaseTest(TransactionTestCase):
         self.assertIn('autotest deployed ', release.summary)
 
     @mock.patch('requests.post', mock_status_ok)
+    @override_settings(DEFAULT_PERMISSIONS_APPS=True)
     def test_admin_can_create_release(self):
         """If a non-user creates an app, an admin should be able to create releases."""
         user = User.objects.get(username='autotest2')

--- a/controller/api/tests/test_scheduler.py
+++ b/controller/api/tests/test_scheduler.py
@@ -35,6 +35,7 @@ class SchedulerTest(TransactionTestCase):
         settings.SCHEDULER_MODULE = 'scheduler.chaos'
         # provide mock authentication used for run commands
         settings.SSH_PRIVATE_KEY = '<some-ssh-private-key>'
+        settings.DEFAULT_PERMISSIONS_APP_MANAGEMENT = False
 
     def tearDown(self):
         # reset for subsequent tests

--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -54,6 +54,14 @@ etcd_set_default builderKey "${DEIS_BUILDER_KEY:-$(openssl rand -base64 64 | tr 
 etcd_set_default registrationMode "enabled"
 etcd_set_default webEnabled 0
 etcd_set_default unitHostname default
+etcd_set_default permissions/apps 1
+etcd_set_default permissions/app_management 0
+etcd_set_default permissions/certs 1
+etcd_set_default permissions/config 1
+etcd_set_default permissions/domains 1
+etcd_set_default permissions/push 1
+etcd_set_default permissions/scale 1
+etcd_set_default permissions/run 1
 
 # safely create required keyspaces
 etcd_safe_mkdir /deis/domains

--- a/controller/templates/confd_settings.py
+++ b/controller/templates/confd_settings.py
@@ -58,6 +58,15 @@ UNIT_HOSTNAME = '{{ if exists "/deis/controller/unitHostname" }}{{ getv "/deis/c
 DEIS_RESERVED_NAMES = ['{{ getv "/deis/controller/subdomain" }}']
 {{ end }}
 
+DEFAULT_PERMISSIONS_APPS = bool('{{ getv "/deis/controller/permissions/apps" }}')
+DEFAULT_PERMISSIONS_APP_MANAGEMENT = bool('{{ getv "/deis/controller/permissions/app_management" }}')
+DEFAULT_PERMISSIONS_CERTS = bool('{{ getv "/deis/controller/permissions/certs" }}')
+DEFAULT_PERMISSIONS_CONFIG = bool('{{ getv "/deis/controller/permissions/config" }}')
+DEFAULT_PERMISSIONS_DOMAINS = bool('{{ getv "/deis/controller/permissions/domains" }}')
+DEFAULT_PERMISSIONS_PUSH = bool('{{ getv "/deis/controller/permissions/push" }}')
+DEFAULT_PERMISSIONS_SCALE = bool('{{ getv "/deis/controller/permissions/scale" }}')
+DEFAULT_PERMISSIONS_RUN = bool('{{ getv "/deis/controller/permissions/run" }}')
+
 # AUTH
 # LDAP
 {{ if exists "/deis/controller/auth/ldap/endpoint" }}

--- a/docs/customizing_deis/controller_settings.rst
+++ b/docs/customizing_deis/controller_settings.rst
@@ -45,6 +45,7 @@ setting                                   description
 /deis/controller/subdomain                subdomain used by the router for API requests (default: "deis")
 /deis/controller/webEnabled               enable controller web UI (default: 0)
 /deis/controller/workers                  number of web worker processes (default: CPU cores * 2 + 1)
+/deis/controller/permissions/*            default permissions, see :ref:`configure_default_permissions`
 /deis/database/host                       host of the database component (set by database)
 /deis/database/port                       port of the database component (set by database)
 /deis/database/engine                     database engine (set by database)
@@ -132,6 +133,36 @@ This will set the registration mode to admin_only.
 .. code-block:: console
 
     $ deisctl config controller set registrationMode="admin_only"
+
+.. _configure_default_permissions:
+
+Configuring Default Permissions
+-------------------------------
+These settings can be used to configure the default permissions for users.
+These settings are retroactive and affects all current and new users.
+
+All permission settings are boolean values, 1 for granted, 0 for denied.
+
+Settings Used by Permissions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=========================================== =======
+setting                                     default
+=========================================== =======
+/deis/controller/permissions/apps           1
+/deis/controller/permissions/app_management 0
+/deis/controller/permissions/certs          1
+/deis/controller/permissions/config         1
+/deis/controller/permissions/domains        1
+/deis/controller/permissions/push           1
+/deis/controller/permissions/scale          1
+/deis/controller/permissions/run            1
+=========================================== =======
+
+For example, this command prevents normal users from creating apps.
+
+.. code-block:: console
+
+    $ deisctl config controller set permissions/apps=0
 
 Using a LDAP Auth
 -----------------


### PR DESCRIPTION
Changing permissions in etcd affects all normal users.

This allows cluster owners to control what permissions their normal users have. For example, they could prevent normal users from creating apps or give full app access to every user (for small development clusters).

This is the first step towards resolving #4150

Fixes #4052