### PR TITLE
ref(controller): remove REGISTRY_MODULE hack

### DIFF
--- a/controller/Makefile
+++ b/controller/Makefile
@@ -74,7 +74,7 @@ setup-venv:
 	venv/bin/pip install --disable-pip-version-check -q -r requirements.txt -r dev_requirements.txt
 
 test-style: setup-venv
-	venv/bin/flake8
+	venv/bin/flake8 --show-pep8 --show-source
 	shellcheck $(SHELL_SCRIPTS)
 
 test-unit: setup-venv test-style

--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -867,8 +867,7 @@ class Release(UuidAuditedModel):
         source_tag = 'git-{}'.format(self.build.sha) if self.build.sha else source_version
         source_image = '{}:{}'.format(self.build.image, source_tag)
         # IOW, this image did not come from the builder
-        # FIXME: remove check for mock registry module
-        if not self.build.sha and 'mock' not in settings.REGISTRY_MODULE:
+        if not self.build.sha:
             # we assume that the image is not present on our registry,
             # so shell out a task to pull in the repository
             data = {

--- a/controller/api/tests/__init__.py
+++ b/controller/api/tests/__init__.py
@@ -6,6 +6,7 @@ import os
 from django.conf import settings
 from django.test.client import RequestFactory, Client
 from django.test.simple import DjangoTestSuiteRunner
+import requests
 
 
 # add patch support to built-in django test client
@@ -46,18 +47,25 @@ class SilentDjangoTestSuiteRunner(DjangoTestSuiteRunner):
             test_labels, extra_tests, **kwargs)
 
 
+def mock_status_ok(*args, **kwargs):
+    resp = requests.Response()
+    resp.status_code = 200
+    resp._content_consumed = True
+    return resp
+
+
 from .test_api_middleware import *  # noqa
 from .test_app import *  # noqa
 from .test_auth import *  # noqa
 from .test_build import *  # noqa
-from .test_config import *  # noqa
-from .test_domain import *  # noqa
 from .test_certificate import *  # noqa
+from .test_config import *  # noqa
 from .test_container import *  # noqa
+from .test_domain import *  # noqa
 from .test_hooks import *  # noqa
 from .test_key import *  # noqa
+from .test_limits import *  # noqa
 from .test_perm import *  # noqa
 from .test_release import *  # noqa
 from .test_scheduler import *  # noqa
 from .test_users import *  # noqa
-from .test_limits import *  # noqa

--- a/controller/api/tests/test_app.py
+++ b/controller/api/tests/test_app.py
@@ -10,7 +10,6 @@ import json
 import logging
 import mock
 import os.path
-import requests
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -18,13 +17,7 @@ from django.test import TestCase
 from rest_framework.authtoken.models import Token
 
 from api.models import App
-
-
-def mock_import_repository_task(*args, **kwargs):
-    resp = requests.Response()
-    resp.status_code = 200
-    resp._content_consumed = True
-    return resp
+from . import mock_status_ok
 
 
 class AppTest(TestCase):
@@ -198,7 +191,7 @@ class AppTest(TestCase):
         self.assertIn('structure', response.data)
         self.assertEqual(response.data['structure'], {"web": 1})
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     @mock.patch('api.models.logger')
     def test_admin_can_manage_other_apps(self, mock_logger):
         """Administrators of Deis should be able to manage all applications.

--- a/controller/api/tests/test_build.py
+++ b/controller/api/tests/test_build.py
@@ -7,11 +7,11 @@ Run the tests with "./manage.py test api"
 from __future__ import unicode_literals
 
 import json
-import mock
 import requests
 
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
+import mock
 from rest_framework.authtoken.models import Token
 
 from api.models import Build
@@ -24,6 +24,7 @@ def mock_import_repository_task(*args, **kwargs):
     return resp
 
 
+@mock.patch('api.models.publish_release', lambda *args: None)
 class BuildTest(TransactionTestCase):
 
     """Tests build notification from build system"""

--- a/controller/api/tests/test_build.py
+++ b/controller/api/tests/test_build.py
@@ -7,7 +7,6 @@ Run the tests with "./manage.py test api"
 from __future__ import unicode_literals
 
 import json
-import requests
 
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
@@ -15,13 +14,7 @@ import mock
 from rest_framework.authtoken.models import Token
 
 from api.models import Build
-
-
-def mock_import_repository_task(*args, **kwargs):
-    resp = requests.Response()
-    resp.status_code = 200
-    resp._content_consumed = True
-    return resp
+from . import mock_status_ok
 
 
 @mock.patch('api.models.publish_release', lambda *args: None)
@@ -35,7 +28,7 @@ class BuildTest(TransactionTestCase):
         self.user = User.objects.get(username='autotest')
         self.token = Token.objects.get(user=self.user).key
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_build(self):
         """
         Test that a null build is created and that users can post new builds
