### PR TITLE
fix(client): show non-JSON HTTP errors

### DIFF
--- a/client/cmd/auth.go
+++ b/client/cmd/auth.go
@@ -29,7 +29,7 @@ func Register(controller string, username string, password string, email string,
 		return err
 	}
 
-	if err = client.CheckConection(httpClient, controllerURL); err != nil {
+	if err = client.CheckConnection(httpClient, controllerURL); err != nil {
 		return err
 	}
 
@@ -115,7 +115,7 @@ func Login(controller string, username string, password string, sslVerify bool) 
 		return err
 	}
 
-	if err = client.CheckConection(httpClient, controllerURL); err != nil {
+	if err = client.CheckConnection(httpClient, controllerURL); err != nil {
 		return err
 	}
 

--- a/client/controller/client/http.go
+++ b/client/controller/client/http.go
@@ -111,7 +111,7 @@ func checkForErrors(res *http.Response, body string) error {
 	bodyMap := make(map[string]interface{})
 
 	if err := json.Unmarshal([]byte(body), &bodyMap); err != nil {
-		return err
+		return fmt.Errorf("\n%s\n%s\n", res.Status, body)
 	}
 
 	errorMessage := fmt.Sprintf("\n%s\n", res.Status)

--- a/client/controller/client/http.go
+++ b/client/controller/client/http.go
@@ -61,7 +61,7 @@ func (c Client) Request(method string, path string, body []byte) (*http.Response
 		return nil, err
 	}
 
-	checkAPICompatability(res.Header.Get("DEIS_API_VERSION"))
+	checkAPICompatibility(res.Header.Get("DEIS_API_VERSION"))
 
 	return res, nil
 }
@@ -152,8 +152,8 @@ func checkForErrors(res *http.Response, body string) error {
 	return errors.New(errorMessage)
 }
 
-// CheckConection checks that the user is connected to a network and the URL points to a valid controller.
-func CheckConection(client *http.Client, controllerURL url.URL) error {
+// CheckConnection checks that the user is connected to a network and the URL points to a valid controller.
+func CheckConnection(client *http.Client, controllerURL url.URL) error {
 	errorMessage := `%s does not appear to be a valid Deis controller.
 Make sure that the Controller URI is correct and the server is running.`
 
@@ -180,7 +180,7 @@ Make sure that the Controller URI is correct and the server is running.`
 		return fmt.Errorf(errorMessage, baseURL)
 	}
 
-	checkAPICompatability(res.Header.Get("DEIS_API_VERSION"))
+	checkAPICompatibility(res.Header.Get("DEIS_API_VERSION"))
 
 	return nil
 }

--- a/client/controller/client/http.go
+++ b/client/controller/client/http.go
@@ -114,16 +114,16 @@ func checkForErrors(res *http.Response, body string) error {
 		return err
 	}
 
-	errorMessage := "\n"
+	errorMessage := fmt.Sprintf("\n%s\n", res.Status)
 	for key, value := range bodyMap {
 		switch v := value.(type) {
 		case string:
-			errorMessage += key + ": " + v + "\n"
+			errorMessage += fmt.Sprintf("%s: %s\n", key, v)
 		case []interface{}:
 			for _, subValue := range v {
 				switch sv := subValue.(type) {
 				case string:
-					errorMessage += key + ": " + sv + "\n"
+					errorMessage += fmt.Sprintf("%s: %s\n", key, sv)
 				default:
 					fmt.Printf("Unexpected type in %s error message array. Contents: %v",
 						reflect.TypeOf(value), sv)
@@ -135,7 +135,6 @@ func checkForErrors(res *http.Response, body string) error {
 		}
 	}
 
-	errorMessage += res.Status + "\n"
 	return errors.New(errorMessage)
 }
 

--- a/client/controller/client/http_test.go
+++ b/client/controller/client/http_test.go
@@ -147,16 +147,16 @@ func TestCheckErrors(t *testing.T) {
 	t.Parallel()
 
 	expected := `
+404 NOT FOUND
 error: This is an error.
 error_array: This is an array.
 error_array: Foo!
-404 NOT FOUND
 `
 	altExpected := `
+404 NOT FOUND
 error_array: This is an array.
 error_array: Foo!
 error: This is an error.
-404 NOT FOUND
 `
 
 	body := `

--- a/client/controller/client/http_test.go
+++ b/client/controller/client/http_test.go
@@ -178,6 +178,36 @@ error: This is an error.
 	if actual != expected && actual != altExpected {
 		t.Errorf("Expected %s or %s, Got %s", expected, altExpected, actual)
 	}
+
+	expected = `
+503 Service Temporarily Unavailable
+<html>
+<head><title>503 Service Temporarily Unavailable</title></head>
+<body bgcolor="white">
+<center><h1>503 Service Temporarily Unavailable</h1></center>
+<hr><center>nginx/1.9.4</center>
+</body>
+</html>
+`
+
+	body = `<html>
+<head><title>503 Service Temporarily Unavailable</title></head>
+<body bgcolor="white">
+<center><h1>503 Service Temporarily Unavailable</h1></center>
+<hr><center>nginx/1.9.4</center>
+</body>
+</html>`
+
+	res = http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Status:     "503 Service Temporarily Unavailable",
+	}
+
+	actual = checkForErrors(&res, body).Error()
+
+	if actual != expected {
+		t.Errorf("Expected %s, Got %s", expected, actual)
+	}
 }
 
 func TestCheckErrorsReturnsNil(t *testing.T) {

--- a/client/controller/client/http_test.go
+++ b/client/controller/client/http_test.go
@@ -109,7 +109,7 @@ func TestCheckConnection(t *testing.T) {
 
 	httpClient := CreateHTTPClient(false)
 
-	if err = CheckConection(httpClient, *u); err != nil {
+	if err = CheckConnection(httpClient, *u); err != nil {
 		t.Error(err)
 	}
 }

--- a/client/controller/client/utils.go
+++ b/client/controller/client/utils.go
@@ -18,7 +18,7 @@ func locateSettingsFile() string {
 	return path.Join(FindHome(), ".deis", filename+".json")
 }
 
-func checkAPICompatability(serverAPIVersion string) {
+func checkAPICompatibility(serverAPIVersion string) {
 	if serverAPIVersion != version.APIVersion {
 		fmt.Printf(`!    WARNING: Client and server API versions do not match. Please consider upgrading.
 !    Client version: %s


### PR DESCRIPTION
This changes the new CLI to display the raw response body and status code for HTTP 40x and 50x errors if JSON decoding fails. It also moves the HTTP status line first for any error displayed, to match the old python CLI.