### PR TITLE
fix(logspout): Truncate lines too big for a single UDP packet

### DIFF
--- a/tests/apps_test.go
+++ b/tests/apps_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/deis/deis/tests/utils"
 )
@@ -27,6 +29,9 @@ var (
 )
 
 func randomString(n int) string {
+	// Be sure we've seeded the random number generator, otherwise we could get the same string
+	// every time.
+	rand.Seed(time.Now().UnixNano())
 	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	b := make([]rune, n)
 	for i := range b {
@@ -121,9 +126,27 @@ func appsRunTest(t *testing.T, params *utils.DeisTestConfig) {
 	}
 	utils.CheckList(t, cmd, params, "Hello, 世界", false)
 	utils.Execute(t, "apps:run env", params, true, "GIT_SHA")
-	// run a REALLY large command to test https://github.com/deis/deis/issues/2046
+	// Fleet/systemd unit files have a limit of 2048 characters per line or else one encounters
+	// problems parsing the unit.  To verify long log messages are truncated and do not crash
+	// logspout (see https://github.com/deis/deis/issues/2046) we must issue a (relatively) short
+	// command via `deis apps:run` that produces a LONG, but testable (predictable) log message we
+	// can search for in the output of `deis logs`.
+	//
+	// The strategy for achieving this is to generate 1k random characters, then use that with a
+	// command submitted via `deis apps:run` that will echo those 1k bytes 64x (on a single line).
+	// Such a message is long enough to crash logspout if handled improperly and ALSO gives us a
+	// large, distinct, and predictable string we can search for in the logs to assert success (and
+	// assert that the message didn't crash logspout) WITHOUT ever needing to transmit such an
+	// egregiously long command via `deis apps:run`.
 	largeString := randomString(1024)
-	utils.Execute(t, "apps:run echo "+largeString, params, false, largeString)
+	utils.Execute(t, fmt.Sprintf("apps:run \"printf '%s%%.0s' {1..64}\"", largeString), params, false, largeString)
+	// To assert the long message didn't crash logspout AND made it to the logger, we will search
+	// the logs for a fragment of the long message-- specifically 2x the random string we generated.
+	// This will help us ensure the actual log message made it through and not JUST the log message
+	// that states the command being execured via `deis apps:run`.  We want to find the former, not
+	// the latter because the latter is too short a message to have possibly crashed logspout if
+	// mishandled.
+	utils.Execute(t, "logs", params, false, strings.Repeat(largeString, 2))
 	if err := utils.Chdir(".."); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #2046 