### PR TITLE
fix(router): fix router common prefix app publishing

### DIFF
--- a/router/rootfs/etc/confd/templates/nginx.conf
+++ b/router/rootfs/etc/confd/templates/nginx.conf
@@ -409,7 +409,7 @@ http {
 
     #start k8s apps
     {{ range $k8namespace := lsdir "/registry/services/specs/" }}
-    {{ $k8appdir := printf "/registry/services/specs/%s" $k8namespace}}{{ range $kapp := ls $k8appdir }}
+    {{ $k8appdir := printf "/registry/services/specs/%s/" $k8namespace}}{{ range $kapp := ls $k8appdir }}
     {{ $k8appPath := printf "/registry/services/specs/%s/%s" $k8namespace $kapp}}{{ $k8Svc := json (getv $k8appPath) }}
     {{ $upstreams := printf "/registry/services/specs/%s/%s" $k8namespace $kapp}}
     upstream {{ if $k8Svc.metadata.labels.name }}{{ $k8Svc.metadata.labels.name }}{{ else }}{{ $k8Svc.metadata.name }}{{ end }} {


### PR DESCRIPTION
using k8s scheduler apps with names which share a common prefix, e.g.
myapp, myapp1, myapp2, failed to get published to the router component.
This fix enforces dir etcd listing of discovered apps. Without the fix,
when apps share a common prefix, multiple non existent entries are
returned causing confd failures.