### PR TITLE
Builder: avoid race on repositories clean up

### DIFF
--- a/builder/rootfs/etc/confd/templates/builder
+++ b/builder/rootfs/etc/confd/templates/builder
@@ -171,8 +171,6 @@ indent "To learn more, use \`deis help\` or visit http://deis.io"
 echo
 
 # cleanup
-cd $REPO_DIR
-git gc &>/dev/null
 if [ -n "$JOB" ]; then
   docker rm -f $JOB &>/dev/null
 fi


### PR DESCRIPTION
Repositories are cleaned up periodically by the `check-repos` script, resulting in a race condition with the final cleanup of the `builder` script.

This change avoids this race by leaving the cleanup work to `check-repos` script only.

Fixes #4393