### PR TITLE
fix(client): fix make install

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -14,8 +14,8 @@ build:
 	CGO_ENABLED=0 godep go build -a -installsuffix cgo -ldflags '-s' -o deis .
 	@$(call check-static-binary,deis)
 
-install:
-	godep go install -v .
+install: build
+	cp deis $$GOPATH/bin
 
 installer: build
 	@if [ ! -d makeself ]; then git clone -b single-binary https://github.com/deis/makeself.git; fi


### PR DESCRIPTION
This updates the `install` target in the Go-based client's `Makefile` to fulfill the reasonable expectation a contributor may have that `make -C client/ build install` will actually install a `deis` binary.  It does so by copying the built binary to `$GOPATH/bin`.