### PR TITLE
fix(client): print usage if no args were given

### DIFF
--- a/client/deis.go
+++ b/client/deis.go
@@ -72,7 +72,8 @@ Use 'git push deis master' to deploy to an application.
 	}
 
 	if len(argv) == 0 {
-		return 0
+		fmt.Println("Usage: deis <command> [<args>...]")
+		return 1
 	}
 
 	// Dispatch the command, passing the argv through so subcommands can


### PR DESCRIPTION
Also return 1 for consistency with the python `deis` CLI. Output is now the same:
```console
$ ./deis badcommand
Found no matching command, try 'deis help'
Usage: deis <command> [<args>...]
$ ./deis 
Usage: deis <command> [<args>...]
$ echo $?
1
```

Closes #4364.