### PR TITLE
fix(router): Fix issues establishing real end-client IP

### DIFF
--- a/router/rootfs/etc/confd/templates/deis.conf
+++ b/router/rootfs/etc/confd/templates/deis.conf
@@ -1,9 +1,10 @@
+{{ $useProxyProtocol := or (getv "/deis/router/proxyProtocol") "false" }}
 server_name_in_redirect off;
 port_in_redirect off;
-listen 80{{ if exists "/deis/router/proxyProtocol" }} proxy_protocol{{ end }};
+listen 80{{ if ne $useProxyProtocol "false" }} proxy_protocol{{ end }};
 
 {{ if exists "/deis/router/sslCert" }}
-listen 443 ssl http2{{ if exists "/deis/router/proxyProtocol" }} proxy_protocol{{ end }};
+listen 443 ssl http2{{ if ne $useProxyProtocol "false" }} proxy_protocol{{ end }};
 ssl_certificate /etc/ssl/deis.cert;
 ssl_certificate_key /etc/ssl/deis.key;
 include ssl.conf;

--- a/router/rootfs/etc/confd/templates/nginx.conf
+++ b/router/rootfs/etc/confd/templates/nginx.conf
@@ -49,12 +49,12 @@ http {
     {{ $firewallErrorCode := or (getv "/deis/router/firewall/errorCode") "400" }}
     client_max_body_size "{{ or (getv "/deis/router/bodySize") "1m" }}";
 
-    {{ $useProxyProtocol := or (getv "/deis/router/proxyProtocol") "false" }}{{ if ne $useProxyProtocol "false" }}
     set_real_ip_from {{ or (getv "/deis/router/proxyRealIpCidr") "10.0.0.0/8" }};
-    real_ip_header proxy_protocol;
+    {{ $useProxyProtocol := or (getv "/deis/router/proxyProtocol") "false" }}{{ if ne $useProxyProtocol "false" }}
+    real_ip_header proxy_protocol;{{ else }}real_ip_header X-Forwarded-For;
     {{ end }}
 
-    log_format upstreaminfo '[$time_local] - {{ if ne $useProxyProtocol "false" }}$proxy_protocol_addr{{ else }}$remote_addr{{ end }} - $remote_user - $status - "$request" - $bytes_sent - "$http_referer" - "$http_user_agent" - "$server_name" - $upstream_addr - $http_host - $upstream_response_time - $request_time';
+    log_format upstreaminfo '[$time_local] - $remote_addr - $remote_user - $status - "$request" - $bytes_sent - "$http_referer" - "$http_user_agent" - "$server_name" - $upstream_addr - $http_host - $upstream_response_time - $request_time';
 
     # send logs to STDOUT so they can be seen using 'docker logs'
     access_log /opt/nginx/logs/access.log upstreaminfo;
@@ -116,11 +116,7 @@ http {
             {{ if eq $useFirewall "true" }}include                     /opt/nginx/firewall/active-mode.rules;{{ end }}
             proxy_buffering             off;
             proxy_set_header            Host $host;
-            {{ if ne $useProxyProtocol "false" }}
-            proxy_set_header            X-Forwarded-For $proxy_protocol_addr;
-            {{ else }}
-            proxy_set_header            X-Forwarded-For $proxy_add_x_forwarded_for;
-            {{ end }}
+            proxy_set_header            X-Forwarded-For $remote_addr;
             proxy_redirect              off;
             proxy_connect_timeout       {{ or (getv "/deis/router/controller/timeout/connect") "10s" }};
             proxy_send_timeout          {{ or (getv "/deis/router/controller/timeout/send") "20m" }};
@@ -169,11 +165,7 @@ http {
             {{ if eq $useFirewall "true" }}include                     /opt/nginx/firewall/active-mode.rules;{{ end }}
             proxy_buffering             off;
             proxy_set_header            Host $host;
-            {{ if ne $useProxyProtocol "false" }}
-            proxy_set_header            X-Forwarded-For $proxy_protocol_addr;
-            {{ else }}
-            proxy_set_header            X-Forwarded-For $proxy_add_x_forwarded_for;
-            {{ end }}
+            proxy_set_header            X-Forwarded-For $remote_addr;
             proxy_redirect              off;
             proxy_connect_timeout       10s;
             proxy_send_timeout          {{ $defaultTimeout }}s;
@@ -250,11 +242,7 @@ http {
             }
             proxy_set_header            X-Forwarded-Port  $access_port;
             proxy_set_header            X-Forwarded-Proto $access_scheme;
-            {{ if ne $useProxyProtocol "false" }}
-            proxy_set_header            X-Forwarded-For   $proxy_protocol_addr;
-            {{ else }}
-            proxy_set_header            X-Forwarded-For   $proxy_add_x_forwarded_for;
-            {{ end }}
+            proxy_set_header            X-Forwarded-For   $remote_addr;
             proxy_set_header            X-Forwarded-Ssl   $access_ssl;
             proxy_redirect              off;
             proxy_connect_timeout       30s;
@@ -327,11 +315,7 @@ http {
             }
             proxy_set_header            X-Forwarded-Port  $access_port;
             proxy_set_header            X-Forwarded-Proto $access_scheme;
-            {{ if ne $useProxyProtocol "false" }}
-            proxy_set_header            X-Forwarded-For   $proxy_protocol_addr;
-            {{ else }}
-            proxy_set_header            X-Forwarded-For   $proxy_add_x_forwarded_for;
-            {{ end }}
+            proxy_set_header            X-Forwarded-For   $remote_addr;
             proxy_set_header            X-Forwarded-Ssl   $access_ssl;
             proxy_redirect              off;
             proxy_connect_timeout       30s;
@@ -455,11 +439,7 @@ http {
             }
             proxy_set_header            X-Forwarded-Port  $access_port;
             proxy_set_header            X-Forwarded-Proto $access_scheme;
-            {{ if ne $useProxyProtocol "false" }}
-            proxy_set_header            X-Forwarded-For   $proxy_protocol_addr;
-            {{ else }}
-            proxy_set_header            X-Forwarded-For   $proxy_add_x_forwarded_for;
-            {{ end }}
+            proxy_set_header            X-Forwarded-For   $remote_addr;
             proxy_set_header            X-Forwarded-Ssl   $access_ssl;
             proxy_redirect              off;
             proxy_connect_timeout       30s;
@@ -517,11 +497,7 @@ http {
             }
             proxy_set_header            X-Forwarded-Port  $access_port;
             proxy_set_header            X-Forwarded-Proto $access_scheme;
-            {{ if ne $useProxyProtocol "false" }}
-            proxy_set_header            X-Forwarded-For   $proxy_protocol_addr;
-            {{ else }}
-            proxy_set_header            X-Forwarded-For   $proxy_add_x_forwarded_for;
-            {{ end }}
+            proxy_set_header            X-Forwarded-For   $remote_addr;
             proxy_set_header            X-Forwarded-Ssl   $access_ssl;
             proxy_redirect              off;
             proxy_connect_timeout       30s;


### PR DESCRIPTION
Fixes #4869 

When PROXY protocol is not in use, this change will attempt to get the end client's IP form the `X-Forwarded-For` HTTP header.  If that header doesn't exist, perhaps because there is no load balancer or proxy in play, as in the case of Vagrant, for instance, there is no harm.

I have confirmed that this fixes #4869 and allows the use of whitelists _without_ PROXY protocol.  This is extremely useful to anyone terminating SSL at the load balancer.

This change should be ported forward to the Deis v2 router.

__EDIT:__ Also, this PR fixes some additional bugs and redundancies relating to PROXY protocol and/or the `X-Forwarded-For` header and the proper determination and use of the real end-client IP.

For instance, in the file `deis.conf`, the strategy used for determining whether PROXY protocol is to be used or not was inconsistent with the strategy used for the same purpose in `nginx.conf`.  As a result, `/deis/router/proxyProtocol=false` in etcd actually left PROXY protocol _enabled_ in `deis.conf`.

Another for instance is that there was a _lot_ of conditional logic that was completely redundant as long as the real end-client IP has been established properly.  The `real_ip` module overwrites the Nginx variable `$remote_addr` (whether from PROXY protocol or the `X-Forwarded-For` HTTP header).  At no point _after_ that should we care what the source of the `$remote_addr` value was.  It can simply be used.  This applies both to logs and to the setting of the `X-Forwarded-For` HTTP header for requests to the upstream backend.