### PR TITLE
docs(quickstart): added install deisctl step at top of quick start docs

### DIFF
--- a/docs/_includes/_get-the-source.rst
+++ b/docs/_includes/_get-the-source.rst
@@ -18,6 +18,8 @@ clone the source code into your `$GOPATH`_:
     $ go get -u -v github.com/deis/deis
     $ cd $GOPATH/src/github.com/deis/deis
 
+Additionally, you'll need the ``deisctl`` CLI tool. If you don't already have it,
+install instructions are :ref:`here <install_deisctl>`.
 
 .. _`source code`: https://github.com/deis/deis
 .. _`releases page`: https://github.com/deis/deis/releases

--- a/docs/installing_deis/quick-start.rst
+++ b/docs/installing_deis/quick-start.rst
@@ -64,7 +64,7 @@ Install Deis Platform
 ---------------------
 
 Now that you've finished provisioning a CoreOS cluster,
-please refer to :ref:`install_deisctl` and :ref:`install_deis_platform`.
+please :ref:`install_deis_platform`.
 
 
 .. _`CoreOS`: https://coreos.com/


### PR DESCRIPTION
I went through the Quick Start steps (AWS path) and because I hadn’t yet installed deisctl the provision script barfed. I noticed that the "install deisctl" is listed at the bottom of the Quick Start docs, suggesting that it's something you do after a successful Quick Start install. It makes more sense to instead make a deisctl install a sort of prereq step at the top of the Quick Start doc.