### PR TITLE
chore(tests): update shellcheck to 0.4.1

### DIFF
--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -65,6 +65,7 @@ etcd_safe_mkdir /deis/services
 echo "controller: running etcd data migrations..."
 for script in /app/migrations/data/*.sh;
 do
+	# shellcheck disable=SC1090
     . "$script";
 done
 echo "controller: done running etcd data migrations."

--- a/tests/bin/setup-node.sh
+++ b/tests/bin/setup-node.sh
@@ -78,7 +78,7 @@ if ! shellcheck -V &> /dev/null; then
   apt-get install -yq cabal-install
   cabal update
   pushd /tmp
-  git clone --branch v0.3.8 --single-branch https://github.com/koalaman/shellcheck.git
+  git clone --branch v0.4.1 --single-branch https://github.com/koalaman/shellcheck.git
   pushd shellcheck
   cabal install --global
   popd +2


### PR DESCRIPTION
`brew install shellcheck` now produces version 0.4.1, which finds an additional error that needs to be ignored.