### PR TITLE
chore(*): update base to alpine:3.3

### DIFF
--- a/builder/rootfs/Dockerfile
+++ b/builder/rootfs/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.2
+FROM alpine:3.3
 
 # install common packages
-RUN apk add --update-cache curl bash sudo && rm -rf /var/cache/apk/*
+RUN apk add --no-cache curl bash sudo
 
 # install etcdctl
 RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/get-deis/etcdctl-v0.4.9 \
@@ -11,19 +11,18 @@ RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/get-d
 RUN curl -sSL -o /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v0.10.0/confd-0.10.0-linux-amd64 \
     && chmod +x /usr/local/bin/confd
 
-RUN apk add --update-cache \
+RUN apk add --no-cache \
     coreutils \
     device-mapper \
     e2fsprogs \
     git \
     iptables \
-    libudev \
+    udev \
     lxc \
     openssh \
     udev \
     util-linux \
-    xz \
-    && rm -rf /var/cache/apk/*
+    xz
 
 # the docker package in alpine disables aufs and devicemapper
 ENV DOCKER_BUCKET get.docker.com

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.2
+FROM alpine:3.3
 
 # install common packages
-RUN apk add --update-cache curl bash sudo && rm -rf /var/cache/apk/*
+RUN apk add --no-cache curl bash sudo
 
 # install etcdctl
 RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/get-deis/etcdctl-v0.4.9 \

--- a/controller/build.sh
+++ b/controller/build.sh
@@ -12,7 +12,7 @@ fi
 
 # install required system packages
 # HACK: install git so we can install bacongobbler's fork of django-fsm
-apk add --update-cache \
+apk add --no-cache \
   build-base \
   git \
   libffi-dev \
@@ -24,7 +24,7 @@ apk add --update-cache \
   python-dev
 
 # install pip
-curl -sSL https://raw.githubusercontent.com/pypa/pip/7.0.3/contrib/get-pip.py | python -
+curl -sSL https://bootstrap.pypa.io/get-pip.py | python - pip==8.1.1
 
 # add a deis user
 adduser deis -D -h /app -s /bin/bash
@@ -39,11 +39,10 @@ mkdir -p /templates && chown -R deis:deis /templates
 pip install --disable-pip-version-check --no-cache-dir -r /app/requirements.txt
 
 # cleanup.
-apk del --purge \
+apk del --no-cache \
   build-base \
   git \
   libffi-dev \
   openldap-dev \
   postgresql-dev \
   python-dev
-rm -rf /var/cache/apk/*

--- a/database/build.sh
+++ b/database/build.sh
@@ -31,13 +31,13 @@ apk add /tmp/pv-1.6.0-r0.apk
 /etc/init.d/postgresql stop || true
 
 # install pip
-curl -sSL https://raw.githubusercontent.com/pypa/pip/7.0.3/contrib/get-pip.py | python -
+curl -sSL https://bootstrap.pypa.io/get-pip.py | python - pip==8.1.1
 
 # install wal-e
 pip install --disable-pip-version-check --no-cache-dir wal-e==0.8.1 oslo.config>=1.12.0
 
 # python port of daemontools
-pip install --disable-pip-version-check --no-cache-dir envdir
+pip install --disable-pip-version-check --no-cache-dir envdir==0.7
 
 mkdir -p /etc/wal-e.d/env /etc/postgresql/main /var/lib/postgresql
 

--- a/logger/image/Dockerfile
+++ b/logger/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:3.3
 
 ENTRYPOINT ["/bin/logger"]
 CMD ["--enable-publish"]

--- a/logspout/image/Dockerfile
+++ b/logspout/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:3.3
 
 ENV DOCKER_HOST unix:///tmp/docker.sock
 ENV ROUTESPATH /tmp

--- a/publisher/image/Dockerfile
+++ b/publisher/image/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.2
+FROM alpine:3.3
 
 # install curl in the image so it is possible to get the runtime
 # profiling information without any additional package installation.
-RUN apk add --update-cache curl && rm -rf /var/cache/apk/*
+RUN apk add --no-cache curl
 
 ADD bin/publisher /usr/local/bin/publisher
 ENTRYPOINT ["/usr/local/bin/publisher"]

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.1
+FROM alpine:3.3
 
 # install common packages
-RUN apk add --update-cache curl bash sudo && rm -rf /var/cache/apk/*
+RUN apk add --no-cache curl bash sudo
 
 # install etcdctl
 RUN curl -sSL -o /usr/local/bin/etcdctl https://s3-us-west-2.amazonaws.com/get-deis/etcdctl-v0.4.9 \

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,15 +1,14 @@
-FROM alpine:3.2
+FROM alpine:3.3
 
 # install common packages
-RUN apk add --update-cache \
+RUN apk add --no-cache \
 	bash \
 	curl \
 	geoip \
 	libssl1.0 \
 	openssl \
 	pcre \
-	sudo \
-	&& rm -rf /var/cache/apk/*
+	sudo
 
 # install confd
 RUN curl -sSL -o /usr/local/bin/confd https://s3-us-west-2.amazonaws.com/opdemand/confd-git-73f7489 \

--- a/router/rootfs/bin/build
+++ b/router/rootfs/bin/build
@@ -20,7 +20,7 @@ mkdir "$BUILD_PATH"
 cd "$BUILD_PATH"
 
 # install required packages to build
-apk add --update-cache \
+apk add --no-cache \
   build-base \
   curl \
   geoip-dev \
@@ -78,7 +78,7 @@ cd "$BUILD_PATH/nginx-$NGINX_VERSION"
   && make && make install
 
 rm -rf "$BUILD_PATH"
-apk del --purge \
+apk del --no-cache \
   build-base \
   curl \
   geoip-dev \
@@ -89,4 +89,3 @@ apk del --purge \
   openssl-dev \
   zlib \
   zlib-dev
-rm -rf /var/cache/apk/*

--- a/tests/fixtures/mock-store/Dockerfile
+++ b/tests/fixtures/mock-store/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.2
+FROM alpine:3.3
 
 # install common packages
-RUN apk add --update-cache curl bash sudo && rm -rf /var/cache/apk/*
+RUN apk add --no-cache curl bash sudo
 
 WORKDIR /app
 EXPOSE 8888

--- a/tests/fixtures/mock-store/build.sh
+++ b/tests/fixtures/mock-store/build.sh
@@ -11,7 +11,7 @@ if [[ -z $DOCKER_BUILD ]]; then
 fi
 
 # install required packages to build
-apk add --update-cache \
+apk add --no-cache \
   build-base \
   curl \
   file \
@@ -30,13 +30,13 @@ git checkout 4c3c3752f990db97e8969c00666251a3b427ef4c
 git apply /tmp/mock-s3-patch.diff
 
 # install pip
-curl -sSL https://raw.githubusercontent.com/pypa/pip/7.0.3/contrib/get-pip.py | python -
+curl -sSL https://bootstrap.pypa.io/get-pip.py | python - pip==8.1.1
 
 python setup.py install
 
 # cleanup.
-apk del --purge \
+apk del --no-cache \
   build-base \
   gcc \
   git
-rm -rf /var/cache/apk/* /tmp/*
+rm -rf /tmp/*

--- a/tests/fixtures/test-etcd/Dockerfile
+++ b/tests/fixtures/test-etcd/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.2
+FROM alpine:3.3
 
 # install common packages
-RUN apk add --update-cache curl tar && rm -rf /var/cache/apk/*
+RUN apk add --no-cache curl tar
 
 # ETCD_VERSION is actually used by the etcd daemon, and causes an issue if we
 # format it for our use here. So, we call this something else.


### PR DESCRIPTION
Updates Docker base images to `alpine:3.3` to benefit from current code and fixes.

Closes #4904.

TODO:
- [x] upgrade builder ~~(compile errors currently)~~
- [x] upgrade registry ~~(compile errors currently)~~
- [x] upgrade database or document why it isn't (new version of postgres uses a different data dir, so an upgrade script would be needed) **Will create a separate PR when this succeeds**