### PR TITLE
fix(controller/web): enable unit tests

### DIFF
--- a/controller/Makefile
+++ b/controller/Makefile
@@ -78,7 +78,7 @@ test-style: setup-venv
 	shellcheck $(SHELL_SCRIPTS)
 
 test-unit: setup-venv test-style
-	venv/bin/coverage run manage.py test --noinput api
+	venv/bin/coverage run manage.py test --noinput web api
 	venv/bin/coverage report -m
 
 test-functional:

--- a/controller/web/tests.py
+++ b/controller/web/tests.py
@@ -6,6 +6,7 @@ Run the tests with "./manage.py test web"
 
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.template import Context
 from django.template import Template
 from django.template import TemplateSyntaxError
@@ -15,6 +16,10 @@ from django.test import TestCase
 class WebViewsTest(TestCase):
 
     fixtures = ['test_web.json']
+
+    @classmethod
+    def setUpClass(cls):
+        settings.WEB_ENABLED = True
 
     def setUp(self):
         self.client.login(username='autotest-1', password='password')


### PR DESCRIPTION
The minimal web pages in deis-controller are an optional feature that can't properly be removed from the code in a backward-compatible release, so they deserve to have their tests included again.