### PR TITLE
ref(aws): Ensure CloudFormation does not replace running instances on AMI changes.

### DIFF
--- a/contrib/aws/provision-aws-cluster.sh
+++ b/contrib/aws/provision-aws-cluster.sh
@@ -52,6 +52,7 @@ aws cloudformation create-stack \
     --template-body "$($THIS_DIR/gen-json.py --channel $COREOS_CHANNEL --version $COREOS_VERSION)" \
     --stack-name $STACK_NAME \
     --parameters "$(<$THIS_DIR/cloudformation.json)" \
+    --stack-policy-body "$(<$THIS_DIR/stack_policy.json)" \
     $EXTRA_AWS_CLI_ARGS
 
 # loop until the instances are created

--- a/contrib/aws/stack_policy.json
+++ b/contrib/aws/stack_policy.json
@@ -1,0 +1,21 @@
+{
+  "Statement" : [
+    {
+      "Effect" : "Deny",
+      "Principal" : "*",
+      "Action" : "Update:Replace",
+      "Resource" : "*",
+      "Condition" : {
+        "StringEquals" : {
+          "ResourceType" : ["AWS::EC2::Instance"]
+        }
+      }
+    },
+    {
+      "Effect" : "Allow",
+      "Principal" : "*",
+      "Action" : "Update:*",
+      "Resource" : "*"
+    }
+  ]
+}

--- a/contrib/aws/update-aws-cluster.sh
+++ b/contrib/aws/update-aws-cluster.sh
@@ -35,6 +35,7 @@ aws cloudformation update-stack \
     --template-body "$($THIS_DIR/gen-json.py --channel $COREOS_CHANNEL --version $COREOS_VERSION)" \
     --stack-name $NAME \
     --parameters "$(<$THIS_DIR/cloudformation.json)" \
+    --stack-policy-body "$(<$THIS_DIR/stack_policy.json)" \
     $EXTRA_AWS_CLI_ARGS
 
 echo_green "Your Deis cluster on AWS CloudFormation has been successfully updated."


### PR DESCRIPTION
Use Stack Policy to prevent updated AMIs from CoreOS causing instance replacements.
When running update-aws-cluster.sh and the CoreOS version has been bumped then a
running machines will be replaced due to CF default behaviour

The Stack Policy is automatically applied on create and update