### PR TITLE
style(contrib/aws): Ensure that files are closed and use yaml.safe_load

### DIFF
--- a/contrib/aws/gen-json.py
+++ b/contrib/aws/gen-json.py
@@ -95,7 +95,8 @@ new_units = [
     dict({'name': 'etcd.service', 'drop-ins': [{'name': '90-after-etcd-volume.conf', 'content': ETCD_DROPIN}]})
 ]
 
-data = yaml.load(file(os.path.join(CURR_DIR, '..', 'coreos', 'user-data'), 'r'))
+with open(os.path.join(CURR_DIR, '..', 'coreos', 'user-data'), 'r') as f:
+    data = yaml.safe_load(f)
 
 # coreos-cloudinit will start the units in order, so we want these to be processed before etcd/fleet
 # are started


### PR DESCRIPTION
The `with` statement ensures that files will be always be closed, this also switches from the deprecated `file` to `open`.

Also use `yaml.safe_load` in favor of `yaml.load`, which can execute arbitrary code.