### PR TITLE
fix(database): arrange etcdctl arguments properly

### DIFF
--- a/database/bin/boot
+++ b/database/bin/boot
@@ -65,7 +65,7 @@ fi
 
 # ensure WAL log bucket exists
 envdir /etc/wal-e.d/env /app/bin/create_bucket "${BUCKET_NAME}"
-INIT_ID=$(etcdctl get -C "$ETCD" "$ETCD_PATH/initId" 2> /dev/null || echo none)
+INIT_ID=$(etcdctl -C "$ETCD" get "$ETCD_PATH/initId" 2> /dev/null || echo none)
 echo "database: expecting initialization id: $INIT_ID"
 
 initial_backup=0


### PR DESCRIPTION
I tested by hand and verified this fixes the syntax error introduced by #4402.