### PR TITLE
chore(*): bump CoreOS to 835.12.0

### DIFF
--- a/contrib/azure/parameters.json
+++ b/contrib/azure/parameters.json
@@ -27,7 +27,7 @@
     "value": 100
   },
   "coreosVersion": {
-    "value": "835.11.0"
+    "value": "835.12.0"
   },
   "storageAccountType": {
     "value": "Premium_LRS"

--- a/contrib/linode/provision-linode-cluster.py
+++ b/contrib/linode/provision-linode-cluster.py
@@ -13,7 +13,7 @@ import sys
 
 import paramiko
 from linodeapi import LinodeApiCommand
-import linodeutils 
+import linodeutils
 
 class ProvisionCommand(LinodeApiCommand):
     _created_linodes = []
@@ -357,7 +357,7 @@ def main():
                                   help='Node data center id. Use list-data-centers to find the id.')
     provision_parser.add_argument('--cloud-config', required=False, default='linode-user-data.yaml', type=file, dest='cloud_config',
                                   help='CoreOS cloud config user-data file')
-    provision_parser.add_argument('--coreos-version', required=False, default='835.11.0', dest='coreos_version',
+    provision_parser.add_argument('--coreos-version', required=False, default='835.12.0', dest='coreos_version',
                                   help='CoreOS version number to install')
     provision_parser.add_argument('--coreos-channel', required=False, default='stable', dest='coreos_channel',
                                   help='CoreOS channel to install from')

--- a/contrib/utils.sh
+++ b/contrib/utils.sh
@@ -13,5 +13,5 @@ function echo_green {
 }
 
 export COREOS_CHANNEL=${COREOS_CHANNEL:-stable}
-export COREOS_VERSION=${COREOS_VERSION:-835.11.0}
+export COREOS_VERSION=${COREOS_VERSION:-835.12.0}
 export DEIS_RELEASE=1.13.0-dev

--- a/docs/installing_deis/baremetal.rst
+++ b/docs/installing_deis/baremetal.rst
@@ -94,7 +94,7 @@ Start the installation
 
 .. code-block:: console
 
-    coreos-install -C stable -c /tmp/config -d /dev/sda -V 835.11.0
+    coreos-install -C stable -c /tmp/config -d /dev/sda -V 835.12.0
 
 
 This will install the latest `CoreOS`_ stable release that has been known to work

--- a/docs/installing_deis/gce.rst
+++ b/docs/installing_deis/gce.rst
@@ -118,7 +118,7 @@ Launch 3 instances. You can choose another starting CoreOS image from the listin
       --metadata-from-file user-data=gce-user-data,sshKeys=$HOME/.ssh/deis.pub \
       --disk name=cored${num},device-name=coredocker \
       --tags deis \
-      --image coreos-stable-835-11-0-v20160122 \
+      --image coreos-stable-835-12-0-v20160202 \
       --image-project coreos-cloud;
     done
 


### PR DESCRIPTION
Fixes a high severity OpenSSL vulnerability: https://coreos.com/releases/#835.12.0