### PR TITLE
feat(logspout): support sending log via tcp

### DIFF
--- a/docs/managing_deis/running-deis-without-ceph.rst
+++ b/docs/managing_deis/running-deis-without-ceph.rst
@@ -110,7 +110,8 @@ than the :ref:`logger` component.
 
     $ HOST=logs.somewhere.com
     $ PORT=98765
-    $ deisctl config logs set host=${HOST} port=${PORT}
+    $ PROTOCOL=udp # Supported protocols are udp and tcp
+    $ deisctl config logs set host=${HOST} port=${PORT} protocol=${PROTOCOL}
 
 Configure registry
 ^^^^^^^^^^^^^^^^^^

--- a/logspout/types.go
+++ b/logspout/types.go
@@ -41,6 +41,7 @@ func (s *Source) All() bool {
 type Target struct {
 	Type      string `json:"type"`
 	Addr      string `json:"addr"`
+	Protocol  string `json:"protocol"`
 	AppendTag string `json:"append_tag,omitempty"`
 }
 


### PR DESCRIPTION
I'm using AWS' Elastic Load Balancer in front on my logstash server, however ELBs don't support UDP. So here's a quick fix to add TCP support. 