@@ -83,7 +76,7 @@ class BuildTest(TransactionTestCase):
         response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 405)
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_response_data(self):
         """Test that the serialized response contains only relevant data."""
         body = {'id': 'test'}
@@ -109,7 +102,7 @@ class BuildTest(TransactionTestCase):
         }
         self.assertDictContainsSubset(expected, response.data)
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_build_default_containers(self):
         url = '/v1/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -195,7 +188,7 @@ class BuildTest(TransactionTestCase):
         self.assertEqual(container['type'], 'web')
         self.assertEqual(container['num'], 1)
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_build_str(self):
         """Test the text representation of a build."""
         url = '/v1/apps'
@@ -212,7 +205,7 @@ class BuildTest(TransactionTestCase):
         self.assertEqual(str(build), "{}-{}".format(
                          response.data['app'], response.data['uuid'][:7]))
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_admin_can_create_builds_on_other_apps(self):
         """If a user creates an application, an administrator should be able
         to push builds.
@@ -234,7 +227,7 @@ class BuildTest(TransactionTestCase):
         self.assertEqual(str(build), "{}-{}".format(
                          response.data['app'], response.data['uuid'][:7]))
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_unauthorized_user_cannot_modify_build(self):
         """
         An unauthorized user should not be able to modify other builds.
