### PR TITLE
fix(builder): added back the check-repos script

### DIFF
--- a/builder/env/envvar.go
+++ b/builder/env/envvar.go
@@ -29,11 +29,11 @@ func Get(c cookoo.Context, params *cookoo.Params) (interface{}, cookoo.Interrupt
 		var val string
 		if val = os.Getenv(name); len(val) == 0 {
 			def := def.(string)
+			val = os.ExpandEnv(def)
 			// We want to make sure that any subsequent calls to Getenv
 			// return the same default.
-			os.Setenv(name, def)
+			os.Setenv(name, val)
 
-			val = os.ExpandEnv(def)
 		}
 		c.Put(name, val)
 		log.Debugf(c, "Name: %s, Val: %s", name, val)

--- a/builder/env/envvar_test.go
+++ b/builder/env/envvar_test.go
@@ -53,8 +53,24 @@ func TestGet(t *testing.T) {
 	if both := cxt.Get(snack, "").(string); both != "coffee and chocolate chip cookies" {
 		t.Errorf("Expected 'coffee and chocolate chip cookies'. Got '%s'", both)
 	}
+}
 
-	if both := os.Getenv(snack); both != snackVal {
-		t.Errorf("Expected %s to not be expanded. Got '%s'", snack, both)
+// TestGetInterpolation is a regression test to make sure that values are
+// interpolated correctly.
+func TestGetInterpolation(t *testing.T) {
+	reg, router, cxt := cookoo.Cookoo()
+
+	os.Setenv("TEST_ENV", "is")
+
+	reg.Route("test", "Test route").
+		Does(Get, "res").
+		Using("TEST_ENV2").WithDefault("de$TEST_ENV")
+
+	if err := router.HandleRequest("test", cxt, true); err != nil {
+		t.Error(err)
+	}
+
+	if os.Getenv("TEST_ENV2") != "deis" {
+		t.Errorf("Expected 'deis', got '%s'", os.Getenv("TEST_ENV2"))
 	}
 }

--- a/builder/rootfs/etc/confd/conf.d/check-repos.toml
+++ b/builder/rootfs/etc/confd/conf.d/check-repos.toml
@@ -1,0 +1,9 @@
+[template]
+src   = "check-repos"
+dest  = "/home/git/check-repos"
+uid = 0
+gid = 0
+mode  = "0755"
+keys = [
+  "/deis/registry",
+]

--- a/builder/rootfs/etc/confd/templates/check-repos
+++ b/builder/rootfs/etc/confd/templates/check-repos
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+export ETCD=${ETCD:-$HOST:4001}
+
+cd $(dirname $0) # absolute path
+
+for repo in $(ls | grep .git)
+do
+    reponame="${repo%.*}"
+    etcdctl -C "$ETCD" ls /deis/services/"$reponame" > /dev/null 2>&1
+    if [[ $? -eq 4 ]]
+    then
+        rm -rf "$repo"
+        appname="{{ getv "/deis/registry/host" }}:{{ getv "/deis/registry/port" }}/$reponame"
+        docker images | grep $appname | awk '{ print $3 }' | xargs -r docker rmi -f
+        # remove any dangling images left over from the cleanup
+        docker images --filter "dangling=true" | awk '{ print $3 }' | grep -v IMAGE | xargs -r docker rmi -f
+    fi
+done

--- a/builder/routes.go
+++ b/builder/routes.go
@@ -42,7 +42,7 @@ func routes(reg *cookoo.Registry) {
 				Name: "vars2",
 				Fn:   env.Get,
 				Using: []cookoo.Param{
-					{Name: "ETCD", DefaultValue: "http://$HOST:$ETCD_PORT"},
+					{Name: "ETCD", DefaultValue: "$HOST:$ETCD_PORT"},
 				},
 			},
 


### PR DESCRIPTION
Per #4338, I have replaced the script and toml file that I overzealously
removed in an earlier builder revision.

closes #4338