### PR TITLE
fix(Makefile): silence docker-machine warning when it isn't installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ dev-registry: check-docker
 	@docker inspect registry >/dev/null 2>&1 && docker start registry || docker run --restart="always" -d -p 5000:5000 --name registry registry:0.9.1
 	@echo
 	@echo "To use a local registry for Deis development:"
-	@echo "    export DEV_REGISTRY=`docker-machine ip $$(docker-machine active) 2>/dev/null`:5000"
+	@echo "    export DEV_REGISTRY=`docker-machine ip $$(docker-machine active 2>/dev/null) 2>/dev/null || echo $(HOST_IPADDR) `:5000"
 
 dev-cluster: discovery-url
 	vagrant up


### PR DESCRIPTION
Without this change:

```
registry

To use a local registry for Deis development:
/bin/bash: docker-machine: command not found
    export DEV_REGISTRY=:5000
```

This change returns `dev-registry` to the old behavior:

```
registry

To use a local registry for Deis development:
    export DEV_REGISTRY=:5000
```

This is useful on Linux where it's common to use docker natively.