### PR TITLE
chore(buildpacks): update heroku-buildpack-multi to v1.0.0

### DIFF
--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -28,7 +28,7 @@ download_buildpack() {
 
 mkdir -p $BUILDPACK_INSTALL_PATH
 
-download_buildpack https://github.com/heroku/heroku-buildpack-multi.git          26fa21a
+download_buildpack https://github.com/heroku/heroku-buildpack-multi.git          v1.0.0
 download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v144
 download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v88
 download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v43


### PR DESCRIPTION
This is the same as the previous SHA 26fa21a, but tidier.