### PR TITLE
fix(client): strip controller port when parsing git remotes

### DIFF
--- a/client/pkg/git/git.go
+++ b/client/pkg/git/git.go
@@ -93,6 +93,9 @@ func findRemote(host string) (string, error) {
 
 	cmd := string(out)
 
+	// Strip off any trailing :port number after the host name.
+	host = strings.Split(host, ":")[0]
+
 	for _, line := range strings.Split(cmd, "\n") {
 		for _, remote := range strings.Split(line, " ") {
 			if strings.Contains(remote, host) {


### PR DESCRIPTION
Backported fix from deis/workflow#425.