### PR TITLE
fix(controller): legacy fix should modify dict instead of dict view

### DIFF
--- a/controller/scheduler/fleet.py
+++ b/controller/scheduler/fleet.py
@@ -152,7 +152,7 @@ class FleetHTTPClient(AbstractSchedulerClient):
         tags = kwargs.get('tags', {})
         unit_tags = tags.viewitems()
         if settings.ENABLE_PLACEMENT_OPTIONS in ['true', 'True', 'TRUE', '1']:
-            unit_tags['dataPlane'] = 'true'
+            tags['dataPlane'] = 'true'
         if unit_tags:
             tagset = ' '.join(['"{}={}"'.format(k, v) for k, v in unit_tags])
             unit.append({"section": "X-Fleet", "name": "MachineMetadata",


### PR DESCRIPTION
When trying to modify the unit_tags, the following error occurs:
`TypeError: dict_items object does not support item assignment`.
This is because it is a view and not a dict. You have to modify
the dict directly in order for this to work.