### PR TITLE
ref(registry/database): change the create_bucket script to avoid allow 'ListAllMyBuckets' on S3 Policy

### DIFF
--- a/database/templates/create_bucket
+++ b/database/templates/create_bucket
@@ -12,5 +12,5 @@ conn = boto.connect_s3(
     calling_format=OrdinaryCallingFormat())
 name = sys.argv[1]
 
-if name not in (bucket.name for bucket in conn.get_all_buckets()):
+if not conn.lookup(name):
     conn.create_bucket(name)

--- a/docs/managing_deis/running-deis-without-ceph.rst
+++ b/docs/managing_deis/running-deis-without-ceph.rst
@@ -137,11 +137,6 @@ the registry:
     {
       "Statement": [
         {
-          "Resource": "arn:aws:s3:::*",
-          "Action": "s3:ListAllMyBuckets",
-          "Effect": "Allow"
-        },
-        {
           "Resource": [
             "arn:aws:s3:::MYBUCKET"
           ],

--- a/registry/templates/create_bucket
+++ b/registry/templates/create_bucket
@@ -22,5 +22,5 @@ name = '{{ getv "/deis/registry/s3bucket" }}'
 name = '{{ getv "/deis/registry/bucketName" }}'
 {{ end }}
 
-if name not in (bucket.name for bucket in conn.get_all_buckets()):
+if not conn.lookup(name):
     conn.create_bucket(name)


### PR DESCRIPTION
Use s3.lookup method to identify bucket name instead of list and expose all bucket names to deis cluster.