### PR TITLE
(docs)aws: replace "ssh-agent add" with "ssh-add"

### DIFF
--- a/docs/installing_deis/aws.rst
+++ b/docs/installing_deis/aws.rst
@@ -59,7 +59,7 @@ During installation, ``deisctl`` will make an SSH connection to the cluster.
 It will need to be able to use this key to connect.
 
 Most users use SSH agent (``ssh-agent``). If this is the case, run
-``ssh-agent add ~/.ssh/deis`` to add the key. Otherwise, you may prefer to
+``ssh-add ~/.ssh/deis`` to add the key. Otherwise, you may prefer to
 modify ``~/.ssh/config`` to add the key to the IPs in AWS.
 
 Choose Number of Instances


### PR DESCRIPTION
Two reasons for this:

- More likely than not, a modern OS will have a separate ssh-add utility installed (and some, e.g., Mac OS X, does not have an "add" option as a a part of the installed ssh-agent binary.
- "ssh-add" is referenced in several other places in the docs, while "ssh-agent add" is only referenced in this one place. We should aim for consistency, and "ssh-add" seems to have momentum on its side.