### PR TITLE
chore(router): update nginx to 1.9.6

### DIFF
--- a/router/rootfs/bin/build
+++ b/router/rootfs/bin/build
@@ -2,7 +2,7 @@
 
 set -eof pipefail
 
-export NGINX_VERSION=1.9.4
+export NGINX_VERSION=1.9.6
 export NAXSI_VERSION=0d53a64ed856e694fcb4038748c8cf6d5551a603
 export NDK_VERSION=0.2.19
 export VTS_VERSION=22c51e201a550bb94e96239fef541347beb4eeca
@@ -33,7 +33,7 @@ apk add --update-cache \
   zlib-dev
 
 # download, verify and extract the source files
-get_src 479b0c03747ee6b2d4a21046f89b06d178a2881ea80cfef160451325788f2ba8 \
+get_src ed501fc6d0eff9d3bc1049cc1ba3a3ac8c602de046acb2a4c108392bbfa865ea \
         "http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
 
 get_src 128b56873eedbd3f240dc0f88a8b260d791321db92f14ba2fc5c49fc5307e04d \
@@ -66,8 +66,8 @@ cd "$BUILD_PATH/nginx-$NGINX_VERSION"
   --with-http_dav_module \
   --with-http_geoip_module \
   --with-http_gzip_static_module \
-  --with-http_spdy_module \
   --with-http_sub_module \
+  --with-http_v2_module \
   --with-mail \
   --with-mail_ssl_module \
   --with-stream \
@@ -78,7 +78,7 @@ cd "$BUILD_PATH/nginx-$NGINX_VERSION"
   && make && make install
 
 rm -rf "$BUILD_PATH"
-apk del \
+apk del --purge \
   build-base \
   curl \
   geoip-dev \

--- a/router/rootfs/etc/confd/templates/deis.conf
+++ b/router/rootfs/etc/confd/templates/deis.conf
@@ -3,7 +3,7 @@ port_in_redirect off;
 listen 80{{ if exists "/deis/router/proxyProtocol" }} proxy_protocol{{ end }};
 
 {{ if exists "/deis/router/sslCert" }}
-listen 443 ssl spdy{{ if exists "/deis/router/proxyProtocol" }} proxy_protocol{{ end }};
+listen 443 ssl http2{{ if exists "/deis/router/proxyProtocol" }} proxy_protocol{{ end }};
 ssl_certificate /etc/ssl/deis.cert;
 ssl_certificate_key /etc/ssl/deis.key;
 include ssl.conf;

--- a/router/rootfs/etc/confd/templates/nginx.conf
+++ b/router/rootfs/etc/confd/templates/nginx.conf
@@ -211,7 +211,7 @@ http {
         server_name_in_redirect off;
         port_in_redirect off;
         listen 80{{ if ne $useProxyProtocol "false" }} proxy_protocol{{ end }};
-        listen 443 ssl spdy{{ if ne $useProxyProtocol "false" }} proxy_protocol{{ end }};
+        listen 443 ssl http2{{ if ne $useProxyProtocol "false" }} proxy_protocol{{ end }};
         ssl_certificate /etc/ssl/deis/certs/{{ $app_domain }}.cert;
         ssl_certificate_key /etc/ssl/deis/keys/{{ $app_domain }}.key;
         include ssl.conf;
@@ -431,7 +431,7 @@ http {
         server_name_in_redirect off;
         port_in_redirect off;
         listen 80{{ if ne $useProxyProtocol "false" }} proxy_protocol{{ end }};
-        listen 443 ssl spdy{{ if ne $useProxyProtocol "false" }} proxy_protocol{{ end }};
+        listen 443 ssl http2{{ if ne $useProxyProtocol "false" }} proxy_protocol{{ end }};
         ssl_certificate /etc/ssl/deis/certs/{{ $app_domain }}.cert;
         ssl_certificate_key /etc/ssl/deis/keys/{{ $app_domain }}.key;
         include ssl.conf;


### PR DESCRIPTION
See http://nginx.org/en/CHANGES

spdy is gone is favor of http2 as of 1.9.5, but it's unclear to me if that would be a breaking change since Deis didn't advertise the availability of the `spdy` protocol. ping @helgi and @aledbf for review.