### PR TITLE
fix(client): print logs that lack a category prefix

### DIFF
--- a/client/cmd/apps.go
+++ b/client/cmd/apps.go
@@ -158,10 +158,19 @@ func AppLogs(appID string, lines int) error {
 		return err
 	}
 
+	return printLogs(logs)
+}
+
+// printLogs prints each log line with a color matched to its category.
+func printLogs(logs string) error {
 	for _, log := range strings.Split(strings.Trim(logs, `\n`), `\n`) {
-		catagory := strings.Split(strings.Split(log, ": ")[0], " ")[1]
+		category := "unknown"
+		parts := strings.Split(strings.Split(log, ": ")[0], " ")
+		if len(parts) >= 2 {
+			category = parts[1]
+		}
 		colorVars := map[string]string{
-			"Color": chooseColor(catagory),
+			"Color": chooseColor(category),
 			"Log":   log,
 		}
 		fmt.Println(prettyprint.ColorizeVars("{{.V.Color}}{{.V.Log}}{{.C.Default}}", colorVars))

--- a/client/cmd/apps_test.go
+++ b/client/cmd/apps_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import "testing"
+
+func TestPrintLogLinesBadLine(t *testing.T) {
+	t.Parallel()
+
+	// Regression test for https://github.com/deis/deis/issues/4420
+	logs := `\nDone preparing production files\n\n\u001b[4mRunning \"concat:plugins\" (concat) task\u001b[24m\n`
+	if err := printLogs(logs); err != nil {
+		t.Fatal(err)
+	}
+
+	logs = `\n\n\n`
+	if err := printLogs(logs); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
The client code behind `deis apps:logs` referenced the second element of a string array without checking its length. This could cause a panic in some cases when the log line wasn't similar to:
```
2015-09-10T16:38:41UTC zaftig-occupant[web.1]: 2015/09/10 16:38:41 listening on 5000...
```

Now such unexpected log lines will get a category of "unknown". Logs with embedded newlines may still look a bit odd on your screen, but at least they will print successfully now.

I broke out part of the code into a `printLogs` func to make it easier to write a regression test.

Closes #4420.