### PR TITLE
ref(user-data): disable iptables in docker

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -48,10 +48,10 @@ coreos:
           [Unit]
           Requires=flanneld.service
           After=flanneld.service
-      - name: 50-insecure-registry.conf
+      - name: 50-custom-options.conf
         content: |
           [Service]
-          Environment="DOCKER_OPTS=--insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 --insecure-registry 100.64.0.0/10"
+          Environment="DOCKER_OPTS=--iptables=false --insecure-registry 10.0.0.0/8 --insecure-registry 172.16.0.0/12 --insecure-registry 192.168.0.0/16 --insecure-registry 100.64.0.0/10"
     - name: flanneld.service
       command: start
       drop-ins:


### PR DESCRIPTION
Flannel provides the required rule to access internet from the containers (`--ip-mask=true`) and a dedicated ip address for all the containers running in the node. This means that is not required the creation of any iptable rules to forward traffic

closes #4686