### PR TITLE
fix(api): disable adding wildcard certificates

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -116,6 +116,11 @@ def validate_certificate(value):
         raise ValidationError('Could not load certificate: {}'.format(e))
 
 
+def validate_common_name(value):
+    if '*' in value:
+        raise ValidationError('Wildcard certificates are not supported')
+
+
 def get_etcd_client():
     if not hasattr(get_etcd_client, "client"):
         # wire up etcd publishing if we can connect
@@ -1011,7 +1016,7 @@ class Certificate(AuditedModel):
     certificate = models.TextField(validators=[validate_certificate])
     key = models.TextField()
     # X.509 certificates allow any string of information as the common name.
-    common_name = models.TextField(unique=True)
+    common_name = models.TextField(unique=True, validators=[validate_common_name])
     expires = models.DateTimeField()
 
     def __str__(self):

--- a/controller/api/tests/test_certificate.py
+++ b/controller/api/tests/test_certificate.py
@@ -80,6 +80,17 @@ thejiQz0ThCMBw7QMpVOiSvYAlQG0ATsRYwdTDqENIWKlerOLCSuxmbqe8XeDKhq
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
 
+    def test_create_wildcard_certificate(self):
+        """Tests creating a wildcard certificate, which should be disabled."""
+        body = {'certificate': self.autotest_example_com_cert,
+                'key': self.key,
+                'common_name': '*.example.com'}
+        response = self.client.post(self.url, json.dumps(body), content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.content),
+                         {'common_name': ['Wildcard certificates are not supported']})
+
     def test_create_certificate_with_different_common_name(self):
         """
         In some cases such as with SAN certificates, the certificate can cover more


### PR DESCRIPTION
since #4762 isn't likely to be added to the LTS release due to some changes still required, this PR disables users from adding wildcard certificates by accident.

closes #4685 