### PR TITLE
chore(tests): use go 1.5 toolchain

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/deis/deis",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.5",
 	"Packages": [
 		"./..."
 	],

--- a/docs/contributing/hacking.rst
+++ b/docs/contributing/hacking.rst
@@ -34,7 +34,7 @@ At a glance, you will need:
 
 - Python 2.7 or later (with ``pip``)
 - virtualenv (``sudo pip install virtualenv``)
-- Go 1.4 or later, with support for compiling to ``linux/amd64``
+- Go 1.5 or later, with support for compiling to ``linux/amd64``
 - Godep (https://github.com/tools/godep)
 - VirtualBox latest
 - Vagrant 1.5 or later
@@ -63,7 +63,7 @@ It is also straightforward to build Go from source:
 .. code-block:: console
 
     $ sudo su
-    $ curl -sSL https://golang.org/dl/go1.4.src.tar.gz | tar -v -C /usr/local -xz
+    $ curl -sSL https://golang.org/dl/go1.5.src.tar.gz | tar -v -C /usr/local -xz
     $ cd /usr/local/go/src
     $ # compile Go for our default platform first, then add cross-compile support
     $ ./make.bash --no-clean
@@ -76,7 +76,7 @@ Configuring Docker Machine (Mac)
 ````````````````````````````````
 
 Deis needs a Docker registry running independently of the Deis cluster. On
-OS X, you will need Docker Machine (http://docs.docker.com/machine/install-machine/) 
+OS X, you will need Docker Machine (http://docs.docker.com/machine/install-machine/)
 to run the registry inside of a VirtualBox image.
 
 .. note::

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,21 +14,23 @@ TEST_POSTGRESQL_IMAGE = $(IMAGE_PREFIX)test-postgresql:$(BUILD_TAG)
 test: test-smoke
 
 test-smoke: test-style
-	godep go test -tags integration -short -timeout 20m -v -run TestSmoke
+# TODO: remove GOMAXPROCS=1 when concurrent stdout issues are fixed
+	GOMAXPROCS=1 godep go test -tags integration -short -timeout 20m -v -run TestSmoke
 
 test-full: test-style
-	godep go test -tags integration -v -run TestGlobal
-	godep go test -tags integration -v -run TestApps
-	godep go test -tags integration -v -run TestAuth
-	godep go test -tags integration -v -run TestBuilds
-	godep go test -tags integration -v -run TestConfig
-	godep go test -tags integration -v -run TestDomains
-	godep go test -tags integration -v -run TestHealthcheck
-	godep go test -tags integration -v -run TestKeys
-	godep go test -tags integration -v -run TestPerms
-	godep go test -tags integration -v -run TestPs
-	godep go test -tags integration -v -run TestReleases
-	godep go test -tags integration -v -run TestUsers
+# TODO: remove GOMAXPROCS=1 when concurrent stdout issues are fixed
+	GOMAXPROCS=1 godep go test -tags integration -v -run TestGlobal
+	GOMAXPROCS=1 godep go test -tags integration -v -run TestApps
+	GOMAXPROCS=1 godep go test -tags integration -v -run TestAuth
+	GOMAXPROCS=1 godep go test -tags integration -v -run TestBuilds
+	GOMAXPROCS=1 godep go test -tags integration -v -run TestConfig
+	GOMAXPROCS=1 godep go test -tags integration -v -run TestDomains
+	GOMAXPROCS=1 godep go test -tags integration -v -run TestHealthcheck
+	GOMAXPROCS=1 godep go test -tags integration -v -run TestKeys
+	GOMAXPROCS=1 godep go test -tags integration -v -run TestPerms
+	GOMAXPROCS=1 godep go test -tags integration -v -run TestPs
+	GOMAXPROCS=1 godep go test -tags integration -v -run TestReleases
+	GOMAXPROCS=1 godep go test -tags integration -v -run TestUsers
 
 mock-store:
 	docker build -t $(MOCK_STORE_IMAGE) fixtures/mock-store/

--- a/tests/bin/setup-node.sh
+++ b/tests/bin/setup-node.sh
@@ -50,7 +50,7 @@ if ! vagrant -v &> /dev/null; then
 fi
 
 # install go
-wget -nv -O- https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz | tar -C /usr/local -xz
+wget -nv -O- https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz | tar -C /usr/local -xz
 echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile
 echo "You must reboot for the global $PATH changes to take effect."
 


### PR DESCRIPTION
Since some integration tests will fail with concurrent goroutines, this change also sets GOMAXPROCS=1 when running them. Big improvements to runtime GC should speed up our components somewhat.

Closes #4308.

Note that this will not automagically put Go 1.5 on all CI test boxen; we need to do that manually once we verify this doesn't break things. I've run it locally against vagrant using Go 1.5 without problems.