### PR TITLE
feat(contrib/linode): allow for cluster expansion and standardize scripts

### DIFF
--- a/contrib/linode/apply-firewall.py
+++ b/contrib/linode/apply-firewall.py
@@ -4,60 +4,60 @@ Apply a "Security Group" to the members of an etcd cluster.
 
 Usage: apply-firewall.py
 """
-import os
 import re
 import string
 import argparse
+import threading
 from threading import Thread
 import uuid
 
-import colorama
-from colorama import Fore, Style
 import paramiko
 import requests
 import sys
 import yaml
 
+from linodeapi import LinodeApiCommand
+import linodeutils 
 
-def get_nodes_from_args(args):
-    if args.discovery_url is not None:
-        return get_nodes_from_discovery_url(args.discovery_url)
-
-    return get_nodes_from_discovery_url(get_discovery_url_from_user_data())
+class FirewallCommand(LinodeApiCommand):
 
 
-def get_nodes_from_discovery_url(discovery_url):
-    try:
-        nodes = []
-        json = requests.get(discovery_url).json()
-        discovery_nodes = json['node']['nodes']
-        for node in discovery_nodes:
-            value = node['value']
-            ip = re.search('([0-9]{1,3}\.){3}[0-9]{1,3}', value).group(0)
-            nodes.append(ip)
-        return nodes
-    except:
-        raise IOError('Could not load nodes from discovery url ' + discovery_url)
+    def get_nodes_from_args(self):
+        if not self.discovery_url:
+            self.discovery_url = self.get_discovery_url_from_user_data()
+        return self.get_nodes_from_discovery_url(self.discovery_url)
+    
+    def get_nodes_from_discovery_url(self, discovery_url):
+        try:
+            nodes = []
+            json = requests.get(discovery_url).json()
+            discovery_nodes = json['node']['nodes']
+            for node in discovery_nodes:
+                value = node['value']
+                ip = re.search('([0-9]{1,3}\.){3}[0-9]{1,3}', value).group(0)
+                nodes.append(ip)
+            return nodes
+        except:
+            raise IOError('Could not load nodes from discovery url ' + discovery_url)
 
 
-def get_discovery_url_from_user_data():
-    name = 'linode-user-data.yaml'
-    log_info('Loading discovery url from ' + name)
-    try:
-        current_dir = os.path.dirname(__file__)
-        user_data_file = file(os.path.abspath(os.path.join(current_dir, name)), 'r')
-        user_data_yaml = yaml.safe_load(user_data_file)
-        return user_data_yaml['coreos']['etcd2']['discovery']
-    except:
-        raise IOError('Could not load discovery url from ' + name)
+    def get_discovery_url_from_user_data(self):
+        name = 'linode-user-data.yaml'
+        linodeutils.log_info('Loading discovery url from ' + name)
+        try:
+            user_data_file = linodeutils.get_file(name)
+            user_data_yaml = yaml.safe_load(user_data_file)
+            return user_data_yaml['coreos']['etcd2']['discovery']
+        except:
+            raise IOError('Could not load discovery url from ' + name)
 
 
-def validate_ip_address(ip):
-    return True if re.match('([0-9]{1,3}\.){3}[0-9]{1,3}', ip) else False
+    def validate_ip_address(self, ip):
+        return True if re.match('([0-9]{1,3}\.){3}[0-9]{1,3}', ip) else False
 
 
-def get_firewall_contents(node_ips, private=False, adding_new_nodes=False):
-    rules_template_text = """*filter
+    def get_firewall_contents(self, node_ips):
+        rules_template_text = """*filter
 :INPUT DROP [0:0]
 :FORWARD DROP [0:0]
 :OUTPUT ACCEPT [0:0]
@@ -84,132 +84,135 @@ def get_firewall_contents(node_ips, private=False, adding_new_nodes=False):
 COMMIT
 """
 
