### PR TITLE
fix(contrib): Add drop-in to make docker require flannel

### DIFF
--- a/contrib/coreos/user-data.example
+++ b/contrib/coreos/user-data.example
@@ -43,6 +43,11 @@ coreos:
       enable: false
     - name: docker.service
       drop-ins:
+      - name: 10-require-flannel.conf
+        content: |
+          [Unit]
+          Requires=flanneld.service
+          After=flanneld.service
       - name: 50-insecure-registry.conf
         content: |
           [Service]


### PR DESCRIPTION
This clears up a race condition where docker can be socket-activated _before_ flannel has finished starting-- in which case docker appears to assign VIPs to containers that are in the 10.1.0.0/16 range instead of the 10.244.0.0/16 range that flannel manages iptables rules for.

The issue essentially breaks the k8s tech preview.  It manifests as 502s from the router when attempting to access an app.  The router sees the upstream as a bad gateway.  What is really happening is that the router is proxying traffic to the application's service endpoint (which is a VIP in an entirely different range with iptables rules managed by kube-proxy), and the traffic gets there no problem, but then cannot reach any pod that the service proxies because all the pods are in the 10.1.0.0/16 range and are not routable.

This PR gets us back in business.