### PR TITLE
ref(docs): remove old py client requirements

### DIFF
--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -18,19 +18,6 @@ python-etcd==0.3.2
 PyYAML==3.11
 South==1.0.2
 
-# Deis client requirements, copied from client/requirements.txt
-cryptography==0.8.2
-docopt==0.6.2
-ndg-httpsclient==0.3.3
-pyasn1==0.1.7
-pyOpenSSL==0.15.1
-python-dateutil==2.4.2
-#PyYAML==3.11
-requests==2.5.1
-tabulate==0.7.4
-termcolor==1.1.0
-urllib3==1.10.2
-
 # Deis documentation requirements
 Sphinx==1.3.1
 smartypants==1.8.6


### PR DESCRIPTION
Missed a spot when #4341 was merged: these packages are no longer needed to build the Sphinx docs.