### PR TITLE
ref(contrib): expose COREOS ENV vars via export in utils.sh. Add DEIS_RELEASE

### DIFF
--- a/contrib/utils.sh
+++ b/contrib/utils.sh
@@ -12,5 +12,6 @@ function echo_green {
   echo -e "\033[0;32m$1\033[0m"
 }
 
-COREOS_CHANNEL=${COREOS_CHANNEL:-stable}
-COREOS_VERSION=${COREOS_VERSION:-766.5.0}
+export COREOS_CHANNEL=${COREOS_CHANNEL:-stable}
+export COREOS_VERSION=${COREOS_VERSION:-766.5.0}
+export DEIS_RELEASE=1.13.0-dev

--- a/docs/roadmap/releases.rst
+++ b/docs/roadmap/releases.rst
@@ -34,6 +34,7 @@ Patch Release
         builder/rootfs/usr/local/src/slugbuilder/Dockerfile \
         builder/rootfs/usr/local/src/slugrunner/Dockerfile \
         client/deis-version \
+        contrib/utils.sh \
         contrib/coreos/user-data.example \
         controller/deis/__init__.py \
         controller/Dockerfile \
@@ -91,6 +92,7 @@ Major or Minor Release
 
     $ ./contrib/bumpver/bumpver -f A.B.C A.B.D \
         README.md \
+        contrib/utils.sh \
         contrib/coreos/user-data.example \
         docs/_includes/_get-the-source.rst \
         docs/installing_deis/install-deisctl.rst \
@@ -156,6 +158,7 @@ Patch Release
 
     ./contrib/bumpver/bumpver -f A.B.C A.B.D \
       README.md \
+      contrib/utils.sh \
       contrib/coreos/user-data.example \
       docs/_includes/_get-the-source.rst \
       docs/installing_deis/install-deisctl.rst \


### PR DESCRIPTION
Without this COREOS_VERSION and COREOS_CHANNEL aren't picked up by sourcing or external scripts