### PR TITLE
feat(logger): add https as a logger drain type

### DIFF
--- a/docs/managing_deis/platform_logging.rst
+++ b/docs/managing_deis/platform_logging.rst
@@ -27,6 +27,9 @@ Application logs can be drained to an external syslog server (or compatible serv
 
 This will send all application logs - there is currently no way to drain logs per application.
 
+Log drain endpoints must be prefixed with a protocol. The currently supported
+protocols are ``syslog`` and ``https``.
+
 Routing host logs to a custom location
 --------------------------------------
 

--- a/logger/drain/drain.go
+++ b/logger/drain/drain.go
@@ -1,11 +1,14 @@
 package drain
 
 import (
+	"crypto/tls"
 	"fmt"
 	"log"
 	"net"
 	"net/url"
+	"net/http"
 	"os"
+	"strings"
 )
 
 func SendToDrain(m string, drain string) error {
@@ -17,10 +20,28 @@ func SendToDrain(m string, drain string) error {
 	switch u.Scheme {
 	case "syslog":
 		sendToSyslogDrain(m, uri)
+	case "https":
+		sendToHttpsDrain(m, uri)
 	default:
 		log.Println(u.Scheme + " drain type is not implemented.")
 	}
 	return nil
+}
+
+func sendToHttpsDrain(m string, drain string) error {
+	buf := strings.NewReader(m)
+
+	tr := &http.Transport{
+  	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+  }
+
+  client := &http.Client{Transport: tr}
+
+	// Skip logging error here since any log line we write will be cycled
+	// infinitely through the drain if there is an ongoing error
+  resp, err := client.Post(("https://" + drain), "text/plain", buf)
+	resp.Body.Close()
+	return err
 }
 
 func sendToSyslogDrain(m string, drain string) error {

--- a/logger/syslogd/syslogd.go
+++ b/logger/syslogd/syslogd.go
@@ -30,7 +30,7 @@ func filter(m syslog.SyslogMessage) bool {
 
 func newHandler() *handler {
 	h := handler{
-		BaseHandler: syslog.NewBaseHandler(5, filter, false),
+		BaseHandler: syslog.NewBaseHandler(100, filter, false),
 	}
 
 	go h.mainLoop() // BaseHandler needs some goroutine that reads from its queue


### PR DESCRIPTION
Not all log aggregation providers provide a hosted syslog-based
collector. Having a log drain that can use https is therefore desirable.

Closes #4527