### PR TITLE
chore(buildpacks): update all Heroku buildpacks

### DIFF
--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -39,4 +39,4 @@ download_buildpack https://github.com/heroku/heroku-buildpack-python.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v92
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v65
-download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v18
+download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v30

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -38,5 +38,5 @@ download_buildpack https://github.com/heroku/heroku-buildpack-play.git          
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v77
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v92
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
-download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v63
+download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v65
 download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v18

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -31,7 +31,7 @@ mkdir -p $BUILDPACK_INSTALL_PATH
 download_buildpack https://github.com/heroku/heroku-buildpack-multi.git          26fa21a
 download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v144
 download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v87
-download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v40
+download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v43
 download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v12
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v19
 download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v24

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -35,7 +35,7 @@ download_buildpack https://github.com/heroku/heroku-buildpack-java.git          
 download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v17
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v19
 download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v26
-download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v70
+download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v77
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v82
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v70
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v63

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -30,7 +30,7 @@ mkdir -p $BUILDPACK_INSTALL_PATH
 
 download_buildpack https://github.com/heroku/heroku-buildpack-multi.git          26fa21a
 download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v144
-download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v86
+download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v87
 download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v40
 download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v12
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v19

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -32,7 +32,7 @@ download_buildpack https://github.com/heroku/heroku-buildpack-multi.git         
 download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v144
 download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v87
 download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v43
-download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v12
+download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v17
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v19
 download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v24
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v70

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -34,7 +34,7 @@ download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v43
 download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v17
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v19
-download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v24
+download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v26
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v70
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v82
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v70

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -29,7 +29,7 @@ download_buildpack() {
 mkdir -p $BUILDPACK_INSTALL_PATH
 
 download_buildpack https://github.com/heroku/heroku-buildpack-multi.git          26fa21a
-download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v140
+download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v144
 download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v86
 download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v40
 download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v12

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -36,7 +36,7 @@ download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v19
 download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v26
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v77
-download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v82
+download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v92
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v70
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v63
 download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v18

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -37,6 +37,6 @@ download_buildpack https://github.com/heroku/heroku-buildpack-grails.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v26
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v77
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v92
-download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v70
+download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v63
 download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v18


### PR DESCRIPTION
Updates all eligible buildpacks to their latest tagged versions. ~~Needs to be tested with all Deis example apps on Deis v1~~ I tested with all Deis example apps on Deis v1:
- [x] [heroku-buildpack-ruby](https://github.com/heroku/heroku-buildpack-ruby/compare/v140...v144)
- [x] [heroku-buildpack-nodejs](https://github.com/heroku/heroku-buildpack-nodejs/compare/v86...v87)
- [x] [heroku-buildpack-java](https://github.com/heroku/heroku-buildpack-java/compare/v40...v43)
- [x] [heroku-buildpack-gradle](https://github.com/heroku/heroku-buildpack-gradle/compare/v12...v17) (tested with [gradle-getting-started](https://github.com/heroku/gradle-getting-started))
- [x] [heroku-buildpack-play](https://github.com/heroku/heroku-buildpack-play/compare/v24...v26)
- [x] [heroku-buildpack-python](https://github.com/heroku/heroku-buildpack-python/compare/v70...v77) using both Django and Flask
- [x] [heroku-buildpack-php](https://github.com/heroku/heroku-buildpack-php/compare/v82...v92)
- [x] [heroku-buildpack-clojure](https://github.com/heroku/heroku-buildpack-clojure/compare/v70...v75) 
- [x] [heroku-buildpack-scala](https://github.com/heroku/heroku-buildpack-scala/compare/v63...v65)
- [x] [heroku-buildpack-go](https://github.com/heroku/heroku-buildpack-go/compare/v15...v30)

See also deis/slugbuilder#23.