### PR TITLE
fix(controller): fix deployment issue when configuration value is int

### DIFF
--- a/controller/registry/dockerclient.py
+++ b/controller/registry/dockerclient.py
@@ -56,7 +56,7 @@ class DockerClient(object):
         """Add a "last-mile" layer of environment config to a Docker image for deis-registry."""
         check_blacklist(repo)
         env = ' '.join("{}='{}'".format(
-            k, v.encode('unicode-escape').replace("'", "\\'")) for k, v in config.viewitems())
+            k, str(v).encode('unicode-escape').replace("'", "\\'")) for k, v in config.viewitems())
         dockerfile = "FROM {}\nENV {}".format(source, env)
         f = io.BytesIO(dockerfile.encode('utf-8'))
         target_repo = "{}/{}:{}".format(self.registry, repo, tag)


### PR DESCRIPTION
When a project contained an integer valued configuration item, the controller exploded on deployments with:

```
Dec 18 05:56:49 deis1537340 sh[11424]: INFO app-name: build app-name-ecd079d created
Dec 18 05:56:50 deis1537340 sh[11424]: INFO app-name: release app-name-v201 created
Dec 18 05:56:50 deis1537340 sh[11424]: INFO [app-name]: croemmich deployed a12cad6
Dec 18 05:56:50 deis1537340 sh[11424]: INFO Pulling Docker image 192.168.167.235:5000/app-name:git-a12cad60
Dec 18 05:56:56 deis1537340 sh[11424]: INFO Tagging Docker image 192.168.167.235:5000/app-name:git-a12cad60 as app-name:git-a12cad60
Dec 18 05:56:56 deis1537340 sh[11424]: ERROR Internal Server Error: /v1/hooks/build
Dec 18 05:56:56 deis1537340 sh[11424]: Traceback (most recent call last):
Dec 18 05:56:56 deis1537340 sh[11424]: File "/usr/lib/python2.7/site-packages/django/core/handlers/base.py", line 112, in get_response
Dec 18 05:56:56 deis1537340 sh[11424]: response = wrapped_callback(request, *callback_args, **callback_kwargs)
Dec 18 05:56:56 deis1537340 sh[11424]: File "/usr/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 57, in wrapped_view
Dec 18 05:56:56 deis1537340 sh[11424]: return view_func(*args, **kwargs)
Dec 18 05:56:56 deis1537340 sh[11424]: File "/usr/lib/python2.7/site-packages/rest_framework/viewsets.py", line 85, in view
Dec 18 05:56:56 deis1537340 sh[11424]: return self.dispatch(request, *args, **kwargs)
Dec 18 05:56:56 deis1537340 sh[11424]: File "/usr/lib/python2.7/site-packages/rest_framework/views.py", line 407, in dispatch
Dec 18 05:56:56 deis1537340 sh[11424]: response = self.handle_exception(exc)
Dec 18 05:56:56 deis1537340 sh[11424]: File "/usr/lib/python2.7/site-packages/rest_framework/views.py", line 404, in dispatch
Dec 18 05:56:56 deis1537340 sh[11424]: response = handler(request, *args, **kwargs)
Dec 18 05:56:56 deis1537340 sh[11424]: File "/app/api/views.py", line 393, in create
Dec 18 05:56:56 deis1537340 sh[11424]: super(BuildHookViewSet, self).create(request, *args, **kwargs)
Dec 18 05:56:56 deis1537340 sh[11424]: File "/app/api/views.py", line 117, in create
Dec 18 05:56:56 deis1537340 sh[11424]: return super(BaseDeisViewSet, self).create(request, *args, **kwargs)
Dec 18 05:56:56 deis1537340 sh[11424]: File "/usr/lib/python2.7/site-packages/rest_framework/mixins.py", line 21, in create
Dec 18 05:56:56 deis1537340 sh[11424]: self.perform_create(serializer)
Dec 18 05:56:56 deis1537340 sh[11424]: File "/app/api/viewsets.py", line 21, in perform_create
Dec 18 05:56:56 deis1537340 sh[11424]: self.post_save(obj)
Dec 18 05:56:56 deis1537340 sh[11424]: File "/app/api/views.py", line 400, in post_save
Dec 18 05:56:56 deis1537340 sh[11424]: build.create(self.user)
Dec 18 05:56:56 deis1537340 sh[11424]: File "/app/api/models.py", line 760, in create
Dec 18 05:56:56 deis1537340 sh[11424]: source_version=source_version)
Dec 18 05:56:56 deis1537340 sh[11424]: File "/app/api/models.py", line 873, in new
Dec 18 05:56:56 deis1537340 sh[11424]: release.publish()
Dec 18 05:56:56 deis1537340 sh[11424]: File "/app/api/models.py", line 889, in publish
Dec 18 05:56:56 deis1537340 sh[11424]: publish_release(source_image, self.config.values, self.image, deis_registry)
Dec 18 05:56:56 deis1537340 sh[11424]: File "/app/registry/dockerclient.py", line 120, in publish_release
Dec 18 05:56:56 deis1537340 sh[11424]: return client.publish_release(source, config, target, deis_registry)
Dec 18 05:56:56 deis1537340 sh[11424]: File "/app/registry/dockerclient.py", line 50, in publish_release
Dec 18 05:56:56 deis1537340 sh[11424]: self.build(source, config, name, tag)
Dec 18 05:56:56 deis1537340 sh[11424]: File "/app/registry/dockerclient.py", line 59, in build
Dec 18 05:56:56 deis1537340 sh[11424]: k, v.encode('unicode-escape').replace("'", "\\'")) for k, v in config.viewitems())
Dec 18 05:56:56 deis1537340 sh[11424]: File "/app/registry/dockerclient.py", line 59, in <genexpr>
Dec 18 05:56:56 deis1537340 sh[11424]: k, v.encode('unicode-escape').replace("'", "\\'")) for k, v in config.viewitems())
Dec 18 05:56:56 deis1537340 sh[11424]: AttributeError: 'int' object has no attribute 'encode'
```

Example:
```
deis config:set -a app-name REDIS_PORT=6379
Creating config... Error: 
500 INTERNAL SERVER ERROR
<h1>Server Error (500)</h1>
```

This provides a simple fix by ensuring all configuration values are strings before calling encode.