@@ -255,7 +248,7 @@ class BuildTest(TransactionTestCase):
                                     HTTP_AUTHORIZATION='token {}'.format(unauthorized_token))
         self.assertEqual(response.status_code, 403)
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_new_build_does_not_scale_up_automatically(self):
         """
         After the first initial deploy, if the containers are scaled down to zero,

--- a/controller/api/tests/test_config.py
+++ b/controller/api/tests/test_config.py
@@ -9,12 +9,12 @@ from __future__ import unicode_literals
 
 import json
 import logging
-import mock
 import requests
 
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
 import etcd
+import mock
 from rest_framework.authtoken.models import Token
 
 import api.exceptions
@@ -52,6 +52,7 @@ class MockEtcdClient:
         return etcd.EtcdResult(None, node)
 
 
+@mock.patch('api.models.publish_release', lambda *args: None)
 class ConfigTest(TransactionTestCase):
 
     """Tests setting and updating config values"""

--- a/controller/api/tests/test_config.py
+++ b/controller/api/tests/test_config.py
@@ -19,13 +19,7 @@ from rest_framework.authtoken.models import Token
 
 import api.exceptions
 from api.models import App, Config
-
-
-def mock_status_ok(*args, **kwargs):
-    resp = requests.Response()
-    resp.status_code = 200
-    resp._content_consumed = True
-    return resp
+from . import mock_status_ok
 
 
 def mock_status_not_found(*args, **kwargs):

--- a/controller/api/tests/test_container.py
+++ b/controller/api/tests/test_container.py
@@ -7,15 +7,15 @@ Run the tests with "./manage.py test api"
 from __future__ import unicode_literals
 
 import json
-import mock
 import requests
 
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
-from scheduler.states import TransitionError
+import mock
 from rest_framework.authtoken.models import Token
 
 from api.models import App, Build, Container, Release
+from scheduler.states import TransitionError
 
 
 def mock_import_repository_task(*args, **kwargs):
@@ -25,6 +25,7 @@ def mock_import_repository_task(*args, **kwargs):
     return resp
 
 
+@mock.patch('api.models.publish_release', lambda *args: None)
 class ContainerTest(TransactionTestCase):
     """Tests creation of containers on nodes"""
 

--- a/controller/api/tests/test_container.py
+++ b/controller/api/tests/test_container.py
@@ -7,7 +7,6 @@ Run the tests with "./manage.py test api"
 from __future__ import unicode_literals
 
 import json
-import requests
 
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
@@ -16,13 +15,7 @@ from rest_framework.authtoken.models import Token
 
 from api.models import App, Build, Container, Release
 from scheduler.states import TransitionError
-
-
-def mock_import_repository_task(*args, **kwargs):
-    resp = requests.Response()
-    resp.status_code = 200
-    resp._content_consumed = True
-    return resp
+from . import mock_status_ok
 
 
 @mock.patch('api.models.publish_release', lambda *args: None)
@@ -171,7 +164,7 @@ class ContainerTest(TransactionTestCase):
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_container_api_docker(self):
         url = '/v1/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -234,7 +227,7 @@ class ContainerTest(TransactionTestCase):
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_container_release(self):
         url = '/v1/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))

--- a/controller/api/tests/test_hooks.py
+++ b/controller/api/tests/test_hooks.py
@@ -7,7 +7,6 @@ Run the tests with "./manage.py test api"
 from __future__ import unicode_literals
 
 import json
-import requests
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -15,12 +14,7 @@ from django.test import TransactionTestCase
 import mock
 from rest_framework.authtoken.models import Token
 
-
-def mock_import_repository_task(*args, **kwargs):
-    resp = requests.Response()
-    resp.status_code = 200
-    resp._content_consumed = True
-    return resp
+from . import mock_status_ok
 
 
 @mock.patch('api.models.publish_release', lambda *args: None)
@@ -98,7 +92,7 @@ class HookTest(TransactionTestCase):
                                     HTTP_X_DEIS_BUILDER_AUTH=settings.BUILDER_KEY)
         self.assertEqual(response.status_code, 403)
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_build_hook(self):
         """Test creating a Build via an API Hook"""
         url = '/v1/apps'

--- a/controller/api/tests/test_hooks.py
+++ b/controller/api/tests/test_hooks.py
@@ -7,12 +7,12 @@ Run the tests with "./manage.py test api"
 from __future__ import unicode_literals
 
 import json
-import mock
 import requests
 
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
+import mock
 from rest_framework.authtoken.models import Token
 
 
@@ -23,6 +23,7 @@ def mock_import_repository_task(*args, **kwargs):
     return resp
 
 
+@mock.patch('api.models.publish_release', lambda *args: None)
 class HookTest(TransactionTestCase):
 
     """Tests API hooks used to trigger actions from external components"""

--- a/controller/api/tests/test_release.py
+++ b/controller/api/tests/test_release.py
@@ -7,11 +7,11 @@ Run the tests with "./manage.py test api"
 from __future__ import unicode_literals
 
 import json
-import mock
 import requests
 
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
+import mock
 from rest_framework.authtoken.models import Token
 
 from api.models import Release
@@ -24,6 +24,7 @@ def mock_import_repository_task(*args, **kwargs):
     return resp
 
 
+@mock.patch('api.models.publish_release', lambda *args: None)
 class ReleaseTest(TransactionTestCase):
 
     """Tests push notification from build system"""

--- a/controller/api/tests/test_release.py
+++ b/controller/api/tests/test_release.py
@@ -7,7 +7,6 @@ Run the tests with "./manage.py test api"
 from __future__ import unicode_literals
 
 import json
-import requests
 
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
@@ -15,13 +14,7 @@ import mock
 from rest_framework.authtoken.models import Token
 
 from api.models import Release
-
-
-def mock_import_repository_task(*args, **kwargs):
-    resp = requests.Response()
-    resp.status_code = 200
-    resp._content_consumed = True
-    return resp
+from . import mock_status_ok
 
 
 @mock.patch('api.models.publish_release', lambda *args: None)
@@ -35,7 +28,7 @@ class ReleaseTest(TransactionTestCase):
         self.user = User.objects.get(username='autotest')
         self.token = Token.objects.get(user=self.user).key
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_release(self):
         """
         Test that a release is created when an app is created, and
@@ -112,7 +105,7 @@ class ReleaseTest(TransactionTestCase):
         self.assertEqual(response.status_code, 405)
         return release3
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_response_data(self):
         body = {'id': 'test'}
         response = self.client.post('/v1/apps', json.dumps(body),
@@ -137,7 +130,7 @@ class ReleaseTest(TransactionTestCase):
         }
         self.assertDictContainsSubset(expected, response.data)
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_release_rollback(self):
         url = '/v1/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -234,14 +227,14 @@ class ReleaseTest(TransactionTestCase):
         self.assertIn('NEW_URL1', values)
         self.assertEqual('http://localhost:8080/', values['NEW_URL1'])
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_release_str(self):
         """Test the text representation of a release."""
         release3 = self.test_release()
         release = Release.objects.get(uuid=release3['uuid'])
         self.assertEqual(str(release), "{}-v3".format(release3['app']))
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_release_summary(self):
         """Test the text summary of a release."""
         release3 = self.test_release()
