### PR TITLE
feat(Registry): add support for IAM role authentication

### DIFF
--- a/docs/customizing_deis/registry_settings.rst
+++ b/docs/customizing_deis/registry_settings.rst
@@ -43,6 +43,21 @@ setting                                   description
 /deis/store/gateway/secretKey             S3 API secret key used to access store-gateway (set by store-gateway)
 ====================================      =================================================================================
 
+If the ``/deis/registry/s3bucket`` key is supplied, the registry
+will use Amazon S3 as its storage backend and use the following values.
+
+====================================      =================================================================================
+setting                                   description
+====================================      =================================================================================
+/deis/registry/s3accessKey                S3 API access key. If not specified, the registry will get it from the instance role
+/deis/registry/s3secretKey                S3 API secret key, required if s3accessKey is specified
+/deis/registry/s3region                   S3 region to connect to, will use boto default if not specified
+/deis/registry/s3bucket                   S3 bucket to store images 
+/deis/registry/s3path                     path in the bucket (default: "/registry")
+/deis/registry/s3encrypt                  whether the object is encrypted while at rest on the server (default: true)
+/deis/registry/s3secure                   use secure protocol to establish connection with S3 (default: true)
+====================================      =================================================================================
+
 The Deis registry component inherits from the Docker registry container, so additional configuration
 options can be supplied. For a full explanation of these settings, see the Docker registry `README`_.
 

--- a/docs/managing_deis/running-deis-without-ceph.rst
+++ b/docs/managing_deis/running-deis-without-ceph.rst
@@ -121,21 +121,58 @@ The :ref:`registry` component won't start until it's configured with an S3 store
 .. code-block:: console
 
     $ BUCKET=MYS3BUCKET
-    $ AWS_ACCESS_KEY=something
-    $ AWS_SECRET_KEY=something
     $ AWS_S3_REGION=some-aws-region #(e.g., us-west-1)
     $ deisctl config registry set s3bucket=${BUCKET} \
-                                  bucketName=${BUCKET} \
-                                  s3accessKey=${AWS_ACCESS_KEY} \
-                                  s3secretKey=${AWS_SECRET_KEY} \
                                   s3region=${AWS_S3_REGION} \
                                   s3path=/ \
                                   s3encrypt=false \
                                   s3secure=false
-    $ deisctl config store set gateway/accessKey=${AWS_ACCESS_KEY} \
-                               gateway/secretKey=${AWS_SECRET_KEY} \
-                               gateway/host=s3.amazonaws.com \
-                               gateway/port=80
+
+By default, the registry will try to authenticate to S3 using the instance role.
+If your cluster is not running on EC2, you can supply hard coded API access and
+secret key:
+
+.. code-block:: console
+
+    $ deisctl config registry set s3accessKey=your-access-key \
+                                  s3secretKey=your-secret-key
+
+For reference, here's example of a policy you could attach to the role/user used by
+the registry:
+
+.. code-block:: javascript
+
+    {
+      "Statement": [
+        {
+          "Resource": "arn:aws:s3:::*",
+          "Action": "s3:ListAllMyBuckets",
+          "Effect": "Allow"
+        },
+        {
+          "Resource": [
+            "arn:aws:s3:::MYBUCKET"
+          ],
+          "Action": [
+            "s3:ListBucket",
+            "s3:GetBucketLocation"
+          ],
+          "Effect": "Allow"
+        },
+        {
+          "Resource": [
+            "arn:aws:s3:::MYBUCKET/*"
+          ],
+          "Action": [
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:DeleteObject"
+          ],
+          "Effect": "Allow"
+        }
+      ],
+      "Version": "2012-10-17"
+    }
 
 Configure database settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/registry/templates/config.yml
+++ b/registry/templates/config.yml
@@ -78,14 +78,14 @@ local: &local
 s3: &s3
     <<: *common
     storage: s3
-    s3_region: {{ if exists "/deis/registry/s3region" }}{{ getv "/deis/registry/s3region" }}{{ else }}""{{ end }}
-    s3_bucket: {{ if exists "/deis/registry/s3bucket" }}{{ getv "/deis/registry/s3bucket" }}{{ else }}""{{ end }}
-    boto_bucket: {{ if exists "/deis/registry/s3bucket" }}{{ getv "/deis/registry/s3bucket" }}{{ else }}""{{ end }}
+    s3_region: {{ if exists "/deis/registry/s3region" }}{{ getv "/deis/registry/s3region" }}{{ else }}~{{ end }}
+    s3_bucket: {{ if exists "/deis/registry/s3bucket" }}{{ getv "/deis/registry/s3bucket" }}{{ else }}~{{ end }}
+    boto_bucket: {{ if exists "/deis/registry/s3bucket" }}{{ getv "/deis/registry/s3bucket" }}{{ else }}~{{ end }}
     storage_path: {{ if exists "/deis/registry/s3path" }}{{ getv "/deis/registry/s3path" }}{{ else }}"/registry"{{ end }}
     s3_encrypt: bool({{ if exists "/deis/registry/s3encrypt" }}{{ getv "/deis/registry/s3encrypt" }}{{ else }}"true"{{ end }})
     s3_secure: bool({{ if exists "/deis/registry/s3secure" }}{{ getv "/deis/registry/s3secure" }}{{ else }}"true"{{ end }})
