### PR TITLE
feat(Router): IP whitelisting for apps and controller

### DIFF
--- a/docs/customizing_deis/router_settings.rst
+++ b/docs/customizing_deis/router_settings.rst
@@ -34,9 +34,10 @@ setting                                      description
 =======================================      ==================================================================================================================================================================================================================================================================================================================================
 /deis/builder/host                           host of the builder component (set by builder)
 /deis/builder/port                           port of the builder component (set by builder)
+/deis/config/\*/deis_whitelist               comma separated list of IPs (or CIDR) allowed to connect to the application containers (set by controller) Example: "0.0.0.0:some_optional_label,10.0.0.0/8"
 /deis/controller/host                        host of the controller component (set by controller)
 /deis/controller/port                        port of the controller component (set by controller)
-/deis/domains/*                              domain configuration for applications (set by controller)
+/deis/domains/\*                             domain configuration for applications (set by controller)
 /deis/router/affinityArg                     for requests with the indicated query string variable, hash its contents to perform session affinity (default: undefined)
 /deis/router/bodySize                        nginx body size setting (default: 1m)
 /deis/router/defaultTimeout                  default timeout value in seconds. Should be greater then the frontfacing load balancers timeout value (default: 1300)
@@ -45,7 +46,9 @@ setting                                      description
 /deis/router/controller/timeout/connect      proxy_connect_timeout for deis-controller (default: 10m)
 /deis/router/controller/timeout/read         proxy_read_timeout for deis-controller (default: 20m)
 /deis/router/controller/timeout/send         proxy_send_timeout for deis-controller (default: 20m)
+/deis/router/controller/whitelist            comma separated list of IPs (or CIDR) allowed to connect to the controller (default: not set) Example: "0.0.0.0:some_optional_label,10.0.0.0/8"
 /deis/router/enforceHTTPS                    redirect all HTTP traffic to HTTPS (default: false)
+/deis/router/enforceWhitelist                deny all connections unless specifically whitelisted (default: false)
 /deis/router/firewall/enabled                nginx naxsi firewall enabled (default: false)
 /deis/router/firewall/errorCode              nginx default firewall error code (default: 400)
 /deis/router/errorLogLevel                   nginx error_log level (default: error) Valid options: debug, info, notice, warn, error, crit, alert, emerg

--- a/docs/managing_deis/security_considerations.rst
+++ b/docs/managing_deis/security_considerations.rst
@@ -81,6 +81,24 @@ The :ref:`Router` component includes a firewall to help thwart attacks. It can b
 ``deisctl config router set firewall/enabled=true``. For more information, see the `router README`_
 and :ref:`router_settings`.
 
+IP Whitelist
+------------
+You can enforce cluster-wide IP whitelisting by running ``deisctl config router set enforceWhitelist=true``.
+Then you'll have to manually whitelist IPs to the applications using the config endpoint of the deis
+client. The format is ``{IP_or_CIDR}:{Optional_label},...``. For example:
+
+.. code-block:: console
+
+    $ deis config:set -a your-app DEIS_WHITELIST="10.0.1.0/24:office_ABC,212.121.212.121:client_YXZ"
+
+The format is the same for the controller whitelist but you need to specify the list directly into
+ectd. For example:
+
+.. code-block:: console
+
+    $ deisctl config router set controller/whitelist="10.0.1.0/24:office_intranet,121.212.121.212:dev_jenkins"
+
+
 .. _`#986`: https://github.com/deis/deis/issues/986
 .. _`contrib/util/custom-firewall.sh`: https://github.com/deis/deis/blob/master/contrib/util/custom-firewall.sh
 .. _`router README`: https://github.com/deis/deis/blob/master/router/README.md

--- a/router/cmd/boot/boot.go
+++ b/router/cmd/boot/boot.go
@@ -49,6 +49,7 @@ func main() {
 	time.Sleep(timeout + 1)
 
 	log.Debug("creating required defaults in etcd...")
+	mkdirEtcd(client, "/deis/config")
 	mkdirEtcd(client, "/deis/controller")
 	mkdirEtcd(client, "/deis/services")
 	mkdirEtcd(client, "/deis/domains")

--- a/router/rootfs/etc/confd/conf.d/nginx.conf.toml
+++ b/router/rootfs/etc/confd/conf.d/nginx.conf.toml
@@ -5,6 +5,7 @@ uid = 0
 gid = 0
 mode  = "0644"
 keys = [
+  "/deis/config",
   "/deis/services",
   "/deis/router",
   "/deis/domains",

--- a/router/rootfs/etc/confd/templates/nginx.conf
+++ b/router/rootfs/etc/confd/templates/nginx.conf
@@ -83,6 +83,9 @@ http {
     ## since HSTS headers are not permitted on HTTP requests, 301 redirects to HTTPS resources are also necessary
     {{ $enforceHTTPS := or (getv "/deis/router/enforceHTTPS") $enableHSTS "false" }}
 
+    {{/* Enabling the enforceWhitelist option deny all connections except those from IPs explicitly allowed */}}
+    {{ $enforceWhitelist := or (getv "/deis/router/enforceWhitelist") "false" }}
+
     ## start deis-controller
     {{ if exists "/deis/controller/host" }}
     upstream deis-controller {
@@ -93,6 +96,20 @@ http {
     server {
         server_name ~^{{ or (getv "/deis/controller/subdomain") "deis" }}\.(?<domain>.+)$;
         include deis.conf;
+
+        {{/* IP Whitelisting */}}
+        {{ $controllerHasWhitelist := exists "/deis/router/controller/whitelist" }}
+        {{ if $controllerHasWhitelist }}
+        ## Only connections from the following addresses are allowed
+        {{ $whitelist := getv "/deis/router/controller/whitelist" }}
+        {{ range $whitelist_entry := split $whitelist "," }}
+        {{ $whitelist_detail := split $whitelist_entry ":" }}
+        allow {{index $whitelist_detail 0}};{{if eq (len $whitelist_detail) 2}}  # {{index $whitelist_detail 1}}{{ end }}
+        {{ end }}
+        {{ end }}
+        {{ if or (eq $enforceWhitelist "true") $controllerHasWhitelist }}
+        deny all;
+        {{ end }}
 
         {{ if exists "/deis/controller/host" }}
         location / {
@@ -207,6 +224,21 @@ http {
         {{ else }}
         include deis.conf;
         {{ end }}
+
+        {{/* IP Whitelisting */}}
+        {{ $appHasWhitelist := exists (printf "/deis/config/%s/deis_whitelist" $app) }}
+        {{ if $appHasWhitelist }}
+        ## Only connections from the following addresses are allowed
+        {{ $whitelist := getv (printf "/deis/config/%s/deis_whitelist" $app) }}
+        {{ range $whitelist_entry := split $whitelist "," }}
+        {{ $whitelist_detail := split $whitelist_entry ":" }}
+        allow {{index $whitelist_detail 0}};{{if eq (len $whitelist_detail) 2}}  # {{index $whitelist_detail 1}}{{ end }}
+        {{ end }}
+        {{ end }}
+        {{ if or (eq $enforceWhitelist "true") $appHasWhitelist}}
+        deny all;
+        {{ end }}
+
         {{ if ne $appContainerLen 0 }}
         location / {
             {{ if eq $useFirewall "true" }}include                     /opt/nginx/firewall/active-mode.rules;{{ end }}
@@ -269,6 +301,21 @@ http {
     server {
         server_name ~^{{ $app }}\.(?<domain>.+)$;
         include deis.conf;
+
+        {{/* IP Whitelisting */}}
+        {{ $appHasWhitelist := exists (printf "/deis/config/%s/deis_whitelist" $app) }}
+        {{ if $appHasWhitelist }}
+        ## Only connections from the following addresses are allowed
+        {{ $whitelist := getv (printf "/deis/config/%s/deis_whitelist" $app) }}
+        {{ range $whitelist_entry := split $whitelist "," }}
+        {{ $whitelist_detail := split $whitelist_entry ":" }}
+        allow {{index $whitelist_detail 0}};{{if eq (len $whitelist_detail) 2}}  # {{index $whitelist_detail 1}}{{ end }}
+        {{ end }}
+        {{ end }}
+        {{ if or (eq $enforceWhitelist "true") $appHasWhitelist}}
+        deny all;
+        {{ end }}
+
         {{ if ne $appContainerLen 0 }}
         location / {
             {{ if eq $useFirewall "true" }}include                     /opt/nginx/firewall/active-mode.rules;{{ end }}


### PR DESCRIPTION
This is a new security feature for the router. This is useful if you run internal applications on Deis and want to restrict access to specific range of IPs. 