### PR TITLE
docs(managing_deis): remove a space from a bash substitution

### DIFF
--- a/docs/managing_deis/running-deis-without-ceph.rst
+++ b/docs/managing_deis/running-deis-without-ceph.rst
@@ -150,7 +150,7 @@ so the controller knows where to connect.
     $ deisctl config database set engine=postgresql_psycopg2 \
                                   host=${HOST} \
                                   port=5432 \
-                                  name=${DATABASE } \
+                                  name=${DATABASE} \
                                   user=${DB_USER} \
                                   password=${DB_PASS}
 


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/deis/deis/4288)
<!-- Reviewable:end -->
