### PR TITLE
fix(registry): fix create_bucket s3 compatability

### DIFF
--- a/registry/templates/create_bucket
+++ b/registry/templates/create_bucket
@@ -8,13 +8,22 @@ conn = boto.connect_s3(
     {{ if exists "/deis/store/gateway/accessKey" }}
     aws_access_key_id='{{ getv "/deis/store/gateway/accessKey" }}',
     aws_secret_access_key='{{ getv "/deis/store/gateway/secretKey" }}',
-    {{end}}
+    {{ else }}
+    {{ if exists "/deis/registry/s3accessKey" }}
+    aws_access_key_id='{{ getv "/deis/registry/s3accessKey" }}',
+    aws_secret_access_key='{{ getv "/deis/registry/s3secretKey" }}',
+    {{ end }}
+    {{ end }}
     {{ if exists "/deis/store/gateway/host" }}
     host='{{ getv "/deis/store/gateway/host" }}',
     port={{ getv "/deis/store/gateway/port" }},
     {{ end }}
+    {{ if exists "/deis/registry/s3bucket" }}
+    is_secure=True)
+    {{ else }}
     is_secure=False,
     calling_format=OrdinaryCallingFormat())
+    {{ end }}
 
 {{ if exists "/deis/registry/s3bucket" }}
 name = '{{ getv "/deis/registry/s3bucket" }}'


### PR DESCRIPTION
The create_bucket script in the registry has some incompatibilities with
s3. In 1.12 deis is using the boto `lookup` function to determine
whether a bucket exists or not.  The boto s3 connection is created using
an OrdinaryCallingFormat, for ceph compatibility.  Unfortunately, S3
returns a 301 when lookup is called with OrdinaryCallingFormat, which
causes the lookup function to return None.

Prior to 1.12 the boto `get_all_buckets` function was used to determine
whether a bucket existed or not, which does not seem to have this
problem.

I've fixed it by updating the create_bucket script to not pass an
OrdinaryCallingFormat if the `/deis/registry/s3bucket` setting is
present, which fixes this issue.  I've also omitted the
`is_secure=False` setting, which would cause boto to use s3 over http.

Additionally, if `/deis/store/gateway/accessKey` is not present (which
should be the case in a stateless setup) I'm using the s3 access keys
configured for the registry.

This fixes #4713 (and maybe #4710 and #4688).  #4710 was labelled as a
documentation bug, but I'm not sure it is - seems like the stateless
registry should just read the s3 configuration from a single place
rather than relying on the `/deis/store/gateway/accessKey` config that
is usually set by the store-gateway.