### PR TITLE
fix(controller): state property can't be used in a list_filter in the Django web admin

### DIFF
--- a/controller/api/admin.py
+++ b/controller/api/admin.py
@@ -54,7 +54,7 @@ class ContainerAdmin(admin.ModelAdmin):
     """
     date_hierarchy = 'created'
     list_display = ('short_name', 'owner', 'app', 'state')
-    list_filter = ('owner', 'app', 'state')
+    list_filter = ('owner', 'app')
 admin.site.register(Container, ContainerAdmin)
 
 


### PR DESCRIPTION
[`Container.state`](https://github.com/deis/deis/blob/master/controller/api/models.py#L579) isn't a concrete model field therefore can't be used in an admin `list_filter`.  The desired functionality would have to be implemented via a custom `django.contrib.admin.SimpleListFilter`, but it's unclear to me how to efficiently query the scheduler for all containers in a given state.

Currently trying to browse to `/admin/` raises `ImproperlyConfigured` with the following error:

`'ContainerAdmin.list_filter[2]' refers to 'state' which does not refer to a Field.`