### PR TITLE
[WIP] feat(builder): pull submodules if detected

### DIFF
--- a/builder/rootfs/Dockerfile
+++ b/builder/rootfs/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --update-cache \
     udev \
     util-linux \
     xz \
+    perl \
     && rm -rf /var/cache/apk/*
 
 # the docker package in alpine disables aufs and devicemapper

--- a/builder/rootfs/etc/confd/templates/builder
+++ b/builder/rootfs/etc/confd/templates/builder
@@ -64,10 +64,31 @@ mkdir -p $BUILD_DIR $CACHE_DIR
 TMP_DIR=$(mktemp -d -p $BUILD_DIR)
 
 cd $REPO_DIR
-git archive $GIT_SHA | tar -xmC $TMP_DIR
 
-# switch to app context
-cd $TMP_DIR
+# Check if .gitmodules file exists.
+git ls-files --with-tree $GIT_SHA --error-unmatch .gitmodules 1>/dev/null 2>/dev/null
+
+if [  $? -eq 0 ]; then
+    puts-step "Git submodules detected"
+
+    # HACK: git archive ignores submodules, so we have to clone
+    # and then -rf .git to mimic archive behavior
+
+    git clone --quiet --reference="$REPO_DIR" "file://$REPO_DIR" "$TMP_DIR"
+    cd $TMP_DIR
+    git checkout $GIT_SHA
+
+    # intialize and pull submodules
+    git submodule init --quiet
+    git submodule update --quiet --recursive
+
+    rm -rf .git
+else
+    git archive $GIT_SHA | tar -xmC $TMP_DIR
+
+    # switch to app context
+    cd $TMP_DIR
+fi
 
 USING_DOCKERFILE=false
 


### PR DESCRIPTION
Why is this WIP?
- The builder uses the bare repo format, which is just the `.git` folder of a normal git repository. At the moment, builder uses `git archive` to get the files out of the bare repo, but you need to have the git repository in order to checkout submodules. The only way to get a working directory of a bare git repo is to clone it. I can clone the bare repository with the command in this script when sshing into the builder, but whenever the command runs in the gitrecieve script, I get a warning that I am cloning into a empty repository and checking out the revision fails. I'm not sure what is up with this. Is this some sort of anti-race condition that you cannot checkout a revision still being pushed to the repository? If so, are there any other ways to checkout submodules? Heroku seems like they might parse the gitmodules file themselves and pull the submodules themselves, but that doesn't seem like a great option if there are any alternatives. I'd love any ideas for other ways to checkout the repository that won't hit that strange error.
- We should probably add tests for this, maybe an example app with a submodule in the integration tests?