### PR TITLE
Add metadata to linode cloud init template.

### DIFF
--- a/contrib/linode/linode-user-data-template.yaml
+++ b/contrib/linode/linode-user-data-template.yaml
@@ -2,7 +2,7 @@
 hostname: $hostname
 coreos:
   fleet:
-    metadata: name=%H
+    metadata: name=%H,controlPlane=true,dataPlane=true,routerMesh=true
   units:
   - name: 00-eth0.network
     runtime: true


### PR DESCRIPTION
In order to allow for "separating of the planes", and to keep up with `/contrib/coreos`, I added the proper metadata tags to `/contrib/linode`.

Without this addition, when you set `deisctl config platform set enablePlacementOptions=true`, you will be unable to perform the deis platform installation because none of the deis components will be able to be placed.