### PR TITLE
fix(logger): add unique id for each app name in logs

### DIFF
--- a/logspout/logspout.go
+++ b/logspout/logspout.go
@@ -102,7 +102,7 @@ func getLogName(name string) (string, string) {
 	if match != nil {
 		return match[1], match[3]
 	}
-	match = getMatch(`^k8s_([a-z0-9-]+)-([a-z]+)\.`, name)
+	match = getMatch(`^k8s_([a-z0-9-]+)-[a-z]+\.[\da-f]+_[a-z0-9-]+-([a-z]+-[\da-z]*)_`, name)
 	if match != nil {
 		return match[1], match[2]
 	}


### PR DESCRIPTION
fixes #4271 
2015-08-26T23:32:15UTC wiggly-buttress[web.97nsr]: 2015/08/26 23:32:15 listening on 5000...
2015-08-26T23:37:34UTC deis[api]: sm scaled containers web=3
2015-08-26T23:37:48UTC wiggly-buttress[web.po4k7]: 2015/08/26 23:37:48 listening on 5000...
2015-08-26T23:37:49UTC wiggly-buttress[web.7wb4n]: 2015/08/26 23:37:49 listening on 5000...

container name of the application: k8s_wiggly-buttress-web.7ee905fa_wiggly-buttress-v2-web-97nsr_wiggly-buttress_a7ae5889-4c4a-11e5-b18a-06842b0bdcf9_bf8b9b46 