-    multiport_private = ' -s 192.168.0.0/16' if private else ''
-    add_new_nodes = ',2379,2380' if adding_new_nodes else ''
-
-    rules_template = string.Template(rules_template_text)
-    return rules_template.substitute(node_ips=string.join(node_ips, ','), multiport_private=multiport_private, add_new_nodes=add_new_nodes)
-
-
-def apply_rules_to_all(host_ips, rules, private_key):
-    pkey = detect_and_create_private_key(private_key)
-
-    threads = []
-    for ip in host_ips:
-        t = Thread(target=apply_rules, args=(ip, rules, pkey))
-        t.setDaemon(False)
-        t.start()
-        threads.append(t)
-    for thread in threads:
-        thread.join()
+        multiport_private = ' -s 192.168.0.0/16' if self.private else ''
+        add_new_nodes = ',2379,2380' if self.adding_new_nodes else ''
+        
+        rules_template = string.Template(rules_template_text)
+        return rules_template.substitute(node_ips=string.join(node_ips, ','), multiport_private=multiport_private, add_new_nodes=add_new_nodes)
 
 
-def detect_and_create_private_key(private_key):
-    private_key_text = private_key.read()
-    private_key.seek(0)
-    if '-----BEGIN RSA PRIVATE KEY-----' in private_key_text:
-        return paramiko.RSAKey.from_private_key(private_key)
-    elif '-----BEGIN DSA PRIVATE KEY-----' in private_key_text:
-        return paramiko.DSSKey.from_private_key(private_key)
-    else:
-        raise ValueError('Invalid private key file ' + private_key.name)
+    def apply_rules_to_all(self, host_ips, rules):
+        pkey = self.detect_and_create_private_key()
+        
+        threads = []
+        for ip in host_ips:
+            t = Thread(target=self.apply_rules, args=(ip, rules, pkey))
+            t.setDaemon(False)
+            t.start()
+            threads.append(t)
+        for thread in threads:
+            thread.join()
 
 
-def apply_rules(host_ip, rules, private_key):
-    # connect to the server via ssh
-    ssh = paramiko.SSHClient()
-    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    ssh.connect(host_ip, username='core', allow_agent=False, look_for_keys=False, pkey=private_key)
+    def detect_and_create_private_key(self):
+        private_key_text = self.private_key.read()
+        self.private_key.seek(0)
+        if '-----BEGIN RSA PRIVATE KEY-----' in private_key_text:
+            return paramiko.RSAKey.from_private_key(self.private_key)
+        elif '-----BEGIN DSA PRIVATE KEY-----' in private_key_text:
+            return paramiko.DSSKey.from_private_key(self.private_key)
+        else:
+            raise ValueError('Invalid private key file ' + self.private_key.name)
 
-    # copy the rules to the temp directory
-    temp_file = '/tmp/' + str(uuid.uuid4())
 
-    ssh.open_sftp()
-    sftp = ssh.open_sftp()
-    sftp.open(temp_file, 'w').write(rules)
+    def apply_rules(self, host_ip, rules, private_key):
+        # connect to the server via ssh
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        ssh.connect(host_ip, username='core', allow_agent=False, look_for_keys=False, pkey=private_key)
 
-    # move the rules in to place and enable and run the iptables-restore.service
-    commands = [
-        'sudo mv ' + temp_file + ' /var/lib/iptables/rules-save',
-        'sudo chown root:root /var/lib/iptables/rules-save',
-        'sudo systemctl enable iptables-restore.service',
-        'sudo systemctl start iptables-restore.service'
-    ]
+        # copy the rules to the temp directory
+        temp_file = '/tmp/' + str(uuid.uuid4())
 
-    for command in commands:
-        stdin, stdout, stderr = ssh.exec_command(command)
-        stdout.channel.recv_exit_status()
+        ssh.open_sftp()
+        sftp = ssh.open_sftp()
+        sftp.open(temp_file, 'w').write(rules)
 
-    ssh.close()
+        # move the rules in to place and enable and run the iptables-restore.service
+        commands = [
+            'sudo mv ' + temp_file + ' /var/lib/iptables/rules-save',
+            'sudo chown root:root /var/lib/iptables/rules-save',
+            'sudo systemctl enable iptables-restore.service',
+            'sudo systemctl start iptables-restore.service'
+        ]
 
