### PR TITLE
docs(installing_deis): clean up old references

### DIFF
--- a/docs/installing_deis/baremetal.rst
+++ b/docs/installing_deis/baremetal.rst
@@ -8,16 +8,10 @@ Bare Metal
 
 Deis clusters can be provisioned anywhere `CoreOS`_ can, including on your own hardware.
 
-Please :ref:`get the source <get_the_source>` and refer to the scripts in `contrib/bare-metal`_
-while following this documentation.
+Please :ref:`get the source <get_the_source>` while following this documentation.
 
 To get CoreOS running on raw hardware, you can boot with `PXE`_ or `iPXE`_ - this will boot a CoreOS
 machine running entirely from RAM. Then, you can `install CoreOS to disk`_.
-
-.. important::
-
-    Deis runs on CoreOS version 494.5.0 or later in the Stable channel.
-
 
 Check System Requirements
 -------------------------
@@ -159,7 +153,6 @@ disk. Add the following block to the ``write_files`` section:
           options single-request
 
 
-.. _`contrib/bare-metal`: https://github.com/deis/deis/tree/master/contrib/bare-metal
 .. _`cluster size`: https://github.com/coreos/etcd/blob/master/Documentation/optimal-cluster-size.md
 .. _`CoreOS`: https://coreos.com/
 .. _`install CoreOS to disk`: https://coreos.com/docs/running-coreos/bare-metal/installing-to-disk/

--- a/docs/installing_deis/openstack.rst
+++ b/docs/installing_deis/openstack.rst
@@ -68,10 +68,6 @@ Upload a CoreOS image to Glance
 
 You need to have a relatively recent CoreOS image.
 
-.. important::
-
-    Deis runs on CoreOS version 494.5.0 or later in the Stable channel.
-
 If you don't already have a suitable CoreOS image and your OpenStack install allows you to upload
 your own images, the following snippet will use the latest CoreOS image from the stable channel:
 


### PR DESCRIPTION
Saying that Deis runs on CoreOS 494.5.0 is a bit misleading,
because a lot of recent improvements require newer versions.

Additionally, we remove the reference for bare metal to
contrib/bare-metal since there are no scripts there.