### PR TITLE
feat(database): supports HTTPs as S3 endpoint

### DIFF
--- a/database/templates/WALE_S3_ENDPOINT
+++ b/database/templates/WALE_S3_ENDPOINT
@@ -1,1 +1,1 @@
-http+path://{{ getv "/deis/store/gateway/host" }}:{{ getv "/deis/store/gateway/port" }}
+http{{ if eq (getv "/deis/store/gateway/port") "443"}}s{{ end }}+path://{{ getv "/deis/store/gateway/host" }}:{{ getv "/deis/store/gateway/port" }}


### PR DESCRIPTION
I use deis in stateless mode, in fact, in semi-stateless mode. It is not documented.

Here the situation:
- Standard stateless deployment
- Added a deis-database.service manually and necessary keys:
```
etcdctl set /deis/store/gateway/accessKey "key"
etcdctl set /deis/store/gateway/secretKey "secret"
etcdctl set /deis/store/gateway/host s3-eu-west-1.amazonaws.com
etcdctl set /deis/store/gateway/port 80
```
This working perfectly! Better than using RDS which is slower and really too expensive!

---

Everything worked properly in `v1.11.1` but not with latest version `v1.12.1`.

**Explanation:**
- Keys `/deis/store/gateway/*` are shared between `database` and `registry` component.
- https://github.com/deis/deis/commit/89027a8e725a5c5197230905708c2e1caaf433f0#diff-800e0a4a3663e2bebfb83d42572b310fR22 introduce `is_secure=True`
- Changed port `80` to `443`
- deis-database does not works with S3 SSL endpoint: https://github.com/deis/deis/blob/master/database/templates/WALE_S3_ENDPOINT#L1
   - `WALE_S3_ENDPOINT` = `http+path://s3-eu-west-1.amazonaws.com:443`
   - Obviously `Connection reset by peer` error appears

**Solution:**
- Add supports of `https` for WAL-E s3 endpoint when `/deis/store/gateway/port` is equal to `443`.