### PR TITLE
Fix awk field separator not working on non-GNU awk

### DIFF
--- a/contrib/openstack/provision-openstack-cluster.sh
+++ b/contrib/openstack/provision-openstack-cluster.sh
@@ -45,7 +45,7 @@ if [ -z "$OS_AUTH_URL" ]; then
 fi
 
 if neutron net-list|grep -q $DEIS_NETWORK &>/dev/null; then
-  NETWORK_ID=$(neutron net-list | grep $DEIS_NETWORK | awk -F'| ' '{print $2}')
+  NETWORK_ID=$(neutron net-list | grep $DEIS_NETWORK | awk -F'|' '{gsub(/ /, "", $0); print $2}')
 else
   echo_yellow "Creating deis private network..."
   CIDR=${DEIS_CIDR:-10.21.12.0/24}


### PR DESCRIPTION
This changes the way awk is used to separate fields so that it works on non-GNU awk.

This changes the field separator from '| ' to '|' and use gsub to strip whitespace.

The actual code, when used on OSX to provision deis on openstack result in the following error:
```
awk: illegal primary in regular expression |  at
 input record number 1, file
 source line number 1
```

The change was tested on OS X and CentOS 6. The risk of it breaking critical stuff is very low IMO.

(first PR so I've tried to follow the contribution guidelines to the best of my understanding. please let me know if there's anything that should be changed)