### PR TITLE
fix(registry): disallow dots in s3 buckets

### DIFF
--- a/docs/customizing_deis/registry_settings.rst
+++ b/docs/customizing_deis/registry_settings.rst
@@ -22,7 +22,7 @@ The following etcd keys are set by the registry component, typically in its /bin
 ===========================              =================================================================================
 setting                                  description
 ===========================              =================================================================================
-/deis/registry/bucketName                store component bucket used for registry image layers (default: registry)
+/deis/registry/bucketName                store component bucket used for registry image layers. Periods are not allowed in the name (default: registry)
 /deis/registry/host                      IP address of the host running registry
 /deis/registry/port                      port used by the registry service (default: 5000)
 /deis/registry/protocol                  protocol for registry (default: http)
@@ -52,7 +52,7 @@ setting                                   description
 /deis/registry/s3accessKey                S3 API access key. If not specified, the registry will get it from the instance role
 /deis/registry/s3secretKey                S3 API secret key, required if s3accessKey is specified
 /deis/registry/s3region                   S3 region to connect to, will use boto default if not specified
-/deis/registry/s3bucket                   S3 bucket to store images 
+/deis/registry/s3bucket                   S3 bucket to store images. Periods are not allowed in the name.
 /deis/registry/s3path                     path in the bucket (default: "/registry")
 /deis/registry/s3encrypt                  whether the object is encrypted while at rest on the server (default: true)
 /deis/registry/s3secure                   use secure protocol to establish connection with S3 (default: true)

--- a/registry/templates/create_bucket
+++ b/registry/templates/create_bucket
@@ -19,17 +19,21 @@ conn = boto.connect_s3(
     port={{ getv "/deis/store/gateway/port" }},
     {{ end }}
     {{ if exists "/deis/registry/s3bucket" }}
-    is_secure=True)
+    is_secure=True
     {{ else }}
     is_secure=False,
-    calling_format=OrdinaryCallingFormat())
+    calling_format=OrdinaryCallingFormat()
     {{ end }}
+)
 
 {{ if exists "/deis/registry/s3bucket" }}
 name = '{{ getv "/deis/registry/s3bucket" }}'
 {{ else }}
 name = '{{ getv "/deis/registry/bucketName" }}'
 {{ end }}
+
+if '.' in name:
+    raise Exception('periods are not supported in bucket name')
 
 if conn.lookup(name) is None:
     conn.create_bucket(name)


### PR DESCRIPTION
OrdinaryCallingFormat is important for any bucket with dot in it, no matter the region. Fixes bug introduced by #4729