### PR TITLE
fix(contrib/gce): replace discovery url properly

### DIFF
--- a/contrib/azure/create-azure-user-data
+++ b/contrib/azure/create-azure-user-data
@@ -57,7 +57,7 @@ def main():
     coreos_template = get_file("../coreos/user-data.example")
 
     coreos_template_w_url = None
-    with open(coreos_template.name, 'r') as file :
+    with open(coreos_template.name, 'r') as file:
       coreos_template_w_url = file.read()
 
     coreos_template_w_url = coreos_template_w_url.replace('#DISCOVERY_URL', url)

--- a/contrib/gce/create-gce-user-data
+++ b/contrib/gce/create-gce-user-data
@@ -56,7 +56,13 @@ def main():
     gce_template = get_file("gce-user-data-template")
     coreos_template = get_file("../coreos/user-data.example")
 
-    configuration_coreos_template = yaml.safe_load(coreos_template)
+    coreos_template_w_url = None
+    with open(coreos_template.name, 'r') as file:
+        coreos_template_w_url = file.read()
+
+    coreos_template_w_url = coreos_template_w_url.replace('#DISCOVERY_URL', url)
+
+    configuration_coreos_template = yaml.safe_load(coreos_template_w_url)
     configuration_gce_template = yaml.safe_load(gce_template)
 
     configuration = combine_dicts(configuration_coreos_template,


### PR DESCRIPTION
Replaces `#DISCOVERY_URL` explicitly to fix GCE provisioning. See #4680--thanks @ritazh!

Closes #4588.