### PR TITLE
fix(contrib/coreos): mask etcd.service

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -18,6 +18,8 @@ coreos:
   update:
     reboot-strategy: "off"
   units:
+    - name: etcd.service
+      mask: true
     - name: etcd2.service
       command: start
     - name: fleet.service


### PR DESCRIPTION
We need to mask etcd.service to prevent in from starting in place
of etcd2.service

closes #4490

I'd like @sgoings to test this on whatever provider he was seeing it on in #4490.