### PR TITLE
ref(aws): prevent replacement of ASG in CF update

### DIFF
--- a/contrib/aws/stack_policy.json
+++ b/contrib/aws/stack_policy.json
@@ -7,7 +7,7 @@
       "Resource" : "*",
       "Condition" : {
         "StringEquals" : {
-          "ResourceType" : ["AWS::EC2::Instance"]
+          "ResourceType" : ["AWS::EC2::Instance", "AWS::AutoScaling::AutoScalingGroup"]
         }
       }
     },


### PR DESCRIPTION
This builds on #4534 to also prevent the replacement of the auto scaling group, which will also replace all of the EC2 instances in the ASG.