### PR TITLE
docs(reference): remove sidenote about pushing only to master

### DIFF
--- a/docs/reference/terms/build.rst
+++ b/docs/reference/terms/build.rst
@@ -9,6 +9,3 @@ Deis builds are created automatically on the controller when a
 developer uses ``git push deis master``.
 
 When a new build is created, a new :ref:`release` is created automatically.
-
-.. note::
-	Deis only supports ``git push`` to the **master** branch.


### PR DESCRIPTION
You can now push to any branch, which will trigger a build.

closes #4870