-    log_success('Applied rule to ' + host_ip)
+        for command in commands:
+            stdin, stdout, stderr = ssh.exec_command(command)
+            stdout.channel.recv_exit_status()
+
+        ssh.close()
+
+        linodeutils.log_success('Applied rule to ' + host_ip)
+
+    def acquire_linode_ips(self):
+        linodeutils.log_info('Getting info for Linodes from display group: ' + self.node_display_group)
+        deis_grp = self.request('linode.list')
+        deis_linodeids = [l.get('LINODEID','') for l in deis_grp if l.get('LPM_DISPLAYGROUP', '') == self.node_display_group]
+        deis_grp_ips = self.request('linode.ip.list')
+        self.deis_privateips = [ip.get('IPADDRESS','') for ip in deis_grp_ips if (ip.get('LINODEID','') in deis_linodeids) and (ip.get('ISPUBLIC', 1) == 0)]
+        self.deis_publicips = [ip.get('IPADDRESS','') for ip in deis_grp_ips if (ip.get('LINODEID','') in deis_linodeids) and (ip.get('ISPUBLIC', 0) == 1)]
+
+    def run(self):
+        #NOTE: defaults to using display group, then manual input (via nodes/hosts), then discovery_url
+        if self.node_display_group:
+            self.acquire_linode_ips()
+            nodes = self.deis_privateips
+            hosts = self.deis_publicips
+        else:
+            nodes = self.nodes if self.nodes is not None else self.get_nodes_from_args()
+            hosts = self.hosts if self.hosts is not None else nodes
+
+        node_ips = []
+        for ip in nodes:
+            if self.validate_ip_address(ip):
+                node_ips.append(ip)
+            else:
+                linodeutils.log_warning('Invalid IP will not be added to security group: ' + ip)
+
+        if not len(node_ips) > 0:
+            raise ValueError('No valid IP addresses in security group.')
+
+        host_ips = []
+        for ip in hosts:
+            if self.validate_ip_address(ip):
+                host_ips.append(ip)
+            else:
+                linodeutils.log_warning('Host has invalid IP address: ' + ip)
+
+        if not len(host_ips) > 0:
+            raise ValueError('No valid host addresses.')
+
+        linodeutils.log_info('Generating iptables rules...')
+        rules = self.get_firewall_contents(node_ips)
+        linodeutils.log_success('Generated rules:')
+        linodeutils.log_debug(rules)
+        
+        linodeutils.log_info('Applying rules...')
+        self.apply_rules_to_all(host_ips, rules)
+        linodeutils.log_success('Done!')
 
 
 def main():
-    colorama.init()
+    linodeutils.init()
 
     parser = argparse.ArgumentParser(description='Apply a "Security Group" to a Deis cluster')
+    parser.add_argument('--api-key', dest='linode_api_key', help='Linode API Key')
     parser.add_argument('--private-key', required=True, type=file, dest='private_key', help='Cluster SSH Private Key')
     parser.add_argument('--private', action='store_true', dest='private', help='Only allow access to the cluster from the private network')
     parser.add_argument('--adding-new-nodes', action='store_true', dest='adding_new_nodes', help='When adding new nodes to existing cluster, allows access to etcd')
     parser.add_argument('--discovery-url', dest='discovery_url', help='Etcd discovery url')
-    parser.add_argument('--hosts', nargs='+', dest='hosts', help='The public IP addresses of the hosts to apply rules to')
+    parser.add_argument('--display-group', required=False, dest='node_display_group', help='Display group (used for Linode IP discovery).')
+    parser.add_argument('--hosts', nargs='+', dest='hosts', help='The public IP addresses of the hosts to apply rules to (for ssh)')
+    parser.add_argument('--nodes', nargs='+', dest='nodes', help='The private IP addresses of the hosts (for iptable setup)')
+    parser.set_defaults(cmd=FirewallCommand)
+    
     args = parser.parse_args()
-
-    nodes = get_nodes_from_args(args)
-    hosts = args.hosts if args.hosts is not None else nodes
-
-    node_ips = []
-    for ip in nodes:
-        if validate_ip_address(ip):
-            node_ips.append(ip)
-        else:
-            log_warning('Invalid IP will not be added to security group: ' + ip)
-
-    if not len(node_ips) > 0:
-        raise ValueError('No valid IP addresses in security group.')
-
-    host_ips = []
-    for ip in hosts:
-        if validate_ip_address(ip):
-            host_ips.append(ip)
-        else:
-            log_warning('Host has invalid IP address: ' + ip)
-
-    if not len(host_ips) > 0:
-        raise ValueError('No valid host addresses.')
-
-    log_info('Generating iptables rules...')
-    rules = get_firewall_contents(node_ips, args.private, args.adding_new_nodes)
-    log_success('Generated rules:')
-    log_debug(rules)
-
-    log_info('Applying rules...')
-    apply_rules_to_all(host_ips, rules, args.private_key)
-    log_success('Done!')
-
-def log_debug(message):
-    print(Style.DIM + Fore.MAGENTA + message + Fore.RESET + Style.RESET_ALL)
-
-
-def log_info(message):
-    print(Fore.CYAN + message + Fore.RESET)
-
-
-def log_warning(message):
-    print(Fore.YELLOW + message + Fore.RESET)
-
-
-def log_success(message):
-    print(Style.BRIGHT + Fore.GREEN + message + Fore.RESET + Style.RESET_ALL)
-
-
-def log_error(message):
-    print(Style.BRIGHT + Fore.RED + message + Fore.RESET + Style.RESET_ALL)
-
+    cmd = args.cmd(args)
+    args.cmd(args).run()
+    
 if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        log_error(e.message)
