### PR TITLE
feat(contrib/digitalocean): improve Digital Ocean provisioning workflow

### DIFF
--- a/contrib/digitalocean/config.sh
+++ b/contrib/digitalocean/config.sh
@@ -2,18 +2,76 @@ export DEIS_TEST_DOMAIN="xip.io"
 export DO_TOKEN
 export DO_SSH_FINGERPRINT
 
-prompt "What Digital Ocean token should I use?" DO_TOKEN
-prompt "What Digital Ocean ssh fingerprint should I use?" DO_SSH_FINGERPRINT
+function check-do-token {
+  if [ ! -z ${1} ]; then
+    local token="${1}"
+    curl --fail -X GET -H "Authorization: Bearer ${token}" \
+                          "https://api.digitalocean.com/v2/account" &> /dev/null
+  else
+    return 1
+  fi
+}
+
+function check-do-ssh-key {
+  local token="${1}"
+  local ssh_fingerprint="${2}"
+
+  if [ ! -z ${ssh_fingerprint} ]; then
+    curl --fail \
+         -X GET \
+         -H \
+         "Authorization: Bearer ${token}" \
+         "https://api.digitalocean.com/v2/account/keys/${ssh_fingerprint}" &> /dev/null
+  else
+    return 1
+  fi
+}
+
+while true; do
+  password-prompt "What DigitalOcean token should I use?" DO_TOKEN
+
+  if ! check-do-token "${DO_TOKEN:-}"; then
+    rerun_log error "Couldn't login to DigitalOcean using this API token. :-("
+    unset DO_TOKEN
+  else
+    rerun_log info "Successfully logged into DigitalOcean!"
+    break
+  fi
+done
+
+while true; do
+  ssh-private-key-prompt "What private SSH key should I use when creating DigitalOcean droplets?" SSH_PRIVATE_KEY_FILE
+
+  export DO_SSH_FINGERPRINT="$(ssh-fingerprint "${SSH_PRIVATE_KEY_FILE}")"
+
+  if ! check-do-ssh-key "${DO_TOKEN}" "${DO_SSH_FINGERPRINT:-}"; then
+    rerun_log error "Couldn't find the fingerprint for this key in DigitalOcean."
+
+    cat <<EOF
+  Upload the public key by pressing the "Add SSH Key" button on
+  your DigitalOcean security page:
+
+    https://cloud.digitalocean.com/settings/security
+
+  Or pick a different key...
+
+EOF
+
+    unset SSH_PRIVATE_KEY_FILE
+  else
+    rerun_log info "This SSH key is correctly configured for use with DigitalOcean!"
+    break
+  fi
+done
+
+rigger-log "DO_SSH_FINGERPRINT set to ${DO_SSH_FINGERPRINT}"
 
 export TF_VAR_deis_root="${DEIS_ROOT}"
-export TF_VAR_token="${DO_TOKEN}"
 export TF_VAR_ssh_keys="${DO_SSH_FINGERPRINT}"
 export TF_VAR_prefix="deis-${DEIS_ID}"
 
 rigger-save-vars DEIS_TEST_DOMAIN \
-                 DO_TOKEN \
                  DO_SSH_FINGERPRINT \
                  TF_VAR_deis_root \
                  TF_VAR_prefix \
-                 TF_VAR_ssh_keys \
-                 TF_VAR_token
+                 TF_VAR_ssh_keys

--- a/contrib/digitalocean/create
+++ b/contrib/digitalocean/create
@@ -2,7 +2,9 @@
 
 set -eo pipefail -o nounset
 
-terraform apply
+export TF_VAR_token="${DO_TOKEN}"
+
+terraform apply | grep --line-buffered -v user_data
 
 export DEISCTL_TUNNEL="$(terraform output ip)"
 export DEIS_TEST_DOMAIN="${DEISCTL_TUNNEL}.xip.io"

--- a/contrib/digitalocean/destroy
+++ b/contrib/digitalocean/destroy
@@ -2,4 +2,6 @@
 
 set -eo pipefail -o nounset
 
+export TF_VAR_token="${DO_TOKEN}"
+
 terraform destroy -force

--- a/contrib/digitalocean/variables.tf
+++ b/contrib/digitalocean/variables.tf
@@ -19,5 +19,5 @@ variable "ssh_keys" {
 }
 
 variable "token" {
-  description = "Your Digital Ocean auth token"
+  description = "Your DigitalOcean auth token"
 }


### PR DESCRIPTION
I'd like to get these changes in (rigger specific, no changes to terraform or docs) for the Digital Ocean deploy day. It makes the tutorial more dead-simple, as in the user is only asked for:

- DO_TOKEN
- ssh private key to use with Digital Ocean

```
~/go/src/github.com/deis/rigger  ⑂ master +    ./rigger configure --provider "digitalocean" --version 1.12.0
DEIS_SOURCE already set to 1. Skipping prompt.
VERSION already set to 1.12.0. Skipping prompt.
DEIS_GIT_REPO already set to https://github.com/deis/deis.git. Skipping prompt.
DEIS_GIT_VERSION already set to 1.12.0. Skipping prompt.
GOPATH already set to /Users/sethgoings/.rigger/d9915759a0/go. Skipping prompt.
DEIS_ROOT already set to /Users/sethgoings/.rigger/d9915759a0/go/src/github.com/deis/deis. Skipping prompt.
Cloning Deis at /Users/sethgoings/.rigger/d9915759a0/go/src/github.com/deis/deis to v1.12.0
Cloning into '/Users/sethgoings/.rigger/d9915759a0/go/src/github.com/deis/deis'...
remote: Counting objects: 2163, done.
remote: Compressing objects: 100% (1912/1912), done.
remote: Total 2163 (delta 163), reused 1361 (delta 77), pack-reused 0
Receiving objects: 100% (2163/2163), 3.10 MiB | 4.69 MiB/s, done.
Resolving deltas: 100% (163/163), done.
Checking connectivity... done.
Configuring digitalocean provider...
DO_TOKEN already set to ******. Skipping prompt.
Successfully logged into Digital Ocean!
-> Which private SSH key should be used? SSH_PRIVATE_KEY_FILE [ /Users/sethgoings/.ssh/deis-ci.pem ]
1) /Users/sethgoings/.ssh/deis-ci.pem
2) /Users/sethgoings/.ssh/deis-test
3) /Users/sethgoings/.ssh/deiskey
4) /Users/sethgoings/.ssh/id_rsa
5) /Users/sethgoings/.ssh/sgoings-ey.pem
#? 2
You chose: 2) /Users/sethgoings/.ssh/deis-test
DO_SSH_FINGERPRINT set to 02:81:cf:41:d0:7e:c2:4f:af:62:02:96:f2:11:59:b9
Configuring local Docker environment...
Started machines may have new IP addresses. You may need to re-run the `docker-machine env` command.
DEV_REGISTRY already set to registry.hub.docker.com. Skipping prompt.
IMAGE_PREFIX already set to deis. Skipping prompt.
Started machines may have new IP addresses. You may need to re-run the `docker-machine env` command.
DEIS_TEST_SSH_KEY already set to /Users/sethgoings/.ssh/deis-test. Skipping prompt.
DEIS_TEST_AUTH_KEY_FULL already set to /Users/sethgoings/.ssh/deis-test. Skipping prompt.
DEIS_TEST_DOMAIN already set to xip.io. Skipping prompt.

Rigger has been configured on this system using /Users/sethgoings/.rigger/d9915759a0/vars
To use the configuration outside of rigger, you can run:

  source "/Users/sethgoings/.rigger/d9915759a0/vars"
```