### PR TITLE
fix(client): fixed a bug, if controller-host with port

### DIFF
--- a/client/pkg/git/git.go
+++ b/client/pkg/git/git.go
@@ -108,6 +108,9 @@ func findRemote(host string) (string, error) {
 // RemoteURL returns the git URL of app.
 func RemoteURL(host, appID string) string {
 	// Go by Example - URL Parsing: https://gobyexample.com/url-parsing
-	domain, _, _ := net.SplitHostPort(host)
+	domain, _, err := net.SplitHostPort(host)
+	if (err != nil) {
+		domain = host
+	}
 	return fmt.Sprintf("ssh://git@%s:2222/%s.git", domain, appID)
 }

--- a/includes.mk
+++ b/includes.mk
@@ -57,7 +57,7 @@ check-deisctl:
 	fi
 
 define check-static-binary
-  @if file $(1) | egrep -q "(statically linked|Mach-O)"; then \
+  if file $(1) | egrep -q "(statically linked|Mach-O)"; then \
     echo -n ""; \
   else \
     echo "The binary file $(1) is not statically linked. Build canceled"; \

--- a/includes.mk
+++ b/includes.mk
@@ -57,7 +57,7 @@ check-deisctl:
 	fi
 
 define check-static-binary
-  if file $(1) | egrep -q "(statically linked|Mach-O)"; then \
+  @if file $(1) | egrep -q "(statically linked|Mach-O)"; then \
     echo -n ""; \
   else \
     echo "The binary file $(1) is not statically linked. Build canceled"; \


### PR DESCRIPTION
fix(client): fixed a bug, if controller-host with port

if router use load balancers: `80->8080`, my controller host url is `http://deis.xxxx.com:8080`
`deis apps:create hehe`
will bad:
```
Git remote deis added
remote available at ssh://git@deis.35d570d5.xxx.com:8080:2222/hehe.git
```
is a bug, I'm fixed