### PR TITLE
chore(swarm): update to go 1.5

### DIFF
--- a/swarm/Dockerfile
+++ b/swarm/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.4
+FROM golang:1.5
 
 WORKDIR /go/src/github.com/docker
 RUN git clone https://github.com/deis/swarm


### PR DESCRIPTION
A minor update for Go 1.5 that should have been included with #4309. I tested this on vagrant.

[skip ci]