### PR TITLE
fix(client): accept multi line config vars.

### DIFF
--- a/client/cmd/config.go
+++ b/client/cmd/config.go
@@ -216,7 +216,7 @@ func ConfigPush(appID string, fileName string) error {
 func parseConfig(configVars []string) map[string]interface{} {
 	configMap := make(map[string]interface{})
 
-	regex := regexp.MustCompile("^([A-z_]+[A-z0-9_]*)=(.+)$")
+	regex := regexp.MustCompile(`^([A-z_]+[A-z0-9_]*)=([\s\S]+)$`)
 	for _, config := range configVars {
 		if regex.MatchString(config) {
 			captures := regex.FindStringSubmatch(config)

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -11,10 +11,12 @@ import (
 )
 
 var (
-	configListCmd         = "config:list --app={{.AppName}}"
-	configSetCmd          = "config:set FOO=讲台 --app={{.AppName}}"
-	configSet2Cmd         = "config:set FOO=10 --app={{.AppName}}"
-	configSet3Cmd         = "config:set POWERED_BY=\"the Deis team\" --app={{.AppName}}"
+	configListCmd = "config:list --app={{.AppName}}"
+	configSetCmd  = "config:set FOO=讲台 --app={{.AppName}}"
+	configSet2Cmd = "config:set FOO=10 --app={{.AppName}}"
+	configSet3Cmd = "config:set POWERED_BY=\"the Deis team\" --app={{.AppName}}"
+	configSet4Cmd = `config:set FOO="This is a
+multiline string" --app={{.AppName}}`
 	configSetBuildpackCmd = "config:set BUILDPACK_URL=$BUILDPACK_URL --app={{.AppName}}"
 	configUnsetCmd        = "config:unset FOO --app={{.AppName}}"
 )
@@ -90,6 +92,8 @@ func configSetTest(t *testing.T, params *utils.DeisTestConfig) {
 	utils.CheckList(t, appsInfoCmd, params, "(v5)", false)
 	utils.Execute(t, configSet2Cmd, params, false, "10")
 	utils.CheckList(t, appsInfoCmd, params, "(v6)", false)
+	utils.Execute(t, configSet4Cmd, params, false, "")
+	utils.CheckList(t, appsInfoCmd, params, "(v7)", false)
 }
 
 func configPushTest(t *testing.T, params *utils.DeisTestConfig) {
@@ -101,7 +105,7 @@ func configPushTest(t *testing.T, params *utils.DeisTestConfig) {
 		t.Fatal(err)
 	}
 	utils.Execute(t, "config:push --app {{.AppName}}", params, false, "Deis")
-	utils.CheckList(t, appsInfoCmd, params, "(v7)", false)
+	utils.CheckList(t, appsInfoCmd, params, "(v8)", false)
 	if err := utils.Chdir(".."); err != nil {
 		t.Fatal(err)
 	}
@@ -109,6 +113,6 @@ func configPushTest(t *testing.T, params *utils.DeisTestConfig) {
 
 func configUnsetTest(t *testing.T, params *utils.DeisTestConfig) {
 	utils.Execute(t, configUnsetCmd, params, false, "")
-	utils.CheckList(t, appsInfoCmd, params, "(v8)", false)
+	utils.CheckList(t, appsInfoCmd, params, "(v9)", false)
 	utils.CheckList(t, "run env --app={{.AppName}}", params, "FOO", true)
 }


### PR DESCRIPTION
The client will now accept multi line configuration variables with `config:set`. Note: this will not work with `config:push` as it uses newlines as a config variable separator.

What now works is: 
```
config:set TEST="MULTI
LINE VAR"`
```

ref #4512