+        linodeutils.log_error(e.message)
         sys.exit(1)

--- a/contrib/linode/create-linode-user-data.py
+++ b/contrib/linode/create-linode-user-data.py
@@ -6,39 +6,40 @@ Usage: create-linode-user-data.py
 """
 import base64
 import sys
-import os
-import collections
 import argparse
 
 import yaml
-import colorama
-from colorama import Fore, Style
 import requests
+import linodeutils
 
 
-def combine_dicts(orig_dict, new_dict):
-    for key, val in new_dict.iteritems():
-        if isinstance(val, collections.Mapping):
-            tmp = combine_dicts(orig_dict.get(key, {}), val)
-            orig_dict[key] = tmp
-        elif isinstance(val, list):
-            orig_dict[key] = (orig_dict.get(key, []) + val)
-        else:
-            orig_dict[key] = new_dict[key]
-    return orig_dict
+def validate_public_key(key):
+    try:
+        type, key_string, comment = key.split()
+        data = base64.decodestring(key_string)
+        return data[4:11] == type
+    except:
+        return False
 
 
-def get_file(name, mode="r", abspath=False):
-    current_dir = os.path.dirname(__file__)
+def generate_etcd_token():
+    linodeutils.log_info('Generating new Etcd token...')
+    data = requests.get('https://discovery.etcd.io/new').text
+    token = data.replace('https://discovery.etcd.io/', '')
+    linodeutils.log_success('Generated new token: ' + token)
+    return token
 
-    if abspath:
-        return file(os.path.abspath(os.path.join(current_dir, name)), mode)
-    else:
-        return file(os.path.join(current_dir, name), mode)
+
+def validate_etcd_token(token):
+    try:
+        int(token, 16)
+        return True
+    except:
+        return False
 
 
 def main():
-    colorama.init()
+    linodeutils.init()
 
     parser = argparse.ArgumentParser(description='Create Linode User Data')
     parser.add_argument('--public-key', action='append', required=True, type=file, dest='public_key_files', help='Authorized SSH Keys')
@@ -58,14 +59,14 @@ def main():
         if validate_public_key(public_key):
             public_keys.append(public_key)
         else:
-            log_warning('Invalid public key: ' + public_key_file.name)
+            linodeutils.log_warning('Invalid public key: ' + public_key_file.name)
 
     if not len(public_keys) > 0:
         raise ValueError('Must supply at least one valid public key')
 
-    linode_user_data = get_file("linode-user-data.yaml", "w", True)
-    linode_template = get_file("linode-user-data-template.yaml")
-    coreos_template = get_file("../coreos/user-data.example")
+    linode_user_data = linodeutils.get_file("linode-user-data.yaml", "w", True)
+    linode_template = linodeutils.get_file("linode-user-data-template.yaml")
+    coreos_template = linodeutils.get_file("../coreos/user-data.example")
 
     coreos_template_string = coreos_template.read()
     coreos_template_string = coreos_template_string.replace('#DISCOVERY_URL', 'https://discovery.etcd.io/' + str(etcd_token))
@@ -73,60 +74,18 @@ def main():
     configuration_linode_template = yaml.safe_load(linode_template)
     configuration_coreos_template = yaml.safe_load(coreos_template_string)
 
-    configuration = combine_dicts(configuration_coreos_template, configuration_linode_template)
+    configuration = linodeutils.combine_dicts(configuration_coreos_template, configuration_linode_template)
     configuration['ssh_authorized_keys'] = public_keys
 
     dump = yaml.dump(configuration, default_flow_style=False, default_style='|')
 
     with linode_user_data as outfile:
         outfile.write("#cloud-config\n\n" + dump)
-        log_success('Wrote Linode user data to ' + linode_user_data.name)
-
-
-def validate_public_key(key):
-    try:
-        type, key_string, comment = key.split()
-        data = base64.decodestring(key_string)
-        return data[4:11] == type
-    except:
-        return False
-
-
-def generate_etcd_token():
-    log_info('Generating new Etcd token...')
-    data = requests.get('https://discovery.etcd.io/new').text
-    token = data.replace('https://discovery.etcd.io/', '')
-    log_success('Generated new token: ' + token)
-    return token
-
-
-def validate_etcd_token(token):
-    try:
-        int(token, 16)
-        return True
-    except:
-        return False
-
-
-def log_info(message):
-    print(Fore.CYAN + message + Fore.RESET)
-
-
-def log_warning(message):
-    print(Fore.YELLOW + message + Fore.RESET)
-
-
-def log_success(message):
-    print(Style.BRIGHT + Fore.GREEN + message + Fore.RESET + Style.RESET_ALL)
-
-
-def log_error(message):
-    print(Style.BRIGHT + Fore.RED + message + Fore.RESET + Style.RESET_ALL)
-
+        linodeutils.log_success('Wrote Linode user data to ' + linode_user_data.name)
 
 if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        log_error(e.message)
+        linodeutils.log_error(e.message)
         sys.exit(1)

--- a/contrib/linode/linodeapi.py
+++ b/contrib/linode/linodeapi.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""
+Provides a class for Linode API commands
+
+Usage: used by other files as a base class
+"""
+import requests
+import threading
+from colorama import Fore, Style
+
+
+class LinodeApiCommand:
+    def __init__(self, arguments):
+        self._arguments = vars(arguments)
+        self._linode_api_key = arguments.linode_api_key if arguments.linode_api_key is not None else '' 
+
+    def __getattr__(self, name):
+        return self._arguments.get(name)
+
+    def request(self, action, **kwargs):
+        data = ''
+        if self._linode_api_key:
+            kwargs['params'] = dict({'api_key': self._linode_api_key, 'api_action': action}.items() + kwargs.get('params', {}).items())
+            response = requests.request('get', 'https://api.linode.com/api/', **kwargs)
+
+            json = response.json()
+            errors = json.get('ERRORARRAY', [])
+            data = json.get('DATA')
+
+            if len(errors) > 0:
+                raise IOError(str(errors))
+        else:
+            self.info('Linode api key not provided. Please provide at the start of script to perform this function.')
+            
+        return data
+
+
+    def run(self):
+        raise NotImplementedError
+
+    def info(self, message):
+        print(Fore.MAGENTA + threading.current_thread().name + ': ' + Fore.CYAN + message + Fore.RESET)
+
+    def success(self, message):
+        print(Fore.MAGENTA + threading.current_thread().name + ': ' + Fore.GREEN + message + Fore.RESET)

