### PR TITLE
feat(router) make vhost_traffic_status_zone configurable

### DIFF
--- a/docs/customizing_deis/router_settings.rst
+++ b/docs/customizing_deis/router_settings.rst
@@ -78,6 +78,7 @@ setting                                      description
 /deis/router/sslSessionTickets               nginx ssl_session_tickets setting (default: on)
 /deis/router/sslSessionTimeout               nginx ssl_session_timeout setting (default: 10m)
 /deis/router/sslBufferSize                   nginx ssl_buffer_size setting (default: 4k)
+/deis/router/trafficStatusZoneSize           nginx vhost_traffic_status_zone size setting (default: 1m)
 /deis/router/workerProcesses                 nginx number of worker processes to start (default: auto i.e. available CPU cores)
 /deis/router/proxyProtocol                   nginx PROXY protocol enabled
 /deis/router/proxyRealIpCidr                 nginx IP with CIDR used by the load balancer in front of deis-router (default: 10.0.0.0/8)

--- a/router/rootfs/etc/confd/templates/nginx.conf
+++ b/router/rootfs/etc/confd/templates/nginx.conf
@@ -13,7 +13,7 @@ events {
 
 http {
     # basic settings
-    vhost_traffic_status_zone;
+    vhost_traffic_status_zone shared:vhost_traffic_status:{{ or (getv "/deis/router/trafficStatusZoneSize") "1m" }};
 
     sendfile on;
     tcp_nopush on;


### PR DESCRIPTION
This change makes the size in the `vhost_traffic_status_zone` directive
configurable. See also https://github.com/deis/deis/issues/4828.