### PR TITLE
fix(tests): remove reference to python client

### DIFF
--- a/tests/bin/test-integration-aws.sh
+++ b/tests/bin/test-integration-aws.sh
@@ -195,6 +195,6 @@ until [ $IN_SERVICE -ge 1 ]; do
         | grep InService | wc -l)
 done
 
-log_phase "Running integration suite with Python Client"
+log_phase "Running integration test suite"
 
 time make test-integration

--- a/tests/bin/test-integration.sh
+++ b/tests/bin/test-integration.sh
@@ -81,6 +81,6 @@ deisctl config platform set sshPrivateKey=$DEIS_TEST_SSH_KEY
 time deisctl install platform
 time deisctl start platform
 
-log_phase "Running integration suite with Python Client"
+log_phase "Running integration test suite"
 
 time make test-integration


### PR DESCRIPTION
Since we're now using the golang client, printing that we were running the integration tests with the python client is wrong. :smiley: 