### PR TITLE
chore(buildpacks): update heroku-buildpack-scala to v66

### DIFF
--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -38,5 +38,5 @@ download_buildpack https://github.com/heroku/heroku-buildpack-play.git          
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v77
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v92
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
-download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v65
+download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v66
 download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v31


### PR DESCRIPTION
Adds SBT 0.13.11 support.
See https://github.com/heroku/heroku-buildpack-scala/compare/v65...v66