### PR TITLE
fix(create_bucket): check for existence of None

### DIFF
--- a/database/templates/create_bucket
+++ b/database/templates/create_bucket
@@ -12,5 +12,5 @@ conn = boto.connect_s3(
     calling_format=OrdinaryCallingFormat())
 name = sys.argv[1]
 
-if not conn.lookup(name):
+if conn.lookup(name) is None:
     conn.create_bucket(name)

--- a/registry/templates/create_bucket
+++ b/registry/templates/create_bucket
@@ -22,5 +22,5 @@ name = '{{ getv "/deis/registry/s3bucket" }}'
 name = '{{ getv "/deis/registry/bucketName" }}'
 {{ end }}
 
-if not conn.lookup(name):
+if conn.lookup(name) is None:
     conn.create_bucket(name)


### PR DESCRIPTION
There are small implications between `if not x` and `if x is None` in
Python:

 - `if not x` checks if the value is false (empty list, `None`, `False`)
 - `if x is None` checks if x is equal to the literal value `None`.

conn.lookup returns `None` if no bucket exists. This code is explicitly
stated in their docs as the proper way to check if a bucket does not
exist.

See: http://boto.readthedocs.org/en/latest/s3_tut.html

I'm not sure how the original issue is caused, but this will likely
resolve it.

closes #4713 

ping @lukasmartinelli and @afterthought. Would you mind verifying that this patch works for you?