@@ -249,7 +242,7 @@ class ReleaseTest(TransactionTestCase):
         # check that the release has push and env change messages
         self.assertIn('autotest deployed ', release.summary)
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_admin_can_create_release(self):
         """If a non-user creates an app, an admin should be able to create releases."""
         user = User.objects.get(username='autotest2')
@@ -273,7 +266,7 @@ class ReleaseTest(TransactionTestCase):
         # account for the config release as well
         self.assertEqual(response.data['count'], 2)
 
-    @mock.patch('requests.post', mock_import_repository_task)
+    @mock.patch('requests.post', mock_status_ok)
     def test_unauthorized_user_cannot_modify_release(self):
         """
         An unauthorized user should not be able to modify other releases.

--- a/controller/api/tests/test_scheduler.py
+++ b/controller/api/tests/test_scheduler.py
@@ -11,11 +11,13 @@ import json
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
+import mock
 from rest_framework.authtoken.models import Token
 
 from scheduler import chaos
 
 
+@mock.patch('api.models.publish_release', lambda *args: None)
 class SchedulerTest(TransactionTestCase):
     """Tests creation of containers on nodes"""
 

--- a/controller/deis/settings.py
+++ b/controller/deis/settings.py
@@ -303,7 +303,6 @@ SECRET_KEY = os.environ.get('DEIS_SECRET_KEY', 'CHANGEME_sapm$s%upvsw5l_zuy_&29r
 BUILDER_KEY = os.environ.get('DEIS_BUILDER_KEY', 'CHANGEME_sapm$s%upvsw5l_zuy_&29rkywd^78ff(qi')
 
 # registry settings
-REGISTRY_MODULE = 'registry.mock'
 REGISTRY_URL = 'http://localhost:5000'
 REGISTRY_HOST = 'localhost'
 REGISTRY_PORT = 5000

--- a/controller/dev_requirements.txt
+++ b/controller/dev_requirements.txt
@@ -1,5 +1,5 @@
 # Run "make coverage" or "make test-unit" for the % of code exercised during tests
-coverage>=3.7.1
+coverage>=4.0
 
 # Run "make flake8" to check python syntax and style
 flake8==2.4.1

--- a/controller/registry/__init__.py
+++ b/controller/registry/__init__.py
@@ -1,9 +1,1 @@
-import importlib
-
-from django.conf import settings
-
-# import the registry module specified in settings
-_registry_module = importlib.import_module(settings.REGISTRY_MODULE)
-
-# expose the publish_release method publicly
-publish_release = _registry_module.publish_release
+from private import publish_release  # noqa

--- a/controller/registry/mock.py
+++ b/controller/registry/mock.py
@@ -1,8 +1,0 @@
-
-def publish_release(source, config, target):
-    """
-    Publish a new release as a Docker image
-
-    This is a mock implementation used for unit tests
-    """
-    return None

--- a/controller/templates/confd_settings.py
+++ b/controller/templates/confd_settings.py
@@ -27,7 +27,6 @@ DEIS_DOMAIN = '{{ getv "/deis/platform/domain" }}'
 ENABLE_PLACEMENT_OPTIONS = """{{ if exists "/deis/platform/enablePlacementOptions" }}{{ getv "/deis/platform/enablePlacementOptions" }}{{ else }}false{{end}}"""
 
 # use the private registry module
-REGISTRY_MODULE = 'registry.private'
 REGISTRY_URL = '{{ getv "/deis/registry/protocol" }}://{{ getv "/deis/registry/host" }}:{{ getv "/deis/registry/port" }}'  # noqa
 REGISTRY_HOST = '{{ getv "/deis/registry/host" }}'
 REGISTRY_PORT = '{{ getv "/deis/registry/port" }}'

--- a/docs/reference/server/registry.rst
+++ b/docs/reference/server/registry.rst
@@ -8,9 +8,3 @@ registry.private
 .. contents::
     :local:
 .. automodule:: registry.private
-
-registry.mock
--------------
-.. contents::
-    :local:
-.. automodule:: registry.mock


### PR DESCRIPTION
While working on #3814 I ran into issues trying to use python's `mock` module in controller/registry unit tests. Turns out the local mock.py module there and associated hackery are not needed, so I PR'ed these changes separately.

Removes the REGISTRY_MODULE machinery, adds verbosity to `flake8` errors that are caught, and updates the python `coverage` library.