### PR TITLE
chore(*): update Docker base image to alpine:3.2

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -4,7 +4,7 @@ Builder creates Docker images to be run elsewhere on the Deis platform.
 Builder itself also runs in a Docker container.
 
 This Docker image is based on the official
-[alpine:3.1](https://registry.hub.docker.com/_/alpine/) image.
+[alpine:3.2](https://registry.hub.docker.com/_/alpine/) image.
 
 Please add any [issues](https://github.com/deis/deis/issues) you find with this software to
 the [Deis Project](https://github.com/deis/deis).

--- a/builder/rootfs/Dockerfile
+++ b/builder/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.2
 
 # install common packages
 RUN apk add --update-cache curl bash sudo && rm -rf /var/cache/apk/*

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.2
 
 # install common packages
 RUN apk add --update-cache curl bash sudo && rm -rf /var/cache/apk/*

--- a/controller/README.md
+++ b/controller/README.md
@@ -4,7 +4,7 @@ A RESTful API server for use in the [Deis](http://deis.io) open source PaaS.
 
 
 This Docker image is based on the official
-[alpine:3.1](https://registry.hub.docker.com/_/alpine/) image.
+[alpine:3.2](https://registry.hub.docker.com/_/alpine/) image.
 
 Please add any [issues](https://github.com/deis/deis/issues) you find with this software to
 the [Deis Project](https://github.com/deis/deis).

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -14,7 +14,6 @@ paramiko==1.15.2
 psycopg2==2.6.1
 python-etcd==0.3.2
 PyYAML==3.11
-setproctitle==1.1.8
 static==1.1.1
 South==1.0.2
 python-ldap==2.4.19

--- a/controller/templates/gconf.py
+++ b/controller/templates/gconf.py
@@ -9,7 +9,6 @@ except (NameError, ValueError):
         workers = multiprocessing.cpu_count() * 2 + 1
     except NotImplementedError:
         workers = 8
-proc_name = 'deis-controller'
 timeout = 1200
 pidfile = '/tmp/gunicorn.pid'
 loglevel = 'info'

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.2
 
 # install common packages
 RUN apk add --update-cache curl bash sudo && rm -rf /var/cache/apk/*

--- a/database/README.md
+++ b/database/README.md
@@ -3,7 +3,7 @@
 A PostgreSQL database for use in the [Deis](http://deis.io) open source PaaS.
 
 This Docker image is based on the official
-[alpine:3.1](https://registry.hub.docker.com/_/alpine/) image.
+[alpine:3.2](https://registry.hub.docker.com/_/alpine/) image.
 
 Please add any [issues](https://github.com/deis/deis/issues) you find with this software to
 the [Deis Project](https://github.com/deis/deis).

--- a/deisctl/units/deis-builder.service
+++ b/deisctl/units/deis-builder.service
@@ -4,7 +4,7 @@ Description=deis-builder
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=30m
-ExecStartPre=/bin/sh -c "docker inspect deis-builder-data >/dev/null 2>&1 || docker run --name deis-builder-data -v /var/lib/docker alpine:3.1 /bin/true"
+ExecStartPre=/bin/sh -c "docker inspect deis-builder-data >/dev/null 2>&1 || docker run --name deis-builder-data -v /var/lib/docker alpine:3.2 /bin/true"
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/builder` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-builder >/dev/null 2>&1 && docker rm -f deis-builder || true"
 ExecStartPre=-/bin/sh -c "/sbin/losetup -f"

--- a/deisctl/units/deis-database.service
+++ b/deisctl/units/deis-database.service
@@ -4,7 +4,7 @@ Description=deis-database
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker inspect deis-database-data >/dev/null 2>&1 || docker run --name deis-database-data -v /var/lib/postgresql alpine:3.1 /bin/true"
+ExecStartPre=/bin/sh -c "docker inspect deis-database-data >/dev/null 2>&1 || docker run --name deis-database-data -v /var/lib/postgresql alpine:3.2 /bin/true"
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-database >/dev/null 2>&1 && docker rm -f deis-database >/dev/null 2>&1 || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/database` && docker run --name deis-database --rm --volumes-from=deis-database-data -p 5432:5432 -e EXTERNAL_PORT=5432 -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"

--- a/deisctl/units/deis-mesos-master.service
+++ b/deisctl/units/deis-mesos-master.service
@@ -10,7 +10,7 @@ RestartSec=20
 TimeoutStartSec=0
 ExecStartPre=-/usr/bin/docker kill deis-mesos-master
 ExecStartPre=-/usr/bin/docker rm deis-mesos-master
-ExecStartPre=/bin/sh -c "docker inspect deis-mesos-master-data >/dev/null 2>&1 || docker run --name deis-mesos-master-data -v /tmp/mesos-master alpine:3.1 /bin/true"
+ExecStartPre=/bin/sh -c "docker inspect deis-mesos-master-data >/dev/null 2>&1 || docker run --name deis-mesos-master-data -v /tmp/mesos-master alpine:3.2 /bin/true"
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/mesos-master` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStart=/usr/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/mesos-master` && docker run --volumes-from=deis-mesos-master-data --name=deis-mesos-master --privileged --net=host -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-mesos-master

--- a/deisctl/units/deis-store-daemon.service
+++ b/deisctl/units/deis-store-daemon.service
@@ -4,7 +4,7 @@ Description=deis-store-daemon
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker inspect deis-store-daemon-data >/dev/null 2>&1 || docker run --name deis-store-daemon-data -v /var/lib/ceph/osd alpine:3.1 /bin/true"
+ExecStartPre=/bin/sh -c "docker inspect deis-store-daemon-data >/dev/null 2>&1 || docker run --name deis-store-daemon-data -v /var/lib/ceph/osd alpine:3.2 /bin/true"
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-daemon` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-daemon >/dev/null 2>&1 && docker rm -f deis-store-daemon >/dev/null 2>&1 || true"
 ExecStartPre=/usr/bin/sleep 10

--- a/deisctl/units/deis-store-monitor.service
+++ b/deisctl/units/deis-store-monitor.service
@@ -4,7 +4,7 @@ Description=deis-store-monitor
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker inspect deis-store-monitor-data >/dev/null 2>&1 || docker run --name deis-store-monitor-data -v /etc/ceph -v /var/lib/ceph/mon alpine:3.1 /bin/true"
+ExecStartPre=/bin/sh -c "docker inspect deis-store-monitor-data >/dev/null 2>&1 || docker run --name deis-store-monitor-data -v /etc/ceph -v /var/lib/ceph/mon alpine:3.2 /bin/true"
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-monitor` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "etcdctl set /deis/store/hosts/$COREOS_PRIVATE_IPV4 `hostname` >/dev/null"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-monitor >/dev/null 2>&1 && docker rm -f deis-store-monitor >/dev/null 2>&1 || true"

--- a/deisctl/units/deis-zookeeper.service
+++ b/deisctl/units/deis-zookeeper.service
@@ -8,7 +8,7 @@ EnvironmentFile=/etc/environment
 Restart=on-failure
 RestartSec=20
 TimeoutStartSec=0
-ExecStartPre=/bin/sh -c "docker inspect zookeeper-data >/dev/null 2>&1 || docker run --name zookeeper-data -v /opt/zookeeper-data alpine:3.1 /bin/true"
+ExecStartPre=/bin/sh -c "docker inspect zookeeper-data >/dev/null 2>&1 || docker run --name zookeeper-data -v /opt/zookeeper-data alpine:3.2 /bin/true"
 ExecStartPre=-/usr/bin/docker kill deis-zookeeper
 ExecStartPre=-/usr/bin/docker rm deis-zookeeper
 ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/zookeeper` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"

--- a/logger/README.md
+++ b/logger/README.md
@@ -3,7 +3,7 @@
 A system logger for use in the [Deis](http://deis.io) open source PaaS.
 
 This Docker image is based on the official
-[alpine:3.1](https://registry.hub.docker.com/_/alpine/) image.
+[alpine:3.2](https://registry.hub.docker.com/_/alpine/) image.
 
 Please add any [issues](https://github.com/deis/deis/issues) you find with this software to
 the [Deis Project](https://github.com/deis/deis).

--- a/logger/image/Dockerfile
+++ b/logger/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.2
 
 ENTRYPOINT ["/bin/logger"]
 CMD ["--enable-publish"]

--- a/logspout/image/Dockerfile
+++ b/logspout/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.2
 
 ENV DOCKER_HOST unix:///tmp/docker.sock
 ENV ROUTESPATH /tmp

--- a/mesos/zookeeper/Dockerfile
+++ b/mesos/zookeeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.2
 
 ENV JAVA_HOME /jre
 ENV PATH ${PATH}:${JAVA_HOME}/bin

--- a/publisher/image/Dockerfile
+++ b/publisher/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.2
 
 # install curl in the image so it is possible to get the runtime
 # profiling information without any additional package installation.

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.2
 
 # install common packages
 RUN apk add --update-cache \

--- a/router/README.md
+++ b/router/README.md
@@ -3,7 +3,7 @@
 An nginx proxy for use in the [Deis](http://deis.io) open source PaaS.
 
 This Docker image is based on the official
-[alpine:3.1](https://registry.hub.docker.com/_/alpine/) image.
+[alpine:3.2](https://registry.hub.docker.com/_/alpine/) image.
 
 Please add any [issues](https://github.com/deis/deis/issues) you find with this software to
 the [Deis Project](https://github.com/deis/deis).

--- a/store/README.md
+++ b/store/README.md
@@ -7,7 +7,7 @@ The bin/boot scripts and Dockerfiles were inspired by
 Seán C. McCord's [docker-ceph](https://github.com/Ulexus/docker-ceph) repository.
 
 This Docker image is based on the official
-[alpine:3.1](https://registry.hub.docker.com/_/alpine/) image.
+[alpine:3.2](https://registry.hub.docker.com/_/alpine/) image.
 
 Please add any issues you find with this software to the
 [Deis project](https://github.com/deis/deis/issues).

--- a/swarm/image/Dockerfile
+++ b/swarm/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.2
 
 COPY bin /app/bin/
 WORKDIR /app/bin

--- a/tests/bin/prime-docker-images.sh
+++ b/tests/bin/prime-docker-images.sh
@@ -11,4 +11,4 @@ docker rm -v `docker ps -a -q`
 docker rmi -f `docker images -q`
 
 # Pull Deis testing essentials
-docker pull alpine:3.1
+docker pull alpine:3.2

--- a/tests/fixtures/mock-store/Dockerfile
+++ b/tests/fixtures/mock-store/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.2
 
 # install common packages
 RUN apk add --update-cache curl bash sudo && rm -rf /var/cache/apk/*

--- a/tests/fixtures/test-etcd/Dockerfile
+++ b/tests/fixtures/test-etcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.2
 
 # install common packages
 RUN apk add --update-cache curl tar && rm -rf /var/cache/apk/*


### PR DESCRIPTION
Updates all components to the current [3.2.3 release](http://alpinelinux.org/posts/Alpine-3.2.3-released.html) in the official Docker [`alpine:3.2` image](https://hub.docker.com/_/alpine/), except the store-* components which use Ubuntu.

Includes openssl 1.0.2, a prerequisite for #4542. 

I spent quite a while trying, but the python `setproctitle` library just won't compile on alpine:3.2 due to expectations about the location of `sasl.h`. It was really a cosmetic nice-to-have (see #3094), so I removed it.

Registry uses M2Crypto for python, which just won't build with swig 3.0.5, so I left deis-registry at alpine:3.1. (It will likely be replaced by my v2 registry container soon anyway, which already uses alpine:3.2.)