### PR TITLE
fix(contrib): urlopen call hangs

### DIFF
--- a/contrib/aws/gen-json.py
+++ b/contrib/aws/gen-json.py
@@ -2,7 +2,7 @@
 import argparse
 import json
 import os
-import urllib
+import urllib2
 import yaml
 
 parser = argparse.ArgumentParser()
@@ -12,7 +12,7 @@ args = vars(parser.parse_args())
 
 url = "http://{channel}.release.core-os.net/amd64-usr/{version}/coreos_production_ami_all.json".format(**args)
 try:
-    amis = json.load(urllib.urlopen(url))
+    amis = json.load(urllib2.urlopen(url))
 except (IOError, ValueError):
     print "The URL {} is invalid.".format(url)
     raise


### PR DESCRIPTION
The `urllib.urlopen(url)` call consistently hangs while `wget` and
`curl` succeed to the same URL for retrieving the AMIs. Tested use
of `urllib2` on Ubuntu Trusty (py 2.7.6) and CentOS 7 (py 2.7.5).