### PR TITLE
fix(logspout): set GOMAXPROCS=1

### DIFF
--- a/logspout/logspout.go
+++ b/logspout/logspout.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -185,6 +186,7 @@ func getEtcdValueOrDefault(c *etcd.Client, key string, defaultValue string) stri
 }
 
 func main() {
+	runtime.GOMAXPROCS(1)
 	debugMode = getopt("DEBUG", "") != ""
 	port := getopt("PORT", "8000")
 	endpoint := getopt("DOCKER_HOST", "unix:///var/run/docker.sock")


### PR DESCRIPTION
During v1.10.0 testing, I have been observing issues with `deis-logspout`.  They are most easily replicable when scaling to many containers quickly.  (Using k8s as the scheduler helps.)

The issue seems to be deadlock and is observable when the Docker event stream normally visible in each `deis-logspout` instance's own logs grinds to a halt.  If this sounds familiar, it is different, but similar to the root cause of #3633 which was closed by #4291

After much observation and testing, I realized I was never able to reproduce this issue if I built the `deis-logspout` container myself.  A variable I eventually realized was in play was that I was building `deis-logspout` using Go 1.4, whilst the images used for release testing where built using Go 1.5.

@gabrtv and @mboersma pointed me in the direction of recent changes in Go 1.5 re: concurrency.  See [here](https://golang.org/s/go15gomaxprocs).

As a workaround, this PR sets `GOMAXPROCS ` to 1 and seems to address the problem.

Ultimately, this is a little bit of a band-aid, but given that I expect #4347 to make broader improvements to how we manage logspout, I think this fix is just right.

@carmstrong @mboersma this needs to make it into v1.10.0.