### PR TITLE
chore(*): bump etcd to 2.1.2

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -25,7 +25,7 @@ coreos:
       RestartSec=10s
       LimitNOFILE=40000
       EnvironmentFile=/etc/environment
-      Environment="ETCD_IMAGE=quay.io/coreos/etcd:v2.1.1"
+      Environment="ETCD_IMAGE=quay.io/coreos/etcd:v2.1.2"
       Environment="ETCD_ELECTION_TIMEOUT=2000"
       Environment="ETCD_HEARTBEAT_INTERVAL=400"
       Environment="ETCD_DATA_DIR=/var/lib/etcd2"

--- a/tests/fixtures/test-etcd/Dockerfile
+++ b/tests/fixtures/test-etcd/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --update-cache curl tar && rm -rf /var/cache/apk/*
 
 # ETCD_VERSION is actually used by the etcd daemon, and causes an issue if we
 # format it for our use here. So, we call this something else.
-ENV INSTALL_ETCD_VERSION v2.1.1
+ENV INSTALL_ETCD_VERSION v2.1.2
 
 # install etcd and etcdctl
 RUN curl -sSL https://github.com/coreos/etcd/releases/download/$INSTALL_ETCD_VERSION/etcd-$INSTALL_ETCD_VERSION-linux-amd64.tar.gz \


### PR DESCRIPTION
https://github.com/coreos/etcd/releases/tag/v2.1.2