--- a/contrib/linode/linodeutils.py
+++ b/contrib/linode/linodeutils.py
@@ -1,0 +1,79 @@
+from colorama import Fore, Style
+import colorama
+import collections
+import os
+
+
+def log_debug(message):
+    print(Style.DIM + Fore.MAGENTA + message + Fore.RESET + Style.RESET_ALL)
+
+
+def log_info(message):
+    print(Fore.CYAN + message + Fore.RESET)
+
+
+def log_warning(message):
+    print(Fore.YELLOW + message + Fore.RESET)
+
+
+def log_success(message):
+    print(Style.BRIGHT + Fore.GREEN + message + Fore.RESET + Style.RESET_ALL)
+
+def log_minor_success(message):
+    print(Fore.GREEN + message + Fore.RESET + Style.RESET_ALL)
+
+def log_error(message):
+    print(Style.BRIGHT + Fore.RED + message + Fore.RESET + Style.RESET_ALL)
+
+    
+''' See provision-cluster.py in method ProvisionCommand._report_created for 
+    an example of use. Each row should be a string tuple. rows is a list of 
+    tuples. '''
+def log_table(rows, header_msg, footer_msg):
+    
+    # set up the report constants
+    divider = Style.BRIGHT + Fore.MAGENTA + ('=' * 109) + Fore.RESET + Style.RESET_ALL
+    column_format = "  {:<20} {:<20} {:<20} {:<20} {:<12} {:>8}"
+    formatted_header = column_format.format(*('HOSTNAME', 'PUBLIC IP', 'PRIVATE IP', 'GATEWAY', 'DC', 'PLAN'))
+    
+    # display the report
+    print('')
+    print(divider)
+    print(divider)
+    print('')
+    print(Style.BRIGHT + Fore.LIGHTGREEN_EX + header_msg + Fore.RESET + Style.RESET_ALL)
+    print('')
+    print(Style.BRIGHT + Fore.CYAN + formatted_header + Fore.RESET + Style.RESET_ALL)
+    for row in rows:
+        print(Fore.CYAN + column_format.format(*row) + Fore.RESET)
+    print('')
+    print('')
+    print(Fore.LIGHTYELLOW_EX + footer_msg + Fore.RESET)
+    print(divider)
+    print(divider)
+    print('')
+
+
+def combine_dicts(orig_dict, new_dict):
+    for key, val in new_dict.iteritems():
+        if isinstance(val, collections.Mapping):
+            tmp = combine_dicts(orig_dict.get(key, {}), val)
+            orig_dict[key] = tmp
+        elif isinstance(val, list):
+            orig_dict[key] = (orig_dict.get(key, []) + val)
+        else:
+            orig_dict[key] = new_dict[key]
+    return orig_dict
+
+
+def get_file(name, mode="r", abspath=False):
+    current_dir = os.path.dirname(__file__)
+
+    if abspath:
+        return file(os.path.abspath(os.path.join(current_dir, name)), mode)
+    else:
+        return file(os.path.join(current_dir, name), mode)
+
+    
+def init():
+    colorama.init()

