### PR TITLE
docs(managing_deis): add workaround for cephless cluster

### DIFF
--- a/docs/managing_deis/running-deis-without-ceph.rst
+++ b/docs/managing_deis/running-deis-without-ceph.rst
@@ -41,7 +41,7 @@ ships these to the :ref:`logger` component.  By default, the logger writes the
 logs to a distributed Ceph filesystem. These logs can then be fetched by the
 :ref:`controller` component via HTTP.
 
-In a Ceph-less clutser, the Logger component should be configured, instead, to
+In a Ceph-less cluster, the Logger component should be configured, instead, to
 use in-memory log storage.  Optionally, a drain may also be configured to forward
 logs to an external log service (such as Papertrail) for longer-term archival.
 
@@ -119,6 +119,13 @@ S3 store configuration sample:
                                   s3path=/ \
                                   s3encrypt=false \
                                   s3secure=false
+
+Due to `issue 4568`_, you'll also need to run the following to ensure confd will template out the
+registry's configuration:
+
+.. code-block:: console
+
+    $ deisctl config store set gateway=' '
 
 By default, the registry will try to authenticate to S3 using the instance role.
 If your cluster is not running on EC2, you can supply hard coded API access and
@@ -218,5 +225,6 @@ When following the :ref:`upgrading-deis` documentation, be sure to use
 .. _`Amazon RDS`: http://aws.amazon.com/rds/
 .. _`Amazon S3`: http://aws.amazon.com/s3/
 .. _`Arne-Christian Blystad`: https://github.com/blystad
+.. _`issue 4568`: https://github.com/deis/deis/issues/4568
 .. _`Papertrail`: https://papertrailapp.com/
 .. _`Swift3`: https://github.com/openstack/swift3


### PR DESCRIPTION
The registry will fail to template the config if /deis/store/gateway
is not set. This workaround works for users running Deis v1 without
Ceph.

closes #4568