### PR TITLE
fix(*): use flock to serialize certain pulls

### DIFF
--- a/deisctl/units/deis-logspout.service
+++ b/deisctl/units/deis-logspout.service
@@ -7,7 +7,7 @@ After=docker.socket etcd2.service etcd.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logspout` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logspout` && docker history $IMAGE >/dev/null 2>&1 || flock -w 1200 /var/run/lock/alpine-pull docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-logspout >/dev/null 2>&1 && docker rm -f deis-logspout || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logspout` && docker run --name deis-logspout --rm -v /var/run/docker.sock:/tmp/docker.sock -e ETCD_HOST=$COREOS_PRIVATE_IPV4 -e HOST=$COREOS_PRIVATE_IPV4 -e DEBUG=1 $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-logspout

--- a/deisctl/units/deis-publisher.service
+++ b/deisctl/units/deis-publisher.service
@@ -7,7 +7,7 @@ After=docker.socket etcd2.service etcd.service
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker history $IMAGE >/dev/null 2>&1 || flock -w 1200 /var/run/lock/alpine-pull docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-publisher >/dev/null 2>&1 && docker rm -f deis-publisher || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker run --name deis-publisher --rm -v /var/run/docker.sock:/var/run/docker.sock $IMAGE --host=$COREOS_PRIVATE_IPV4 --etcd-host=$COREOS_PRIVATE_IPV4"
 ExecStop=-/usr/bin/docker stop deis-publisher

--- a/deisctl/units/deis-store-admin.service
+++ b/deisctl/units/deis-store-admin.service
@@ -4,7 +4,7 @@ Description=deis-store-admin
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-admin` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-admin` && docker history $IMAGE >/dev/null 2>&1 || flock -w 1200 /var/run/lock/store-pull docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-admin >/dev/null 2>&1 && docker rm -f deis-store-admin >/dev/null 2>&1 || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-admin` && docker run --name deis-store-admin --rm --volumes-from=deis-store-daemon-data --volumes-from=deis-store-monitor-data -e HOST=$COREOS_PRIVATE_IPV4 $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-store-admin

--- a/deisctl/units/deis-store-daemon.service
+++ b/deisctl/units/deis-store-daemon.service
@@ -4,8 +4,9 @@ Description=deis-store-daemon
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker inspect deis-store-daemon-data >/dev/null 2>&1 || docker run --name deis-store-daemon-data -v /var/lib/ceph/osd alpine:3.2 /bin/true"
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-daemon` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "IMAGE=alpine:3.2 && docker history $IMAGE >/dev/null 2>&1 || flock -w 1200 /var/run/lock/alpine-pull docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "IMAGE=alpine:3.2 && docker inspect deis-store-daemon-data >/dev/null 2>&1 || docker run --name deis-store-daemon-data -v /var/lib/ceph/osd $IMAGE /bin/true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-daemon` && docker history $IMAGE >/dev/null 2>&1 || flock -w 1200 /var/run/lock/store-pull docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-daemon >/dev/null 2>&1 && docker rm -f deis-store-daemon >/dev/null 2>&1 || true"
 ExecStartPre=/usr/bin/sleep 10
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-daemon` && docker run --name deis-store-daemon --rm --volumes-from=deis-store-daemon-data -e HOST=$COREOS_PRIVATE_IPV4 -p 6800 --net host $IMAGE"

--- a/deisctl/units/deis-store-gateway.service
+++ b/deisctl/units/deis-store-gateway.service
@@ -4,7 +4,7 @@ Description=deis-store-gateway
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-gateway` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-gateway` && docker history $IMAGE >/dev/null 2>&1 || flock -w 1200 /var/run/lock/store-pull docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-gateway >/dev/null 2>&1 && docker rm -f deis-store-gateway || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-gateway` && docker run --name deis-store-gateway --rm -h deis-store-gateway -e HOST=$COREOS_PRIVATE_IPV4 -e EXTERNAL_PORT=8888 -p 8888:8888 $IMAGE"
 ExecStartPost=/bin/sh -c "until (echo 'Waiting for ceph gateway on 8888/tcp...' && curl -sSL http://localhost:8888|grep -e '<ID>anonymous</ID><DisplayName></DisplayName>' >/dev/null 2>&1); do sleep 1; done"

--- a/deisctl/units/deis-store-metadata.service
+++ b/deisctl/units/deis-store-metadata.service
@@ -4,7 +4,7 @@ Description=deis-store-metadata
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-metadata` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-metadata` && docker history $IMAGE >/dev/null 2>&1 || flock -w 1200 /var/run/lock/store-pull docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-metadata >/dev/null 2>&1 && docker rm -f deis-store-metadata || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-metadata` && docker run --name deis-store-metadata --rm -e HOST=$COREOS_PRIVATE_IPV4 --net host $IMAGE"
 ExecStop=-/usr/bin/docker stop deis-store-metadata

--- a/deisctl/units/deis-store-monitor.service
+++ b/deisctl/units/deis-store-monitor.service
@@ -4,8 +4,9 @@ Description=deis-store-monitor
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=20m
-ExecStartPre=/bin/sh -c "docker inspect deis-store-monitor-data >/dev/null 2>&1 || docker run --name deis-store-monitor-data -v /etc/ceph -v /var/lib/ceph/mon alpine:3.2 /bin/true"
-ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-monitor` && docker history $IMAGE >/dev/null 2>&1 || docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "IMAGE=alpine:3.2 && docker history $IMAGE >/dev/null 2>&1 || flock -w 1200 /var/run/lock/alpine-pull docker pull $IMAGE"
+ExecStartPre=/bin/sh -c "IMAGE=alpine:3.2 && docker inspect deis-store-monitor-data >/dev/null 2>&1 || docker run --name deis-store-monitor-data -v /etc/ceph -v /var/lib/ceph/mon $IMAGE /bin/true"
+ExecStartPre=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-monitor` && docker history $IMAGE >/dev/null 2>&1 || flock -w 1200 /var/run/lock/store-pull docker pull $IMAGE"
 ExecStartPre=/bin/sh -c "etcdctl set /deis/store/hosts/$COREOS_PRIVATE_IPV4 `hostname` >/dev/null"
 ExecStartPre=/bin/sh -c "docker inspect deis-store-monitor >/dev/null 2>&1 && docker rm -f deis-store-monitor >/dev/null 2>&1 || true"
 ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-monitor` && docker run --name deis-store-monitor --rm --volumes-from=deis-store-monitor-data -e HOST=$COREOS_PRIVATE_IPV4 -p 6789 --net host $IMAGE"


### PR DESCRIPTION
Fixes #4584 by serializing `docker pull` among units pulling images with layers in common.  This is applied only to global units that are most likely to start in parallel as the result of a new node being added to a cluster.

Attn: @mboersma @carmstrong @gabrtv 