### PR TITLE
fix(deisctl): don't panic when config key/value is malformed

### DIFF
--- a/deisctl/config/config.go
+++ b/deisctl/config/config.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"strings"
+	"regexp"
 
 	"github.com/deis/deis/deisctl/utils"
 )
@@ -65,12 +65,17 @@ func doConfig(target string, action string, key []string, cb Backend, w io.Write
 
 func doConfigSet(cb Backend, root string, kvs []string) ([]string, error) {
 	var result []string
+	regex := regexp.MustCompile(`^(.+)=([\s\S]+)$`)
 
 	for _, kv := range kvs {
 
+		if !regex.MatchString(kv) {
+			return []string{}, fmt.Errorf("'%s' does not match the pattern 'key=var', ex: foo=bar\n", kv)
+		}
+
 		// split k/v from args
-		split := strings.SplitN(kv, "=", 2)
-		k, v := split[0], split[1]
+		captures := regex.FindStringSubmatch(kv)
+		k, v := captures[1], captures[2]
 
 		// prepare path and value
 		path := root + k

--- a/deisctl/config/config_test.go
+++ b/deisctl/config/config_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"bytes"
 	"encoding/base64"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -27,7 +26,7 @@ func TestGetConfig(t *testing.T) {
 	expected := "foo\n8000\n"
 	output := testWriter.String()
 	if output != expected {
-		t.Error(fmt.Errorf("Expected: '%s', Got:'%s'", expected, output))
+		t.Errorf("Expected: '%s', Got:'%s'", expected, output)
 	}
 }
 
@@ -59,7 +58,21 @@ func TestSetConfig(t *testing.T) {
 	expected := "bar\n1000\n"
 	output := testWriter.String()
 	if output != expected {
-		t.Error(fmt.Errorf("Expected: '%s', Got:'%s'", expected, output))
+		t.Errorf("Expected: '%s', Got:'%s'", expected, output)
+	}
+}
+
+func TestSetConfigError(t *testing.T) {
+	t.Parallel()
+
+	testMock := mock.ConfigBackend{Expected: []*model.ConfigNode{}}
+	testWriter := bytes.Buffer{}
+
+	expected := "'foo' does not match the pattern 'key=var', ex: foo=bar\n"
+	err := doConfig("controller", "set", []string{"foo", "=", "bar"}, testMock, &testWriter)
+
+	if err.Error() != expected {
+		t.Errorf("Expected: '%s', Got:'%q'", expected, err)
 	}
 }
 
@@ -78,7 +91,7 @@ func TestDeleteConfig(t *testing.T) {
 	expected := "testing\nport\n"
 	output := testWriter.String()
 	if output != expected {
-		t.Error(fmt.Errorf("Expected: '%s', Got:'%s'", expected, output))
+		t.Errorf("Expected: '%s', Got:'%s'", expected, output)
 	}
 }
 


### PR DESCRIPTION
Fixes #4597