### PR TITLE
fix(vagrant): fix Vagrantfile to handle spaces

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ CONTRIB_UTILS_PATH = File.join(File.dirname(__FILE__), "contrib", "utils.sh")
 # Make variables from contrib/utils.sh accessible
 if File.exists?(CONTRIB_UTILS_PATH)
   cu_vars = Hash.new do |hash, key|
-    stdin, stdout, stderr = Open3.popen3("/usr/bin/env", "bash", "-c", "source #{CONTRIB_UTILS_PATH} && echo $#{key}")
+    stdin, stdout, stderr = Open3.popen3("/usr/bin/env", "bash", "-c", "source '#{CONTRIB_UTILS_PATH}' && echo $#{key}")
     value = stdout.gets.chomp
     hash[key] = value unless value.empty?
   end


### PR DESCRIPTION
This change allows Vagrant to work properly when the path to the
location of the clone of this repo contain spaces. For example, if this
repo were cloned to this path:

```
/users/userA/path with spaces/code/deis
```

`vagrant up` would fail. This change fixes that.