### PR TITLE
fix(tests): binaries are installed in the wrong directories

### DIFF
--- a/tests/bin/test-latest.sh
+++ b/tests/bin/test-latest.sh
@@ -27,13 +27,13 @@ log_phase "Running test-latest on $DEIS_TEST_APP"
 log_phase "Installing clients"
 
 # install deis CLI from http://deis.io/ website
-pushd $DEIS_ROOT/deisctl
+pushd $DEIS_ROOT/client
 curl -sSL http://deis.io/deis-cli/install.sh | sh
 popd
 
 # install deisctl from http://deis.io/ website
 # installs latest unit files to $HOME/.deis/units
-pushd $DEIS_ROOT/client
+pushd $DEIS_ROOT/deisctl
 curl -sSL http://deis.io/deisctl/install.sh | sh
 popd
 


### PR DESCRIPTION
Minor fix to put test binaries in the correct directories.  This doesn't actually affect anything since `deis` and `deisctl` are executed via `PATH`, which still correctly finds them.