### PR TITLE
fix(client-go): pass arguments when using root command to list

### DIFF
--- a/client-go/deis_test.go
+++ b/client-go/deis_test.go
@@ -12,10 +12,14 @@ func TestHelpReformatting(t *testing.T) {
 	expected := "help"
 
 	for _, test := range tests {
-		actual := parseArgs([]string{test})
+		actual, argv := parseArgs([]string{test})
 
-		if actual[0] != expected {
-			t.Errorf("Expected %s, Got %s", expected, actual[0])
+		if actual != expected {
+			t.Errorf("Expected %s, Got %s", expected, actual)
+		}
+
+		if len(argv) != 1 {
+			t.Errorf("Expected length of 1, Got %d", len(argv))
 		}
 	}
 }
@@ -24,13 +28,18 @@ func TestHelpReformattingWithCommand(t *testing.T) {
 	t.Parallel()
 
 	tests := []string{"--help", "-h", "help"}
-	expected := "--help"
+	expected := "test"
+	expectedArgv := []string{"test", "--help"}
 
 	for _, test := range tests {
-		actual := parseArgs([]string{test, "test"})
+		actual, argv := parseArgs([]string{test, "test"})
 
-		if actual[1] != expected {
-			t.Errorf("Expected %s, Got %s", expected, actual[1])
+		if actual != expected {
+			t.Errorf("Expected %s, Got %s", expected, actual)
+		}
+
+		if !reflect.DeepEqual(expectedArgv, argv) {
+			t.Errorf("Expected %v, Got %v", expectedArgv, argv)
 		}
 	}
 }
@@ -38,11 +47,17 @@ func TestHelpReformattingWithCommand(t *testing.T) {
 func TestCommandSplitting(t *testing.T) {
 	t.Parallel()
 
-	expected := []string{"apps", "create", "test", "foo"}
-	actual := parseArgs([]string{"apps:create", "test", "foo"})
+	expected := "apps"
+	expectedArgv := []string{"apps:create", "test", "foo"}
 
-	if !reflect.DeepEqual(expected, actual) {
-		t.Errorf("Expected %v, Got %v", expected, actual)
+	actual, argv := parseArgs(expectedArgv)
+
+	if actual != expected {
+		t.Errorf("Expected %s, Got %s", expected, actual)
+	}
+
+	if !reflect.DeepEqual(expectedArgv, argv) {
+		t.Errorf("Expected %v, Got %v", expectedArgv, argv)
 	}
 }
 

--- a/client-go/parser/apps.go
+++ b/client-go/parser/apps.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -24,29 +23,32 @@ apps:destroy       destroy an application
 
 Use 'deis help [command]' to learn more.
 `
-	if len(argv) < 2 {
-		return appsList([]string{"apps:list"})
-	}
 
-	switch argv[1] {
-	case "create":
-		return appCreate(combineCommand(argv))
-	case "list":
-		return appsList(combineCommand(argv))
-	case "info":
-		return appInfo(combineCommand(argv))
-	case "open":
-		return appOpen(combineCommand(argv))
-	case "logs":
-		return appLogs(combineCommand(argv))
-	case "run":
-		return appRun(combineCommand(argv))
-	case "destroy":
-		return appDestroy(combineCommand(argv))
-	case "--help":
-		fmt.Print(usage)
-		return nil
+	switch argv[0] {
+	case "apps:create":
+		return appCreate(argv)
+	case "apps:list":
+		return appsList(argv)
+	case "apps:info":
+		return appInfo(argv)
+	case "apps:open":
+		return appOpen(argv)
+	case "apps:logs":
+		return appLogs(argv)
+	case "apps:run":
+		return appRun(argv)
+	case "apps:destroy":
+		return appDestroy(argv)
 	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "apps" {
+			argv[0] = "apps:list"
+			return appsList(argv)
+		}
+
 		PrintUsage()
 		return nil
 	}

--- a/client-go/parser/auth.go
+++ b/client-go/parser/auth.go
@@ -22,26 +22,23 @@ auth:regenerate        regenerate user tokens
 
 Use 'deis help [command]' to learn more.
 `
-	if len(argv) < 2 {
-		return nil
-	}
 
-	switch argv[1] {
-	case "register":
-		return authRegister(combineCommand(argv))
-	case "login":
-		return authLogin(combineCommand(argv))
-	case "logout":
-		return authLogout(combineCommand(argv))
-	case "passwd":
-		return authPasswd(combineCommand(argv))
-	case "whoami":
-		return authWhoami(combineCommand(argv))
-	case "cancel":
-		return authCancel(combineCommand(argv))
-	case "regenerate":
-		return authRegenerate(combineCommand(argv))
-	case "--help":
+	switch argv[0] {
+	case "auth:register":
+		return authRegister(argv)
+	case "auth:login":
+		return authLogin(argv)
+	case "auth:logout":
+		return authLogout(argv)
+	case "auth:passwd":
+		return authPasswd(argv)
+	case "auth:whoami":
+		return authWhoami(argv)
+	case "auth:cancel":
+		return authCancel(argv)
+	case "auth:regenerate":
+		return authRegenerate(argv)
+	case "auth":
 		fmt.Print(usage)
 		return nil
 	default:

--- a/client-go/parser/builds.go
+++ b/client-go/parser/builds.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/deis/deis/client-go/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
@@ -17,19 +15,22 @@ builds:create      imports an image and deploys as a new release
 
 Use 'deis help [command]' to learn more.
 `
-	if len(argv) < 2 {
-		return buildsList([]string{"builds:list"})
-	}
 
-	switch argv[1] {
-	case "list":
-		return buildsList(combineCommand(argv))
-	case "create":
-		return buildsCreate(combineCommand(argv))
-	case "--help":
-		fmt.Print(usage)
-		return nil
+	switch argv[0] {
+	case "builds:list":
+		return buildsList(argv)
+	case "builds:create":
+		return buildsCreate(argv)
 	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "builds" {
+			argv[0] = "builds:list"
+			return buildsList(argv)
+		}
+
 		PrintUsage()
 		return nil
 	}

--- a/client-go/parser/certs.go
+++ b/client-go/parser/certs.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/deis/deis/client-go/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
@@ -18,21 +16,24 @@ certs:remove          remove an SSL certificate from an app
 
 Use 'deis help [command]' to learn more.
 `
-	if len(argv) < 2 {
-		return certsList([]string{"certs:list"})
-	}
 
-	switch argv[1] {
-	case "list":
-		return certsList(combineCommand(argv))
-	case "add":
-		return certAdd(combineCommand(argv))
-	case "remove":
-		return certRemove(combineCommand(argv))
-	case "--help":
-		fmt.Print(usage)
-		return nil
+	switch argv[0] {
+	case "certs:list":
+		return certsList(argv)
+	case "certs:add":
+		return certAdd(argv)
+	case "certs:remove":
+		return certRemove(argv)
 	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "certs" {
+			argv[0] = "certs:list"
+			return certsList(argv)
+		}
+
 		PrintUsage()
 		return nil
 	}

--- a/client-go/parser/config.go
+++ b/client-go/parser/config.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/deis/deis/client-go/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
@@ -20,25 +18,28 @@ config:push        set environment variables from .env
 
 Use 'deis help [command]' to learn more.
 `
-	if len(argv) < 2 {
-		return configList([]string{"config:list"})
-	}
 
-	switch argv[1] {
-	case "list":
-		return configList(combineCommand(argv))
-	case "set":
-		return configSet(combineCommand(argv))
-	case "unset":
-		return configUnset(combineCommand(argv))
-	case "pull":
-		return configPull(combineCommand(argv))
-	case "push":
-		return configPush(combineCommand(argv))
-	case "--help":
-		fmt.Print(usage)
-		return nil
+	switch argv[0] {
+	case "config:list":
+		return configList(argv)
+	case "config:set":
+		return configSet(argv)
+	case "config:unset":
+		return configUnset(argv)
+	case "config:pull":
+		return configPull(argv)
+	case "config:push":
+		return configPush(argv)
 	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "config" {
+			argv[0] = "config:list"
+			return configList(argv)
+		}
+
 		PrintUsage()
 		return nil
 	}

--- a/client-go/parser/domains.go
+++ b/client-go/parser/domains.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/deis/deis/client-go/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
@@ -18,21 +16,23 @@ domains:remove        unbind a domain from an application
 
 Use 'deis help [command]' to learn more.
 `
-	if len(argv) < 2 {
-		return domainsList([]string{"domains:list"})
-	}
-
-	switch argv[1] {
-	case "add":
-		return domainsAdd(combineCommand(argv))
-	case "list":
-		return domainsList(combineCommand(argv))
-	case "remove":
-		return domainsRemove(combineCommand(argv))
-	case "--help":
-		fmt.Print(usage)
-		return nil
+	switch argv[0] {
+	case "domains:add":
+		return domainsAdd(argv)
+	case "domains:list":
+		return domainsList(argv)
+	case "domains:remove":
+		return domainsRemove(argv)
 	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "domains" {
+			argv[0] = "domains:list"
+			return domainsList(argv)
+		}
+
 		PrintUsage()
 		return nil
 	}

--- a/client-go/parser/git.go
+++ b/client-go/parser/git.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/deis/deis/client-go/cmd"
@@ -17,14 +16,11 @@ git:remote          Adds git remote of application to repository
 
 Use 'deis help [command]' to learn more.
 `
-	if len(argv) < 2 {
-		return errors.New("'deis git' is not a valid command, try 'deis help git'")
-	}
 
-	switch argv[1] {
-	case "remote":
-		return gitRemote(combineCommand(argv))
-	case "--help":
+	switch argv[0] {
+	case "git:remote":
+		return gitRemote(argv)
+	case "git":
 		fmt.Print(usage)
 		return nil
 	default:

--- a/client-go/parser/keys.go
+++ b/client-go/parser/keys.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/deis/deis/client-go/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
@@ -18,21 +16,24 @@ keys:remove      remove an SSH key
 
 Use 'deis help [command]' to learn more.
 `
-	if len(argv) < 2 {
-		return keysList([]string{"keys:list"})
-	}
 
-	switch argv[1] {
-	case "list":
-		return keysList(combineCommand(argv))
-	case "add":
-		return keyAdd(combineCommand(argv))
-	case "remove":
-		return keyRemove(combineCommand(argv))
-	case "--help":
-		fmt.Print(usage)
-		return nil
+	switch argv[0] {
+	case "keys:list":
+		return keysList(argv)
+	case "keys:add":
+		return keyAdd(argv)
+	case "keys:remove":
+		return keyRemove(argv)
 	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "keys" {
+			argv[0] = "keys:list"
+			return keysList(argv)
+		}
+
 		PrintUsage()
 		return nil
 	}

--- a/client-go/parser/limits.go
+++ b/client-go/parser/limits.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/deis/deis/client-go/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
@@ -18,21 +16,24 @@ limits:unset       unset resource limits for an app
 
 Use 'deis help [command]' to learn more.
 `
-	if len(argv) < 2 {
-		return limitsList([]string{"limits:list"})
-	}
 
-	switch argv[1] {
-	case "list":
-		return limitsList(combineCommand(argv))
-	case "set":
-		return limitSet(combineCommand(argv))
-	case "unset":
-		return limitUnset(combineCommand(argv))
-	case "--help":
-		fmt.Print(usage)
-		return nil
+	switch argv[0] {
+	case "limits:list":
+		return limitsList(argv)
+	case "limits:set":
+		return limitSet(argv)
+	case "limits:unset":
+		return limitUnset(argv)
 	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "limits" {
+			argv[0] = "limits:list"
+			return limitsList(argv)
+		}
+
 		PrintUsage()
 		return nil
 	}

--- a/client-go/parser/perms.go
+++ b/client-go/parser/perms.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/deis/deis/client-go/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
@@ -18,21 +16,23 @@ perms:delete          delete a permission for a user
 
 Use 'deis help perms:[command]' to learn more.
 `
-	if len(argv) < 2 {
-		return permsList([]string{"perms:list"})
-	}
-
-	switch argv[1] {
-	case "list":
-		return permsList(combineCommand(argv))
-	case "create":
-		return permCreate(combineCommand(argv))
-	case "delete":
-		return permDelete(combineCommand(argv))
-	case "--help":
-		fmt.Print(usage)
-		return nil
+	switch argv[0] {
+	case "perms:list":
+		return permsList(argv)
+	case "perms:create":
+		return permCreate(argv)
+	case "perms:delete":
+		return permDelete(argv)
 	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "perms" {
+			argv[0] = "perms:list"
+			return permsList(argv)
+		}
+
 		PrintUsage()
 		return nil
 	}

--- a/client-go/parser/ps.go
+++ b/client-go/parser/ps.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/deis/deis/client-go/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
@@ -18,21 +16,24 @@ ps:scale       scale processes (e.g. web=4 worker=2)
 
 Use 'deis help [command]' to learn more.
 `
-	if len(argv) < 2 {
-		return psList([]string{"ps:list"})
-	}
 
-	switch argv[1] {
-	case "list":
-		return psList(combineCommand(argv))
-	case "restart":
-		return psRestart(combineCommand(argv))
-	case "scale":
-		return psScale(combineCommand(argv))
-	case "--help":
-		fmt.Print(usage)
-		return nil
+	switch argv[0] {
+	case "ps:list":
+		return psList(argv)
+	case "ps:restart":
+		return psRestart(argv)
+	case "ps:scale":
+		return psScale(argv)
 	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "ps" {
+			argv[0] = "ps:list"
+			return psList(argv)
+		}
+
 		PrintUsage()
 		return nil
 	}

--- a/client-go/parser/releases.go
+++ b/client-go/parser/releases.go
@@ -19,21 +19,24 @@ releases:rollback    return to a previous release
 
 Use 'deis help [command]' to learn more.
 `
-	if len(argv) < 2 {
-		return releasesList([]string{"releases:list"})
-	}
 
-	switch argv[1] {
-	case "list":
-		return releasesList(combineCommand(argv))
-	case "info":
-		return releasesInfo(combineCommand(argv))
-	case "rollback":
-		return releasesRollback(combineCommand(argv))
-	case "--help":
-		fmt.Print(usage)
-		return nil
+	switch argv[0] {
+	case "releases:list":
+		return releasesList(argv)
+	case "releases:info":
+		return releasesInfo(argv)
+	case "releases:rollback":
+		return releasesRollback(argv)
 	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "releases" {
+			argv[0] = "releases:list"
+			return releasesList(argv)
+		}
+
 		PrintUsage()
 		return nil
 	}

--- a/client-go/parser/tags.go
+++ b/client-go/parser/tags.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/deis/deis/client-go/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
@@ -18,21 +16,24 @@ tags:unset       unset tags for an app
 
 Use 'deis help [command]' to learn more.
 `
-	if len(argv) < 2 {
-		return tagsList([]string{"tags:list"})
-	}
 
-	switch argv[1] {
-	case "list":
-		return tagsList(combineCommand(argv))
-	case "set":
-		return tagsSet(combineCommand(argv))
-	case "unset":
-		return tagsUnset(combineCommand(argv))
-	case "--help":
-		fmt.Print(usage)
-		return nil
+	switch argv[0] {
+	case "tags:list":
+		return tagsList(argv)
+	case "tags:set":
+		return tagsSet(argv)
+	case "tags:unset":
+		return tagsUnset(argv)
 	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "tags" {
+			argv[0] = "tags:list"
+			return tagsList(argv)
+		}
+
 		PrintUsage()
 		return nil
 	}

--- a/client-go/parser/users.go
+++ b/client-go/parser/users.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/deis/deis/client-go/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
@@ -16,17 +14,20 @@ users:list        list all registered users
 
 Use 'deis help [command]' to learn more.
 `
-	if len(argv) < 2 {
-		return usersList([]string{"users:list"})
-	}
 
-	switch argv[1] {
-	case "list":
-		return usersList(combineCommand(argv))
-	case "--help":
-		fmt.Print(usage)
-		return nil
+	switch argv[0] {
+	case "users:list":
+		return usersList(argv)
 	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "users" {
+			argv[0] = "users:list"
+			return usersList(argv)
+		}
+
 		PrintUsage()
 		return nil
 	}

--- a/client-go/parser/utils.go
+++ b/client-go/parser/utils.go
@@ -5,16 +5,6 @@ import (
 	"strconv"
 )
 
-// docopt expects commands to be in the proper format, but we split them apart for
-// routing purposes, so the commands need to be recombined.
-func combineCommand(argv []string) []string {
-	if len(argv) > 1 {
-		return append([]string{argv[0] + ":" + argv[1]}, argv[2:]...)
-	}
-
-	return nil
-}
-
 func safeGetValue(args map[string]interface{}, key string) string {
 	if args[key] == nil {
 		return ""
@@ -34,4 +24,15 @@ func responseLimit(limit string) (int, error) {
 func PrintUsage() {
 	fmt.Println("Found no matching command, try 'deis help'")
 	fmt.Println("Usage: deis <command> [<args>...]")
+}
+
+func printHelp(argv []string, usage string) bool {
+	if len(argv) > 1 {
+		if argv[1] == "--help" || argv[1] == "-h" {
+			fmt.Print(usage)
+			return true
+		}
+	}
+
+	return false
 }

--- a/client-go/parser/utils_test.go
+++ b/client-go/parser/utils_test.go
@@ -1,20 +1,6 @@
 package parser
 
-import (
-	"reflect"
-	"testing"
-)
-
-func TestCommandCombing(t *testing.T) {
-	t.Parallel()
-
-	expected := []string{"apps:create", "test", "foo"}
-	actual := combineCommand([]string{"apps", "create", "test", "foo"})
-
-	if !reflect.DeepEqual(expected, actual) {
-		t.Errorf("Expected %s, Got %s", expected, actual)
-	}
-}
+import "testing"
 
 func TestSafeGet(t *testing.T) {
 	t.Parallel()
@@ -43,5 +29,27 @@ func TestSafeGetNil(t *testing.T) {
 
 	if expected != actual {
 		t.Errorf("Expected %s, Got %s", expected, actual)
+	}
+}
+
+func TestPrintHelp(t *testing.T) {
+	t.Parallel()
+
+	usage := ""
+
+	if !printHelp([]string{"ps", "--help"}, usage) {
+		t.Error("Expected true")
+	}
+
+	if !printHelp([]string{"ps", "-h"}, usage) {
+		t.Error("Expected true")
+	}
+
+	if printHelp([]string{"ps"}, usage) {
+		t.Error("Expected false")
+	}
+
+	if printHelp([]string{"ps", "--foo"}, usage) {
+		t.Error("Expected false")
 	}
 }


### PR DESCRIPTION
Fixes #4357 

This change got fairly in depth because of the new matching that had to be done to separate invalid commands from arguments passed to `command:list`.