### PR TITLE
fix(controller): do not require slash at the end of the `GET /v1/users`

### DIFF
--- a/controller/api/tests/test_users.py
+++ b/controller/api/tests/test_users.py
@@ -12,7 +12,7 @@ class TestUsers(TestCase):
     fixtures = ['tests.json']
 
     def test_super_user_can_list(self):
-        url = '/v1/users/'
+        url = '/v1/users'
 
         user = User.objects.get(username='autotest')
         token = Token.objects.get(user=user)
@@ -24,7 +24,7 @@ class TestUsers(TestCase):
         self.assertEqual(len(response.data['results']), 3)
 
     def test_non_super_user_cannot_list(self):
-        url = '/v1/users/'
+        url = '/v1/users'
 
         user = User.objects.get(username='autotest2')
         token = Token.objects.get(user=user)

--- a/controller/api/urls.py
+++ b/controller/api/urls.py
@@ -99,5 +99,5 @@ urlpatterns = patterns(
     url(r'^certs/?',
         views.CertificateViewSet.as_view({'get': 'list', 'post': 'create'})),
     # list users
-    url(r'^users/', views.UserView.as_view({'get': 'list'})),
+    url(r'^users/?', views.UserView.as_view({'get': 'list'})),
 )


### PR DESCRIPTION
Documentation includes sample code for listing all users using API. It
shows `GET /v1/users` endpoint which did not work. API required a slash
character at the end of URL:

```bash
 $ curl -I -H "Authorization: token ..." -H "Content-Type: application/json" https://...co/v1/users
HTTP/1.1 404 NOT FOUND
Server: nginx/1.9.6
Date: Wed, 03 Feb 2016 10:55:02 GMT
Content-Type: text/html
Connection: keep-alive
Vary: Accept-Encoding
X_DEIS_API_VERSION: 1.7
DEIS_PLATFORM_VERSION: 1.12.1
X_DEIS_PLATFORM_VERSION: 1.12.1
DEIS_API_VERSION: 1.7

 $ curl -I -H "Authorization: token ..." -H "Content-Type: application/json" https://....co/v1/users/
HTTP/1.1 200 OK
Server: nginx/1.9.6
Date: Wed, 03 Feb 2016 10:55:39 GMT
Content-Type: application/json
Connection: keep-alive
Vary: Accept-Encoding
DEIS_PLATFORM_VERSION: 1.12.1
X_DEIS_PLATFORM_VERSION: 1.12.1
DEIS_API_VERSION: 1.7
Allow: GET, HEAD, OPTIONS
X_DEIS_API_VERSION: 1.7
```

Make the slash optional so both, `GET /v1/users` and `GET /v1/users/`
versions will work.