### PR TITLE
fix(logger): allow underscores in container names

### DIFF
--- a/logger/syslogd/syslogd.go
+++ b/logger/syslogd/syslogd.go
@@ -50,7 +50,7 @@ func fileExists(path string) (bool, error) {
 }
 
 func getLogFile(message string) (io.Writer, error) {
-	r := regexp.MustCompile(`^.* ([-a-z0-9]+)\[[a-z0-9-_\.]+\].*`)
+	r := regexp.MustCompile(`^.* ([-_a-z0-9]+)\[[a-z0-9-_\.]+\].*`)
 	match := r.FindStringSubmatch(message)
 	if match == nil {
 		return nil, fmt.Errorf("Could not find app name in message: %s", message)


### PR DESCRIPTION
Our custom `deis-logspout` does some work to resolve "application name" and "pid" from the name of each container it's attached to and includes these in the log messages it sends to `deis-logger`.  If the container's name doesn't match the usual format expected for a deis application, then the app name is simply the name of the container and the pid is simply 1.

Where this fails is if a container name has an underscore in it-- and Docker containers, if not explicitly named, use generated names that _do_ container underscores.  In such a case, the app name component of the message coming _from_ `deis-logspout` will contain an underscore, but on the `deis-logspout` side, the message gets rejected because, per a regex, it doesn't appear to contain an app name.

This change updates that regex such that `deis-logger` will recognize app names with underscores in them.