### PR TITLE
ref(contrib): assume jq utility is available

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -85,9 +85,7 @@ coreos:
         Description=etcd debugging service
 
         [Service]
-        ExecStartPre=/usr/bin/curl -sSL -o /opt/bin/jq http://stedolan.github.io/jq/download/linux64/jq
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/jq
-        ExecStart=/usr/bin/bash -c "while true; do curl -sL http://127.0.0.1:4001/v2/stats/self | /opt/bin/jq . ; sleep 1 ; done"
+        ExecStart=/usr/bin/bash -c "while true; do curl -sL http://127.0.0.1:4001/v2/stats/self | jq . ; sleep 1 ; done"
     - name: increase-nf_conntrack-connections.service
       command: start
       content: |

--- a/contrib/util/custom-firewall.sh
+++ b/contrib/util/custom-firewall.sh
@@ -1,11 +1,5 @@
 #!/bin/env bash
 
-if [ ! -f /opt/bin/jq ]; then
-  echo "/opt/bin/jq is missing. Downloading..."
-  curl -sSL -o /opt/bin/jq http://stedolan.github.io/jq/download/linux64/jq
-  chmod +x /opt/bin/jq
-fi
-
 # obtain the etcd node members and check that at least there is three
 ETCD_NODES=$(curl -s http://localhost:4001/v2/members | jq '.[] | .[].peerURLs | length' | wc -l)
 if test $ETCD_NODES -lt 3; then


### PR DESCRIPTION
CoreOS has included `/usr/bin/jq` v1.4 since [release 717.0.0](https://coreos.com/releases/#717.0.0). This removes some cruft from when it was necessary to install it to `/opt/bin/jq`.