--- a/docs/installing_deis/linode.rst
+++ b/docs/installing_deis/linode.rst
@@ -180,17 +180,29 @@ each host. To do so, run:
 
     $ ./apply-firewall.py --private-key /path/to/key/deis --hosts 1.2.3.4 11.22.33.44 111.222.33.44
 
+    
+Or, you can provide the display group (NOTE: the default display group is ``deis``) to search for the
+nodes using the Linode API, by running:
 
-The script will use the etcd discovery url in the generated ``linode-user-data.yaml`` file or the value of the
-discovery-url argument, if provided, to find all of the nodes in your cluster and create iptables rules to allow
-connections between nodes while blocking outside connections automatically. Full command usage:
+.. code-block:: console
+
+    $ ./apply-firewall.py --private-key /path/to/key/deis --api-key YOUR_LINODE_API_KEY --display-group YOUR_DISPLAY_GROUP
+
+
+The script will use either the Linode API or the etcd discovery url to find all of the nodes in your
+cluster and create iptables rules to allow connections between nodes while blocking outside connections
+automatically. Note that when discovering node ips, the ``--display-group`` parameter has highest priority,
+then manual specification via ``--nodes`` and ``--hosts`` (i.e. public and private ips), then the etcd
+discovery url via parameter ``--display-url`` or the ``linode-user-data.yaml`` file. Full command usage:
 
 .. code-block:: console
 
     usage: apply-firewall.py [-h] --private-key PRIVATE_KEY [--private]
                              [--adding-new-nodes]
                              [--discovery-url DISCOVERY_URL]
+                             [--display-group DISPLAY_GROUP]
                              [--hosts HOSTS [HOSTS ...]]
+                             [--nodes HOSTS [HOSTS ...]]
 
     Apply a "Security Group" to a Deis cluster
 
@@ -200,11 +212,15 @@ connections between nodes while blocking outside connections automatically. Full
                             Cluster SSH Private Key
       --private             Only allow access to the cluster from the private
                             network
-      --adding-new-nodes    When adding new nodes to existing cluster, allows access to etcd                      
+      --adding-new-nodes    When adding new nodes to existing cluster, allows access to etcd
+      --display-group DISPLAY_GROUP
+                            Linode display group for nodes 
       --discovery-url DISCOVERY_URL
                             Etcd discovery url
       --hosts HOSTS [HOSTS ...]
-                            The IP addresses of the hosts to apply rules to
+                            The public IP addresses of the hosts
+      --nodes HOSTS [HOSTS ...]
+                            The private IP addresses of the hosts 
 
 
 Install Deis Platform
@@ -217,20 +233,23 @@ start installing the platform.
 Adding Nodes to an Existing Cluster
 -----------------------------------
 
