### PR TITLE
chore(builder): update Docker to 1.8.3

### DIFF
--- a/builder/docker/docker.go
+++ b/builder/docker/docker.go
@@ -157,6 +157,10 @@ func ParallelBuild(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Inte
 
 	for _, img := range images {
 		img := img
+
+		// HACK: ensure "docker build" is serialized by allowing only one entry in
+		// the WaitGroup. This works around the "simultaneous docker pull" bug.
+		wg.Wait()
 		wg.Add(1)
 		safely.GoDo(c, func() {
 			log.Infof(c, "Starting build for %s (tag: %s)", img.Path, img.Tag)

--- a/builder/rootfs/Dockerfile
+++ b/builder/rootfs/Dockerfile
@@ -26,8 +26,12 @@ RUN apk add --update-cache \
     && rm -rf /var/cache/apk/*
 
 # the docker package in alpine disables aufs and devicemapper
-RUN curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.8.3 -o /usr/bin/docker && \
-  chmod +x /usr/bin/docker
+ENV DOCKER_BUCKET get.docker.com
+ENV DOCKER_VERSION 1.8.3
+ENV DOCKER_SHA256 f024bc65c45a3778cf07213d26016075e8172de8f6e4b5702bedde06c241650f
+RUN curl -sSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-$DOCKER_VERSION" -o /usr/bin/docker \
+	&& echo "${DOCKER_SHA256} /usr/bin/docker" | sha256sum -c - \
+	&& chmod +x /usr/bin/docker
 
 # configure ssh server
 RUN mkdir -p /var/run/sshd && rm -rf /etc/ssh/ssh_host*

--- a/builder/rootfs/Dockerfile
+++ b/builder/rootfs/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --update-cache \
     && rm -rf /var/cache/apk/*
 
 # the docker package in alpine disables aufs and devicemapper
-RUN curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.5.0 -o /usr/bin/docker && \
+RUN curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.8.3 -o /usr/bin/docker && \
   chmod +x /usr/bin/docker
 
 # configure ssh server


### PR DESCRIPTION
This should be the final change necessary to future-proof Deis against the [disabling of the V1 API](http://blog.docker.com/2015/10/docker-hub-deprecation-1-5/) at Docker Hub on December 7.

Now that #4581 is merged, `deis pull` does not depend on the extended V1 registry-to-registry transfer API and works with images built by any version of Docker. The "last-mile" layer of ENV variables is also done by Docker now and doesn't depend on the V1 registry API. Bumping Docker up to the current 1.8.3 in deis-builder should ensure that new or upgraded Deis clusters can survive December 7.

Docker registry V2 work for deis-registry is also close to completion, but needs a migration tool and further testing: see #4641.

Refs #4636.

TODO:
- [x] add sha256sum checking to downloaded docker binary
- [x] add the equivalent of `flock` locks around builder `docker pull` and `docker build` operations
