### PR TITLE
fix(builder): continue updating etcd after errors

### DIFF
--- a/builder/etcd/etcd.go
+++ b/builder/etcd/etcd.go
@@ -349,14 +349,13 @@ func UpdateHostPort(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Int
 	safely.GoDo(c, func() {
 		ticker := time.NewTicker(10 * time.Second)
 		for range ticker.C {
-			//log.Infof(c, "Setting SSHD host/port")
 			if _, err := os.FindProcess(sshd); err != nil {
 				log.Errf(c, "Lost SSHd process: %s", err)
 				break
 			} else {
 				if err := setHostPort(client, base, host, port, ttl); err != nil {
 					log.Errf(c, "Etcd error setting host/port: %s", err)
-					break
+					continue
 				}
 			}
 		}


### PR DESCRIPTION
If deis-builder is unable to update etcd with its ssh server host and port, the `UpdateHostPort` task exits and the service must be restarted. Logging the error but continuing to try to update etcd should be more robust behavior. @rvadim has been running Deis with this patch for over a month and it seems to have helped in his situation.

Closes #4495.
ping @technosophos for builder review.