### PR TITLE
chore(buildpacks): update heroku-buildpack-go to v31

### DIFF
--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -39,4 +39,4 @@ download_buildpack https://github.com/heroku/heroku-buildpack-python.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v92
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v65
-download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v30
+download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v31


### PR DESCRIPTION
Adds Go 1.6 support.
See https://github.com/heroku/heroku-buildpack-go/compare/v30...v31