### PR TITLE
fix(units): Add a more explicit restart policy

### DIFF
--- a/controller/scheduler/fleet.py
+++ b/controller/scheduler/fleet.py
@@ -377,6 +377,8 @@ CONTAINER_TEMPLATE = [
     {"section": "Service", "name": "TimeoutStopSec", "value": "10"},
     {"section": "Service", "name": "RestartSec", "value": "5"},
     {"section": "Service", "name": "Restart", "value": "on-failure"},
+    {"section": "Service", "name": "StartLimitInterval", "value": "60s"},
+    {"section": "Service", "name": "StartLimitBurst", "value": "3"},
 ]
 
 

--- a/deisctl/units/deis-builder.service
+++ b/deisctl/units/deis-builder.service
@@ -14,6 +14,8 @@ ExecStartPost=/bin/sh -c "echo 'Waiting for builder on 2223/tcp...' && until nca
 ExecStop=-/usr/bin/docker stop deis-builder
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-controller.service
+++ b/deisctl/units/deis-controller.service
@@ -12,6 +12,8 @@ ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/controller` && docker
 ExecStop=-/usr/bin/docker stop deis-controller
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-database.service
+++ b/deisctl/units/deis-database.service
@@ -14,6 +14,8 @@ ExecStop=-/usr/bin/docker exec deis-database sudo service postgresql stop
 ExecStop=-/usr/bin/docker stop deis-database
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-logger.service
+++ b/deisctl/units/deis-logger.service
@@ -12,6 +12,8 @@ ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logger` && docker run
 ExecStop=-/usr/bin/docker stop deis-logger
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-logspout.service
+++ b/deisctl/units/deis-logspout.service
@@ -13,6 +13,8 @@ ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/logspout` && docker r
 ExecStop=-/usr/bin/docker stop deis-logspout
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-publisher.service
+++ b/deisctl/units/deis-publisher.service
@@ -13,6 +13,8 @@ ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/publisher` && docker 
 ExecStop=-/usr/bin/docker stop deis-publisher
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-registry.service
+++ b/deisctl/units/deis-registry.service
@@ -11,6 +11,8 @@ ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/registry` && docker r
 ExecStop=-/usr/bin/docker stop deis-registry
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-router.service
+++ b/deisctl/units/deis-router.service
@@ -11,6 +11,8 @@ ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/router` && docker run
 ExecStop=-/usr/bin/docker stop deis-router
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-store-admin.service
+++ b/deisctl/units/deis-store-admin.service
@@ -10,6 +10,8 @@ ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-admin` && docke
 ExecStop=-/usr/bin/docker stop deis-store-admin
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-store-daemon.service
+++ b/deisctl/units/deis-store-daemon.service
@@ -13,6 +13,8 @@ ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-daemon` && dock
 ExecStop=-/usr/bin/docker stop deis-store-daemon
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-store-gateway.service
+++ b/deisctl/units/deis-store-gateway.service
@@ -11,6 +11,8 @@ ExecStartPost=/bin/sh -c "until (echo 'Waiting for ceph gateway on 8888/tcp...' 
 ExecStop=-/usr/bin/docker stop deis-store-gateway
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-store-metadata.service
+++ b/deisctl/units/deis-store-metadata.service
@@ -10,6 +10,8 @@ ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-metadata` && do
 ExecStop=-/usr/bin/docker stop deis-store-metadata
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-store-monitor.service
+++ b/deisctl/units/deis-store-monitor.service
@@ -13,6 +13,8 @@ ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/store-monitor` && doc
 ExecStop=-/usr/bin/docker stop deis-store-monitor
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-store-volume.service
+++ b/deisctl/units/deis-store-volume.service
@@ -11,6 +11,8 @@ ExecStartPost=/bin/sh -c "test -d /var/lib/deis/store/logs || mkdir -p /var/lib/
 ExecStopPost=-/usr/bin/umount /var/lib/deis/store
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-swarm-manager.service
+++ b/deisctl/units/deis-swarm-manager.service
@@ -10,6 +10,8 @@ ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/swarm` && docker run 
 ExecStop=-/usr/bin/docker stop deis-swarm-manager
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target

--- a/deisctl/units/deis-swarm-node.service
+++ b/deisctl/units/deis-swarm-node.service
@@ -10,6 +10,8 @@ ExecStart=/bin/sh -c "IMAGE=`/run/deis/bin/get_image /deis/swarm` && docker run 
 ExecStop=-/usr/bin/docker stop deis-swarm-node
 Restart=on-failure
 RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixes #4632
Added two stanzas to the unit files for all deis components:
StartLimitInterval and StartLimitBurst. This tells systemd to only allow
a certain number of restarts to occur (StartLimitBurst) within the
specified interval (StartLimitInterval). If StartLimitBurst+1 retry
fails systemd will not try to start the application again. The counter
is reset after the interval.

Also added the above stanzas to the fleet template for user
applications.