### PR TITLE
Update buildpacks

### DIFF
--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -39,4 +39,4 @@ download_buildpack https://github.com/heroku/heroku-buildpack-python.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v82
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v70
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v63
-download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v16
+download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v18

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -31,7 +31,7 @@ mkdir -p $BUILDPACK_INSTALL_PATH
 download_buildpack https://github.com/heroku/heroku-buildpack-multi.git          26fa21a
 download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v140
 download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v86
-download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v39
+download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v40
 download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v12
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v19
 download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v24

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -36,7 +36,7 @@ download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v19
 download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v24
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v70
-download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v75
+download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v82
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v68
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v60
 download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v16

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -35,7 +35,7 @@ download_buildpack https://github.com/heroku/heroku-buildpack-java.git          
 download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v12
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v19
 download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v24
-download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v62
+download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v70
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v75
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v68
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v60

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -29,7 +29,7 @@ download_buildpack() {
 mkdir -p $BUILDPACK_INSTALL_PATH
 
 download_buildpack https://github.com/heroku/heroku-buildpack-multi.git          26fa21a
-download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v138
+download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v140
 download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v80
 download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v39
 download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v12

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -30,7 +30,7 @@ mkdir -p $BUILDPACK_INSTALL_PATH
 
 download_buildpack https://github.com/heroku/heroku-buildpack-multi.git          26fa21a
 download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v140
-download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v80
+download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v86
 download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v39
 download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v12
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v19

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -38,5 +38,5 @@ download_buildpack https://github.com/heroku/heroku-buildpack-play.git          
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v70
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v82
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v70
-download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v60
+download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v63
 download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v16

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -37,6 +37,6 @@ download_buildpack https://github.com/heroku/heroku-buildpack-grails.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v24
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v70
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v82
-download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v68
+download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v70
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v60
 download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v16


### PR DESCRIPTION
Updates all eligible buildpacks to their latest tagged versions. I tested these with the Deis project example apps:
- [x] [heroku-buildpack-ruby](https://github.com/heroku/heroku-buildpack-ruby/compare/v138...v140)
- [x] [heroku-buildpack-nodejs](https://github.com/heroku/heroku-buildpack-nodejs/compare/v80...v86)
- [x] [heroku-buildpack-java](https://github.com/heroku/heroku-buildpack-java/compare/v39...v40)
- [x] [heroku-buildpack-python](https://github.com/heroku/heroku-buildpack-python/compare/v62...v70) using both Django and Flask
- [x] [heroku-buildpack-php](https://github.com/heroku/heroku-buildpack-php/compare/v75...v82)
- [x] [heroku-buildpack-clojure](https://github.com/heroku/heroku-buildpack-clojure/compare/v68...v70)* -- ~~couldn't finish test because https://clojars.org is down, need to retry when it comes back online~~ works fine once clojars.org came back
- [x] [heroku-buildpack-scala](https://github.com/heroku/heroku-buildpack-scala/compare/v60...v63)
- [x] [heroku-buildpack-go](https://github.com/heroku/heroku-buildpack-go/compare/v16...v18)



