### PR TITLE
fix(database): use ETCD host during database recovery detection

### DIFF
--- a/database/bin/boot
+++ b/database/bin/boot
@@ -65,7 +65,7 @@ fi
 
 # ensure WAL log bucket exists
 envdir /etc/wal-e.d/env /app/bin/create_bucket "${BUCKET_NAME}"
-INIT_ID=$(etcdctl get "$ETCD_PATH/initId" 2> /dev/null || echo none)
+INIT_ID=$(etcdctl get -C "$ETCD" "$ETCD_PATH/initId" 2> /dev/null || echo none)
 echo "database: expecting initialization id: $INIT_ID"
 
 initial_backup=0


### PR DESCRIPTION
When troubleshooting failed database recovery on Azure, it seems we are failing to pull the `/deis/database/initId` from etcd even when it is populated.  Upon closer inspection I noticed we are not passing in the list of etcd hosts to etcdctl.  This PR passes `-C $ETCD` which seems to resolve the issue.  This will require manual database failover testing.

Reminder: all of these boot scripts need to be rewritten in Go. :wink: 