-When adding one or more nodes to an existing CoreOS setup, ``etcd`` requires access to ports 2379
-and 2380. 
+When adding one or more nodes to an existing CoreOS setup, ``etcd`` will be `added as a proxy to
+the existing cluster`_. The setup of a proxy requires access to ports 2379 and 2380 of the existing
+nodes in the cluster.
 
-When adding nodes to the cluster, before cluster provisioning, run:
+In order to open up these ports, before cluster provisioning, run:
 
 .. code-block:: console
 
-    $ ./apply-firewall.py --private-key /path/to/key/deis --hosts 1.2.3.4 11.22.33.44 111.222.33.44 --adding-new-nodes
+    $ ./apply-firewall.py --private-key /path/to/key/deis --hosts 1.2.3.4 11.22.33.44 111.222.33.44
+                          --adding-new-nodes
 
     
-Then provision the cluster as described above and apply security groups settings using ``./apply-firewall.py``
-without the ``--adding-new-nodes`` parameter.
+Then provision the cluster as described above and afterwards reapply the firewall using
+``./apply-firewall.py`` without the ``--adding-new-nodes`` parameter.
 
 
+.. _`added as a proxy to the existing cluster`: https://coreos.com/etcd/docs/latest/clustering.html#public-etcd-discovery-service
 .. _`contrib/linode`: https://github.com/deis/deis/tree/master/contrib/linode
 .. _`Linode Account Settings`: https://manager.linode.com/account/settings
 .. _`Linode API Keys`: https://manager.linode.com/profile/api

--- a/docs/installing_deis/linode.rst
+++ b/docs/installing_deis/linode.rst
@@ -188,6 +188,7 @@ connections between nodes while blocking outside connections automatically. Full
 .. code-block:: console
 
     usage: apply-firewall.py [-h] --private-key PRIVATE_KEY [--private]
+                             [--adding-new-nodes]
                              [--discovery-url DISCOVERY_URL]
                              [--hosts HOSTS [HOSTS ...]]
 
@@ -199,6 +200,7 @@ connections between nodes while blocking outside connections automatically. Full
                             Cluster SSH Private Key
       --private             Only allow access to the cluster from the private
                             network
+      --adding-new-nodes    When adding new nodes to existing cluster, allows access to etcd                      
       --discovery-url DISCOVERY_URL
                             Etcd discovery url
       --hosts HOSTS [HOSTS ...]
@@ -212,7 +214,25 @@ Now that you've finished provisioning a cluster, please refer to :ref:`install_d
 start installing the platform.
 
 
+Adding Nodes to an Existing Cluster
+-----------------------------------
+
+When adding one or more nodes to an existing CoreOS setup, ``etcd`` requires access to ports 2379
+and 2380. 
+
+When adding nodes to the cluster, before cluster provisioning, run:
+
+.. code-block:: console
+
+    $ ./apply-firewall.py --private-key /path/to/key/deis --hosts 1.2.3.4 11.22.33.44 111.222.33.44 --adding-new-nodes
+
+    
+Then provision the cluster as described above and apply security groups settings using ``./apply-firewall.py``
+without the ``--adding-new-nodes`` parameter.
+
+
 .. _`contrib/linode`: https://github.com/deis/deis/tree/master/contrib/linode
 .. _`Linode Account Settings`: https://manager.linode.com/account/settings
 .. _`Linode API Keys`: https://manager.linode.com/profile/api
 .. _`pip`: https://pip.pypa.io/en/stable/
+


### PR DESCRIPTION
1. I added the option to open ports 2379 and 2380 during cluster expansion. This is useful due to [the new nodes being added as proxies within etcd when using a public discovery URL that has reached it's size limit](https://coreos.com/etcd/docs/latest/clustering.html#public-etcd-discovery-service).
2. I standardized and normalized the python functions used during CoreOS provisioning (i.e. Linode API calls and logging).
3. I added multiple methods of providing IPs when applying a firewall to the cluster. Namely, IPs can now be provided via a Linode display-group, manually, or using the discovery URL. This is useful particularly when running this command outside of the CoreOS cluster, but also when adding nodes to an existing cluster because (as noted above) the new nodes will be added as proxies within etcd and will not be included in the information provided by the public discovery URL.
4. Updated the docs accordingly. 

None of these are breaking changes. Please let me know if you need any changes or have any questions, and I will be happy to oblige. 