### PR TITLE
fix(docs): update NewRelic section.

### DIFF
--- a/docs/managing_deis/platform_monitoring.rst
+++ b/docs/managing_deis/platform_monitoring.rst
@@ -112,9 +112,6 @@ New Relic
 
 The `New Relic`_ monitoring service's agent will run on the CoreOS host and report metrics to New Relic.
 
-Unlike Datadog, however, the agent running on the host doesn't send metrics for individual containers
-unless those containers have been built with a Dockerfile that installs their own instance of the agent.
-
 The Deis community's own Johannes Würbach has developed a fleet service for New Relic in his
 `newrelic-sysmond`_ repository.
 


### PR DESCRIPTION
NewRelic now reports individual docker container cpu and memory usage under the Docker tab of a server.