### PR TITLE
fix(tests): use and patch known "good" version of mock-s3

### DIFF
--- a/tests/fixtures/mock-store/Dockerfile
+++ b/tests/fixtures/mock-store/Dockerfile
@@ -8,5 +8,6 @@ EXPOSE 8888
 CMD ["/app/bin/boot"]
 ADD bin/boot /app/bin/boot
 
+ADD mock-s3-patch.diff /tmp/mock-s3-patch.diff
 ADD build.sh /tmp/build.sh
 RUN DOCKER_BUILD=true /tmp/build.sh

--- a/tests/fixtures/mock-store/build.sh
+++ b/tests/fixtures/mock-store/build.sh
@@ -23,10 +23,11 @@ apk add --update-cache \
 curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/get-deis/etcdctl-v0.4.9 \
   && chmod +x /usr/local/bin/etcdctl
 
-git clone https://github.com/jserver/mock-s3 /app/mock-s3 --depth 1
+git clone https://github.com/jserver/mock-s3 /app/mock-s3
 cd /app/mock-s3
-#FIXME: This is a gisted patch to enable pseudo-handling of POST requests, otherwise wal-e crashes attempting to delete old wal segments
-curl https://gist.githubusercontent.com/anonymous/c565f11a8d90d6e2d92b/raw/c5815f6c83aa5c2cfb7b0a34cfab4a075c97be16/mock-s3-post.diff|git apply
+#FIXME: This is a gisted patch to a known "good" version of mock-s3 to enable pseudo-handling of POST requests, otherwise wal-e crashes attempting to delete old wal segments
+git checkout 4c3c3752f990db97e8969c00666251a3b427ef4c
+git apply /tmp/mock-s3-patch.diff
 
 # install pip
 curl -sSL https://raw.githubusercontent.com/pypa/pip/7.0.3/contrib/get-pip.py | python -

--- a/tests/fixtures/mock-store/mock-s3-patch.diff
+++ b/tests/fixtures/mock-store/mock-s3-patch.diff
@@ -1,0 +1,14 @@
+diff --git a/mock_s3/main.py b/mock_s3/main.py
+index bd0307f..29c431a 100755
+--- a/mock_s3/main.py
++++ b/mock_s3/main.py
+@@ -65,6 +65,9 @@ class S3Handler(BaseHTTPRequestHandler):
+     def do_HEAD(self):
+         return self.do_GET()
+ 
++    def do_POST(self):
++        return self.do_GET()
++
+     def do_PUT(self):
+         parsed_path = urlparse.urlparse(self.path)
+         qs = urlparse.parse_qs(parsed_path.query, True)


### PR DESCRIPTION
This removes the download and application of a gisted diff during building of the mock-store test fixture.  Downloading this file has long resulted in intermittent 503s, and as of recently, have broken the build consistently because the diff no longer applies.

Even if this passes CI, we should still circle back to verify it does not affect #3128
