### PR TITLE
ref(user-data): use default etcd2 and flannel services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ discovery-url:
 	@for i in 1 2 3 4 5; do \
 		URL=`curl -s -w '\n' https://discovery.etcd.io/new?size=$$DEIS_NUM_INSTANCES`; \
 		if [ ! -z $$URL ]; then \
-			sed -e "s,discovery #DISCOVERY_URL,discovery $$URL," contrib/coreos/user-data.example > contrib/coreos/user-data; \
+			sed -e "s,discovery: #DISCOVERY_URL,discovery: $$URL," contrib/coreos/user-data.example > contrib/coreos/user-data; \
 			echo "Wrote $$URL to contrib/coreos/user-data"; \
 		    break; \
 		fi; \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,10 +78,8 @@ Vagrant.configure("2") do |config|
 
   config.trigger.before :up do
     if File.exists?(CLOUD_CONFIG_PATH) && !File.readlines(CLOUD_CONFIG_PATH).grep(/\s*discovery #DISCOVERY_URL/).any?
-      # Vagrant binds the VMs IP in VirtualBox's bridge network to the eth1 interface instead of eth0.
-      # This necessitates the substitution below, which is not required anywhere except in Vagrant.
       user_data = File.read(CLOUD_CONFIG_PATH)
-      new_userdata = user_data.gsub("/opt/bin/flanneld --ip-masq=true", "/opt/bin/flanneld --iface=eth1 --ip-masq=true")
+      new_userdata = user_data.gsub("coreos:", "coreos:\n  flannel:\n    interface: $public_ipv4")
       File.open(CLOUD_CONFIG_PATH, "w") {|file| file.puts new_userdata }
     else
       raise Vagrant::Errors::VagrantError.new, "Run 'make discovery-url' first to create user-data."

--- a/contrib/aws/gen-json.py
+++ b/contrib/aws/gen-json.py
@@ -73,7 +73,7 @@ PREPARE_ETCD_DATA_DIRECTORY = '''
   Description=Prepares the etcd data directory
   Requires=media-etcd.mount
   After=media-etcd.mount
-  Before=etcd.service
+  Before=etcd2.service
   [Service]
   Type=oneshot
   RemainAfterExit=yes
@@ -92,7 +92,7 @@ new_units = [
     dict({'name': 'format-etcd-volume.service', 'command': 'start', 'content': FORMAT_ETCD_VOLUME}),
     dict({'name': 'media-etcd.mount', 'command': 'start', 'content': MOUNT_ETCD_VOLUME}),
     dict({'name': 'prepare-etcd-data-directory.service', 'command': 'start', 'content': PREPARE_ETCD_DATA_DIRECTORY}),
-    dict({'name': 'etcd.service', 'drop-ins': [{'name': '90-after-etcd-volume.conf', 'content': ETCD_DROPIN}]})
+    dict({'name': 'etcd2.service', 'drop-ins': [{'name': '90-after-etcd-volume.conf', 'content': ETCD_DROPIN}]})
 ]
 
 with open(os.path.join(CURR_DIR, '..', 'coreos', 'user-data'), 'r') as f:

--- a/contrib/azure/azure-coreos-cluster
+++ b/contrib/azure/azure-coreos-cluster
@@ -61,14 +61,19 @@ parser.add_argument('--no-discovery-url', action='store_true',
 cloud_init_template = """#cloud-config
 
 coreos:
-  etcd:
+  etcd2:
     # generate a new token for each unique cluster from https://discovery.etcd.io/new
     discovery: {0}
-    # deployments across multiple cloud services will need to use $public_ipv4
-    addr: $private_ipv4:4001
-    peer-addr: $private_ipv4:7001
+    # multi-region and multi-cloud deployments need to use $public_ipv4
+    advertise-client-urls: http://$private_ipv4:2379
+    initial-advertise-peer-urls: http://$private_ipv4:2380
+    # listen on both the official ports and the legacy ports
+    # legacy ports can be omitted if your application doesn't depend on them
+    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
+    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    data-dir: /var/lib/etcd2
   units:
-    - name: etcd.service
+    - name: etcd2.service
       command: start
     - name: fleet.service
       command: start

--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -1,161 +1,101 @@
 #cloud-config
----
+
 coreos:
+  etcd2:
+    # generate a new token for each unique cluster from https://discovery.etcd.io/new
+    discovery: #DISCOVERY_URL
+    # multi-region and multi-cloud deployments need to use $public_ipv4
+    advertise-client-urls: http://$private_ipv4:2379
+    initial-advertise-peer-urls: http://$private_ipv4:2380
+    # listen on both the official ports and the legacy ports
+    # legacy ports can be omitted if your application doesn't depend on them
+    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
+    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    data-dir: /var/lib/etcd2
   fleet:
-    # We have to set the public_ip here so this works on Vagrant -- otherwise, Vagrant VMs
-    # will all publish the same private IP. This is harmless for cloud providers.
-    public-ip: $private_ipv4
-    # allow etcd to slow down at times
-    etcd_request_timeout: 3.0
+    public-ip: $public_ipv4
     metadata: controlPlane=true,dataPlane=true,routerMesh=true
+  update:
+    reboot-strategy: "off"
   units:
-  - name: etcd.service
-    command: start
-    content: |
-      [Unit]
-      Description=etcd2 container
-      Requires=early-docker.service
-      After=early-docker.service
-      Before=early-docker.target
+    - name: etcd2.service
+      command: start
+    - name: fleet.service
+      command: start
+    - name: docker-tcp.socket
+      command: start
+      enable: true
+      content: |
+        [Unit]
+        Description=Docker Socket for the API
 
-      [Service]
-      User=etcd
-      PermissionsStartOnly=true
-      Restart=always
-      RestartSec=10s
-      LimitNOFILE=40000
-      EnvironmentFile=/etc/environment
-      Environment="ETCD_IMAGE=quay.io/coreos/etcd:v2.1.2"
-      Environment="ETCD_ELECTION_TIMEOUT=2000"
-      Environment="ETCD_HEARTBEAT_INTERVAL=400"
-      Environment="ETCD_HOST_DATA_DIR=/var/lib/etcd2"
-      Environment="ETCD_NAME=%m"
-      Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
-      ExecStartPre=/bin/sh -c "docker history $ETCD_IMAGE >/dev/null 2>&1 || docker pull $ETCD_IMAGE"
-      ExecStartPre=/bin/sh -c "docker inspect $ETCD_NAME >/dev/null 2>&1 && docker rm -f $ETCD_NAME || true"
-      ExecStart=/usr/bin/docker run --net=host --rm \
-        --volume=${ETCD_HOST_DATA_DIR}:/var/lib/etcd2 \
-        --volume=/usr/share/ca-certificates:/etc/ssl/certs:ro \
-        -p 4001:4001 -p 2380:2380 -p 2379:2379 -p 7001:7001 \
-        --name ${ETCD_NAME} \
-        ${ETCD_IMAGE} \
-        -name ${ETCD_NAME} \
-        -data-dir /var/lib/etcd2 \
-        -advertise-client-urls http://${COREOS_PRIVATE_IPV4}:2379,http://${COREOS_PRIVATE_IPV4}:4001 \
-        -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
-        -initial-advertise-peer-urls http://${COREOS_PRIVATE_IPV4}:2380,http://${COREOS_PRIVATE_IPV4}:7001 \
-        -listen-peer-urls http://0.0.0.0:2380,http://0.0.0.0:7001 \
-        --heartbeat-interval ${ETCD_HEARTBEAT_INTERVAL} \
-        --election-timeout ${ETCD_ELECTION_TIMEOUT} \
-        --discovery #DISCOVERY_URL
-      ExecStop=-/usr/bin/docker stop $ETCD_NAME
-  - name: etcd2.service
-    mask: true
-  - name: docker-tcp.socket
-    command: start
-    enable: true
-    content: |
-      [Unit]
-      Description=Docker Socket for the API
+        [Socket]
+        ListenStream=2375
+        Service=docker.service
+        BindIPv6Only=both
 
-      [Socket]
-      ListenStream=2375
-      BindIPv6Only=both
-      Service=docker.service
-      [Install]
-      WantedBy=sockets.target
-  - name: flanneld.service
-    command: start
-    content: |
-      [Unit]
-      Description=Network fabric for containers
-      Documentation=https://github.com/coreos/flannel
-      Requires=early-docker.service etcd.service
-      After=etcd.service early-docker.service
-      Before=early-docker.target
+        [Install]
+        WantedBy=sockets.target
+    - name: update-engine.service
+      command: stop
+      enable: false
+    - name: docker.service
+      drop-ins:
+      - name: 50-insecure-registry.conf
+        content: |
+          [Service]
+          Environment="DOCKER_OPTS=--insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 --insecure-registry 100.64.0.0/10"
+    - name: flanneld.service
+      drop-ins:
+      - name: 50-network-config.conf
+        content: |
+          [Service]
+          ExecStartPre=/usr/bin/etcdctl mk /coreos.com/network/config '{"Network": "10.244.0.0/16", "SubnetLen": 24, "SubnetMin": "10.244.0.0", "Backend": {"Type": "vxlan"}}'
+    - name: graceful-deis-shutdown.service
+      content: |
+        [Unit]
+        Description=Clean up
+        DefaultDependencies=no
+        After=fleet.service etcd2.service docker.service docker.socket deis-store-admin.service deis-store-daemon.service deis-store-volume.service deis-store-monitor.service
+        Requires=fleet.service etcd2.service deis-store-admin.service deis-store-daemon.service deis-store-volume.service docker.service docker.socket deis-store-monitor.service
 
-      [Service]
-      Type=notify
-      Restart=always
-      RestartSec=5
-      Environment="TMPDIR=/var/tmp/"
-      Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
-      Environment="FLANNEL_VER=0.5.1"
-      LimitNOFILE=40000
-      LimitNPROC=1048576
-      ExecStartPre=/sbin/modprobe ip_tables
-      ExecStartPre=/usr/bin/mkdir -p /run/flannel
-      ExecStartPre=/usr/bin/touch /run/flannel/options.env
-      ExecStartPre=-/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"10.244.0.0/16", "SubnetLen": 24, "SubnetMin":"10.244.0.0", "Backend": {"Type": "vxlan"}}'
-      ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
-        /usr/bin/docker run --net=host --privileged=true --rm \
-        --volume=/run/flannel:/run/flannel \
-        --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
-        --env-file=/run/flannel/options.env \
-        --volume=/usr/share/ca-certificates:/etc/ssl/certs:ro \
-        quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true
+        [Install]
+        WantedBy=shutdown.target halt.target reboot.target
 
-      # Update docker options
-      ExecStartPost=/usr/bin/docker run --net=host --rm -v /run:/run \
-        quay.io/coreos/flannel:${FLANNEL_VER} \
-        /opt/bin/mk-docker-opts.sh -d /run/flannel_docker_opts.env -i
-  - name: stop-update-engine.service
-    command: start
-    content: |
-      [Unit]
-      Description=stop update-engine
+        [Service]
+        ExecStop=/opt/bin/graceful-shutdown.sh --really
+        Type=oneshot
+        TimeoutSec=1200
+        RemainAfterExit=yes
+    - name: install-deisctl.service
+      command: start
+      content: |
+        [Unit]
+        Description=Install deisctl utility
+        ConditionPathExists=!/opt/bin/deisctl
 
-      [Service]
-      Type=oneshot
-      ExecStart=/usr/bin/systemctl stop update-engine.service
-      ExecStartPost=/usr/bin/systemctl mask update-engine.service
-  - name: graceful-deis-shutdown.service
-    content: |
-      [Unit]
-      Description=Clean up
-      DefaultDependencies=no
-      After=fleet.service etcd.service docker.service docker.socket deis-store-admin.service deis-store-daemon.service deis-store-volume.service deis-store-monitor.service
-      Requires=fleet.service etcd.service deis-store-admin.service deis-store-daemon.service deis-store-volume.service docker.service docker.socket deis-store-monitor.service
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/sh -c 'curl -sSL --retry 5 --retry-delay 2 http://deis.io/deisctl/install.sh | sh -s 1.10.0'
+    - name: debug-etcd.service
+      content: |
+        [Unit]
+        Description=etcd debugging service
 
-      [Install]
-      WantedBy=shutdown.target halt.target reboot.target
+        [Service]
+        ExecStartPre=/usr/bin/curl -sSL -o /opt/bin/jq http://stedolan.github.io/jq/download/linux64/jq
+        ExecStartPre=/usr/bin/chmod +x /opt/bin/jq
+        ExecStart=/usr/bin/bash -c "while true; do curl -sL http://127.0.0.1:4001/v2/stats/self | /opt/bin/jq . ; sleep 1 ; done"
+    - name: increase-nf_conntrack-connections.service
+      command: start
+      content: |
+        [Unit]
+        Description=Increase the number of connections in nf_conntrack. default is 65536
 
-      [Service]
-      ExecStop=/opt/bin/graceful-shutdown.sh --really
-      Type=oneshot
-      TimeoutSec=1200
-      RemainAfterExit=yes
-  - name: install-deisctl.service
-    command: start
-    content: |
-      [Unit]
-      Description=Install deisctl utility
-      ConditionPathExists=!/opt/bin/deisctl
-
-      [Service]
-      Type=oneshot
-      ExecStart=/usr/bin/sh -c 'curl -sSL --retry 5 --retry-delay 2 http://deis.io/deisctl/install.sh | sh -s 1.10.0'
-  - name: debug-etcd.service
-    content: |
-      [Unit]
-      Description=etcd debugging service
-
-      [Service]
-      ExecStartPre=/usr/bin/curl -sSL -o /opt/bin/jq http://stedolan.github.io/jq/download/linux64/jq
-      ExecStartPre=/usr/bin/chmod +x /opt/bin/jq
-      ExecStart=/usr/bin/bash -c "while true; do curl -sL http://127.0.0.1:4001/v2/stats/self | /opt/bin/jq . ; sleep 1 ; done"
-  - name: increase-nf_conntrack-connections.service
-    command: start
-    content: |
-      [Unit]
-      Description=Increase the number of connections in nf_conntrack. default is 65536
-
-      [Service]
-      Type=oneshot
-      ExecStartPre=/usr/sbin/modprobe nf_conntrack
-      ExecStart=/bin/sh -c "sysctl -w net.netfilter.nf_conntrack_max=262144"
-  - name: fleet.service
-    command: start
+        [Service]
+        Type=oneshot
+        ExecStartPre=/usr/sbin/modprobe nf_conntrack
+        ExecStart=/bin/sh -c "sysctl -w net.netfilter.nf_conntrack_max=262144"
 write_files:
   - path: /etc/deis-release
     content: |
@@ -168,15 +108,6 @@ write_files:
       function nse() {
         docker exec -it $1 bash
       }
-  - path: /etc/systemd/system/docker.service.d/50-insecure-registry.conf
-    content: |
-      [Unit]
-      Requires=flanneld.service
-      After=flanneld.service
-
-      [Service]
-      EnvironmentFile=/etc/environment_proxy
-      Environment="DOCKER_OPTS=--insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 --insecure-registry 100.64.0.0/10"
   - path: /run/deis/bin/get_image
     permissions: '0755'
     content: |
@@ -219,7 +150,7 @@ write_files:
       echo $PRETTY_NAME
       source /etc/deis-release
       echo "Deis $DEIS_RELEASE"
-      etcd -version
+      etcd2 -version | head -n1
       fleet -version
       printf "\n"
 
@@ -269,22 +200,22 @@ write_files:
       fi
       set -e -x -o pipefail
       # determine osd id
-      CURRENT_STATUS=$(/usr/bin/docker exec deis-store-admin ceph health | awk '{print $1}')
-      OSD_HOSTS=($(/usr/bin/etcdctl ls /deis/store/hosts/| awk -F'/' '{print $5}'))
+      CURRENT_STATUS=$(docker exec deis-store-admin ceph health | awk '{print $1}')
+      OSD_HOSTS=($(etcdctl ls /deis/store/hosts/| awk -F'/' '{print $5}'))
       for HOST in "${OSD_HOSTS[@]}"
       do
         PUBLIC_IP=$(fleetctl list-machines -fields="machine,ip" -full -no-legend| grep `cat /etc/machine-id` | awk '{print $2}')
         if [ "$HOST" = "$PUBLIC_IP" ] ; then
-          OSD_ID=$(/usr/bin/etcdctl get /deis/store/osds/$PUBLIC_IP)
+          OSD_ID=$(etcdctl get /deis/store/osds/$PUBLIC_IP)
           break
         fi
       done
       # if we own an osd and its healthy, try to gracefully remove it
       if [ ! -z "$OSD_ID" ] && [[ "$CURRENT_STATUS" == *"HEALTH_OK"* ]] && [ ${#OSD_HOSTS[@]} -gt "3" ]; then
-        /usr/bin/docker exec deis-store-admin ceph osd out $OSD_ID
+        docker exec deis-store-admin ceph osd out $OSD_ID
         sleep 30
         TIMEWAITED=0
-        until [[ $(/usr/bin/docker exec deis-store-admin ceph health) == *"HEALTH_OK"* ]]
+        until [[ $(docker exec deis-store-admin ceph health) == *"HEALTH_OK"* ]]
         do
           if [ $TIMEWAITED -gt "1200" ]
           then
@@ -294,29 +225,21 @@ write_files:
           echo "waiting" && sleep 5
           TIMEWAITED=$((TIMEWAITED+5))
         done
-        /usr/bin/docker stop deis-store-daemon
-        /usr/bin/docker exec deis-store-admin ceph osd crush remove osd.$OSD_ID
-        /usr/bin/docker exec deis-store-admin ceph auth del osd.$OSD_ID
-        /usr/bin/docker exec deis-store-admin ceph osd rm $OSD_ID
-        /usr/bin/etcdctl rm /deis/store/osds/$PUBLIC_IP
+        docker stop deis-store-daemon
+        docker exec deis-store-admin ceph osd crush remove osd.$OSD_ID
+        docker exec deis-store-admin ceph auth del osd.$OSD_ID
+        docker exec deis-store-admin ceph osd rm $OSD_ID
+        etcdctl rm /deis/store/osds/$PUBLIC_IP
         etcdctl rm /deis/store/hosts/$PUBLIC_IP && sleep 10
         # remove ceph mon
-        /usr/bin/docker stop deis-store-monitor || true
-        /usr/bin/docker exec deis-store-admin ceph mon remove `hostname -f` # fixme
-        /usr/bin/docker stop deis-store-metadata || true
+        docker stop deis-store-monitor || true
+        docker exec deis-store-admin ceph mon remove `hostname -f` # fixme
+        docker stop deis-store-metadata || true
       fi
 
-      # TODO: remove the next check once etcdctl is using etcd2
-      ETCDCTL=/usr/bin/etcdctl
-      if ! $ETCDCTL --version | grep -q "etcdctl version 2.0."; then
-        ETCD_VERSION=2.0.13
-        curl -sSL https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz | \
-          tar zxv -C /opt/bin etcd-v${ETCD_VERSION}-linux-amd64/etcdctl --strip=1
-        ETCDCTL="/opt/bin/etcdctl"
-      fi
       # removing the node from etcd
-      NODE=$($ETCDCTL member list | grep `cat /etc/machine-id` | cut -d ':' -f 1)
-      $ETCDCTL member remove $NODE
+      NODE=$(etcdctl member list | grep `cat /etc/machine-id` | cut -d ':' -f 1)
+      etcdctl member remove $NODE
   - path: /opt/bin/wupiao
     permissions: '0755'
     content: |

--- a/deisctl/units/deis-logspout.service
+++ b/deisctl/units/deis-logspout.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=deis-logspout
-Requires=docker.socket etcd.service
-After=docker.socket etcd.service
+Requires=docker.socket
+Wants=etcd2.service
+After=docker.socket etcd2.service etcd.service
 
 [Service]
 EnvironmentFile=/etc/environment

--- a/deisctl/units/deis-publisher.service
+++ b/deisctl/units/deis-publisher.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=deis-publisher
-Requires=docker.socket etcd.service
-After=docker.socket etcd.service
+Requires=docker.socket
+Wants=etcd2.service
+After=docker.socket etcd2.service etcd.service
 
 [Service]
 EnvironmentFile=/etc/environment

--- a/docs/managing_deis/isolating-etcd.rst
+++ b/docs/managing_deis/isolating-etcd.rst
@@ -34,25 +34,12 @@ the ``-proxy on`` flag. For example:
 .. code-block:: yaml
 
     #cloud-config
-    ---
+
     coreos:
-      # ...
-      - name: etcd.service
-        command: start
-        content: |
-          # ...
-          [Service]
-          # ...
-          ExecStart=/usr/bin/docker run --net=host --rm \
-            # ...
-            -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
-            # ...
-            --discovery <discovery url here> \
-            -proxy on
-          # ...
+      etcd2:
+        discovery: <discovery URL here>
+        proxy: on
         # ...
-      # ...
-    # ...
 
 Isolating etcd as described here requires subsets of a cluster's hosts to be
 configured differently from one another (including or excluding the


### PR DESCRIPTION
This refactors and hopefully simplifies the thorny cloud-config Deis has in user-data.example. It uses the native CoreOS flanneld.service and etcd2.service--currently v2.1.2, same as Deis v1.10--and minimizes the differences with a [stock CoreOS user-data](https://github.com/coreos/coreos-vagrant/blob/master/user-data.sample). Also removes `etcd` timing tweaks which seemed to be unneeded based on my testing for v1.10--see #4384.

Also moves Docker `--insecure-registry` config into a unit drop-in and removes the cruft from the graceful-shutdown script. I've tested this against vagrant with Deis v1.10, Deis master, and Deis v1.8 upgraded to v1.10 + this PR. Also tested k8s, v1.9.1 upgrade, and the graceful-shutdown.sh script.

Closes #4384.
Closes #4409.