### PR TITLE
fix(database): bail out if unable to check for existing backups

### DIFF
--- a/database/bin/boot
+++ b/database/bin/boot
@@ -75,7 +75,8 @@ if [[ "$(cat $PG_DATA_DIR/initialized 2> /dev/null)" != "$INIT_ID" ]]; then
   echo "database: no existing database found or it is outdated."
   # check if there are any backups -- if so, let's restore
   # we could probably do better than just testing number of lines -- one line is just a heading, meaning no backups
-  if [[ $(envdir /etc/wal-e.d/env wal-e --terse backup-list | wc -l) -gt "1" ]]; then
+  BACKUP_LIST=$(envdir /etc/wal-e.d/env wal-e --terse backup-list) # if this fails, this script will exit
+  if [[ $(echo "$BACKUP_LIST" | wc -l) -gt "1" ]]; then
     echo "database: restoring from backup..."
     rm -rf $PG_DATA_DIR
     sudo -u postgres envdir /etc/wal-e.d/env wal-e backup-fetch $PG_DATA_DIR LATEST


### PR DESCRIPTION
This change separates the command responsible for getting a list of backups from the `wc -l` it is piped in to. This way, when the wal-e command fails, script pipefail is triggered and the boot script exits, as it should.

fixes #4748