### PR TITLE
fix(controller): clarify error if registration is disabled

### DIFF
--- a/controller/api/permissions.py
+++ b/controller/api/permissions.py
@@ -1,3 +1,5 @@
+
+from rest_framework import exceptions
 from rest_framework import permissions
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -103,7 +105,7 @@ class HasRegistrationAuth(permissions.BasePermission):
         """
         try:
             if settings.REGISTRATION_MODE == 'disabled':
-                return False
+                raise exceptions.PermissionDenied('Registration is disabled')
             if settings.REGISTRATION_MODE == 'enabled':
                 return True
             elif settings.REGISTRATION_MODE == 'admin_only':


### PR DESCRIPTION
Changes the error message from the generic "You do not have permission to perform this action" when registration is disabled.

```console
$ deisctl config controller get registrationMode
disabled
$ deis register http://deis.local3.deisapp.com --username=test2 --password=asdf1234 --email=just@testing.thanks
Registration failed: Error: 
detail: Registration is disabled
403 FORBIDDEN
```

Closes #4371.