-    s3_access_key: {{ if exists "/deis/registry/s3accessKey" }}{{ getv "/deis/registry/s3accessKey" }}{{ else }}""{{ end }}
-    s3_secret_key: {{ if exists "/deis/registry/s3secretKey" }}{{ getv "/deis/registry/s3secretKey" }}{{ else }}""{{ end }}
+    s3_access_key: {{ if exists "/deis/registry/s3accessKey" }}{{ getv "/deis/registry/s3accessKey" }}{{ else }}~{{ end }}
+    s3_secret_key: {{ if exists "/deis/registry/s3secretKey" }}{{ getv "/deis/registry/s3secretKey" }}{{ else }}~{{ end }}
 
 # Ceph Object Gateway Configuration
 # See http://ceph.com/docs/master/radosgw/ for details on installing this service.
@@ -93,15 +93,15 @@ ceph-s3: &ceph-s3
     <<: *common
     storage: s3
     s3_region: ~
-    s3_bucket: {{ getv "/deis/registry/bucketName" }}
+    s3_bucket: {{if exists "/deis/registry/bucketName"}}{{ getv "/deis/registry/bucketName" }}{{ else }}""{{ end }}
     s3_encrypt: false
     s3_secure: false
     storage_path: /registry
-    s3_access_key: {{ getv "/deis/store/gateway/accessKey" }}
-    s3_secret_key: {{ getv "/deis/store/gateway/secretKey" }}
-    boto_bucket: {{ getv "/deis/registry/bucketName" }}
-    boto_host: {{ getv "/deis/store/gateway/host" }}
-    boto_port: {{ getv "/deis/store/gateway/port" }}
+    s3_access_key: {{if exists "/deis/store/gateway/accessKey"}}{{ getv "/deis/store/gateway/accessKey" }}{{ else }}""{{ end }}
+    s3_secret_key: {{if exists "/deis/store/gateway/secretKey"}}{{ getv "/deis/store/gateway/secretKey" }}{{ else }}""{{ end }}
+    boto_bucket: {{if exists "/deis/registry/bucketName"}}{{ getv "/deis/registry/bucketName" }}{{ else }}""{{ end }}
+    boto_host: {{if exists "/deis/store/gateway/host"}}{{ getv "/deis/store/gateway/host" }}{{ else }}""{{ end }}
+    boto_port: {{if exists "/deis/store/gateway/port"}}{{ getv "/deis/store/gateway/port" }}{{ else }}""{{ end }}
     boto_debug: 0
     boto_calling_format: boto.s3.connection.OrdinaryCallingFormat
 
@@ -194,7 +194,7 @@ prod:
 
 # Flavor used by deis
 deis:
-    {{ if exists "/deis/registry/s3accessKey" }}<<: *s3
+    {{ if exists "/deis/registry/s3bucket" }}<<: *s3
     {{ else if exists "/deis/registry/swiftAuthURL" }} <<: *openstack-swift
     {{ else }} <<: *ceph-s3
     {{ end }}

--- a/registry/templates/create_bucket
+++ b/registry/templates/create_bucket
@@ -5,13 +5,22 @@ import sys
 from boto.s3.connection import OrdinaryCallingFormat
 
 conn = boto.connect_s3(
+    {{ if exists "/deis/store/gateway/accessKey" }}
     aws_access_key_id='{{ getv "/deis/store/gateway/accessKey" }}',
     aws_secret_access_key='{{ getv "/deis/store/gateway/secretKey" }}',
+    {{end}}
+    {{ if exists "/deis/store/gateway/host" }}
     host='{{ getv "/deis/store/gateway/host" }}',
     port={{ getv "/deis/store/gateway/port" }},
+    {{ end }}
     is_secure=False,
     calling_format=OrdinaryCallingFormat())
+
+{{ if exists "/deis/registry/s3bucket" }}
+name = '{{ getv "/deis/registry/s3bucket" }}'
+{{ else }}
 name = '{{ getv "/deis/registry/bucketName" }}'
+{{ end }}
 
 if name not in (bucket.name for bucket in conn.get_all_buckets()):
     conn.create_bucket(name)


### PR DESCRIPTION
As described in [AWS best practises](http://docs.aws.amazon.com/IAM/latest/UserGuide/IAMBestPractices.html#use-roles-with-ec2), application running on EC2 should not use hard coded Access Key and Secret Key and instead use  attached IAM roles to authenticate to Amazon web services. 

Here's some fixes I had to made for boto to connect using IAM roles. I've tried to be as backward compatible as possible but I did not test other workflows (help needed :pray:). 

I've also updated the *customizing deis -> registry settings* doc to include the keys that were added with the *Running Deis without Ceph* feature and the new `s3assumeRole` key.