### PR TITLE
fix(user-data): use $private_ipv4 for fleet

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -13,7 +13,7 @@ coreos:
     listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
     data-dir: /var/lib/etcd2
   fleet:
-    public-ip: $public_ipv4
+    public-ip: $private_ipv4
     metadata: controlPlane=true,dataPlane=true,routerMesh=true
   update:
     reboot-strategy: "off"


### PR DESCRIPTION
Reverts this networking configuration to the interface it used previous to the v1.11.0 release, which was changed in 445dbaecfadb1e2690734413cc43f30abcb13b21.

Closes #4594.
Closes #4608.