### PR TITLE
fix(logspout): fix deadlock when attaching

### DIFF
--- a/logspout/attacher.go
+++ b/logspout/attacher.go
@@ -122,7 +122,11 @@ func (m *AttachManager) Listen(source *Source, logstream chan *Log, closer <-cha
 	if source == nil {
 		source = new(Source)
 	}
-	events := make(chan *AttachEvent)
+	depth := len(m.attached)
+	if depth == 0 {
+		depth = 1
+	}
+	events := make(chan *AttachEvent, depth)
 	m.addListener(events)
 	defer m.removeListener(events)
 	for {


### PR DESCRIPTION
Fixes #3633 

This isn't guaranteed to be a magic bullet that solves every logging-related issue, but we have uncovered deadlock that can occur when logspout attempts attaching to containers.  At several points in this process, a lock on a mutex is acquired and released.  At one such point, after acquiring a lock, a message is written to an unbuffered channel.  Since writes to an unbuffered channel will block until another goroutine receives the message, and since sometimes there is no one listening, execution can block indefinitely at this point while holding on to the lock that other goroutines are waiting for.  Using a buffered channel seems to alleviate this issue.

Thanks to @aledbf and @technosophos for help in diagnosing the issue.

N.B.: Longer term, we might consider adopting a newer version of logspout, as it's gone through two major refactors since we forked and enhanced it to work with Deis.  I'll track that in a separate issue.