### PR TITLE
fix(logspout): handle k8s app:run logs

### DIFF
--- a/logspout/logspout.go
+++ b/logspout/logspout.go
@@ -110,6 +110,11 @@ func getLogParts(logline *Log) (string, string, string) {
 	if match != nil {
 		return match[1], match[2], logline.Data
 	}
+	// handle k8s runs
+	match = getMatch(`^k8s_([a-z0-9-]+)-[a-z0-9]+-run-[0-9]+\.[\da-f]+_[a-z0-9-]+-([a-z]+-[\da-z]*)_`, logline.Name)
+	if match != nil {
+		return match[1], match[2], logline.Data
+	}
 	if logline.Name == "deis-controller" {
 		data_match := getMatch(`^[A-Z]+ \[([a-z0-9-]+)\]: (.*)`, logline.Data)
 		if data_match != nil {


### PR DESCRIPTION
k8s containers created to serve app:run executions use a distinct name
which seems to differ from the one used for running apps. Logspout does
not match the run names and falls back to spitting out the raw log
message. This behaviour not only causes run logs to be missed but also
seems to cause logger service to freeze and stop any additional message
handling.