### PR TITLE
ref(contrib/azure): specify CoreOS version as a parameter

### DIFF
--- a/contrib/azure/arm-template.json
+++ b/contrib/azure/arm-template.json
@@ -81,6 +81,12 @@
         "description": "Size in GB of the Docker volume."
       },
       "defaultValue": "100"
+    },
+    "coreosVersion": {
+      "type": "string",
+      "metadata": {
+        "description": "Version of CoreOS to deploy."
+      }
     }
   },
   "variables": {
@@ -352,7 +358,7 @@
             "publisher": "[variables('imagePublisher')]",
             "offer": "[variables('imageOffer')]",
             "sku": "[variables('imageSKU')]",
-            "version": "766.4.0"
+            "version": "[parameters('coreosVersion')]"
           },
           "dataDisks": [
             {

--- a/contrib/azure/parameters.json
+++ b/contrib/azure/parameters.json
@@ -25,5 +25,8 @@
   },
   "dockerVolumeSize": {
     "value": 100
+  },
+  "coreosVersion": {
+    "value": "766.4.0"
   }
 }

--- a/docs/installing_deis/azure.rst
+++ b/docs/installing_deis/azure.rst
@@ -85,7 +85,7 @@ or via the CLI with ``azure vm show``:
 
 .. code-block:: console
 
-    $ azure vm show deisNode0 --resource-group deis
+    $ azure vm show deisNode0 --resource-group deis | grep 'Public IP address'
 
 Configure DNS
 -------------


### PR DESCRIPTION
I got this idea from @sgoings. Being able to toggle the version in `parameters.json` is a lot easier for users (and us when we bump the CoreOS version).