### PR TITLE
fix(builder): demote handshake failure log to debug

### DIFF
--- a/builder/sshd/server.go
+++ b/builder/sshd/server.go
@@ -134,7 +134,7 @@ func (s *server) handleConn(conn net.Conn, conf *ssh.ServerConfig) {
 	_, chans, reqs, err := ssh.NewServerConn(conn, conf)
 	if err != nil {
 		// Handshake failure.
-		log.Errf(s.c, "Failed handshake: %s (%v)", err, conn)
+		log.Debugf(s.c, "Failed handshake: %s", err)
 		return
 	}
 


### PR DESCRIPTION
It's okay for connections to probe the server without initiating
a handshake, but it's still useful for developers to see when incoming
connections are not connecting.

closes #4431