### PR TITLE
fix(deisctl): error when journaling a global unit

### DIFF
--- a/deisctl/backend/fleet/journal.go
+++ b/deisctl/backend/fleet/journal.go
@@ -18,6 +18,12 @@ func (c *FleetClient) Journal(target string) (err error) {
 
 // runJournal tails the systemd journal for a given unit
 func (c *FleetClient) runJournal(name string) (exit int) {
+	u, err := c.Fleet.Unit(name)
+	if suToGlobal(*u) {
+		fmt.Fprintf(c.errWriter, "Unable to get journal for global unit %s. Check on a host directly using journalctl.\n", name)
+		return 1
+	}
+
 	machineID, err := c.findUnit(name)
 
 	if err != nil {


### PR DESCRIPTION
```console
$ deisctl journal store-volume
Unable to get journal for global unit deis-store-volume.service. Check on a host directly using journalctl.
$ deisctl journal controller
-- Logs begin at Fri 2015-08-28 16:59:47 UTC. --
Aug 28 17:17:36 deis-01 sh[3237]: > api:0017_auto__del_cluster__del_field_app_cluster
Aug 28 17:17:37 deis-01 sh[3237]: > api:0018_drop_field_release_image__chg_field_release_build
...
```

Closes #4361.