### PR TITLE
fix(router): revert symlink to /dev/stdout

### DIFF
--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -21,10 +21,6 @@ RUN addgroup -S nginx && \
 
 COPY rootfs /
 
-# forward request and error logs to docker
-RUN ln -sf /dev/stdout /opt/nginx/logs/access.log
-RUN ln -sf /dev/stderr /opt/nginx/logs/error.log
-
 # compile nginx from source
 RUN build
 


### PR DESCRIPTION
Nginx cannot log to a device for some reason, so this will have to stay. Why this works for `nginx` and not for `deis/router` is a little odd  (perhaps something to do with back-grounding nginx?)