### PR TITLE
feat(controller): add wildcard subdomain support

### DIFF
--- a/controller/api/urls.py
+++ b/controller/api/urls.py
@@ -45,7 +45,7 @@ urlpatterns = patterns(
     url(r"^apps/(?P<id>{})/containers/?".format(settings.APP_URL_REGEX),
         views.ContainerViewSet.as_view({'get': 'list'})),
     # application domains
-    url(r"^apps/(?P<id>{})/domains/(?P<domain>[-\._\w]+)/?".format(settings.APP_URL_REGEX),
+    url(r"^apps/(?P<id>{})/domains/(?P<domain>[-\._\w\*]+)/?".format(settings.APP_URL_REGEX),
         views.DomainViewSet.as_view({'delete': 'destroy'})),
     url(r"^apps/(?P<id>{})/domains/?".format(settings.APP_URL_REGEX),
         views.DomainViewSet.as_view({'post': 'create', 'get': 'list'})),


### PR DESCRIPTION
This alters the check for wildcard subdomains in the controller to not
explicitly disallow wildcard subdomains.  It adds some basic checks to
make sure the wildcard is at the start or end, as nginx doesn't support
wildcards anywhere else.  It also ensures that the wildcard domain can
not obstruct the deis controller domain, as nginx always prefers
wildcard domains over regex domains (which the controller uses).

I've been running wildcard domains in deis for some time by manually
adding them into etcd, so I'm reasonably confident that the controller
validation is the only thing preventing this from working.

This fixes #1608.

EDIT (@bacongobbler): also closes #4685