### PR TITLE
fix(router): Allow for comma-delimited X-Forwarded-Proto

### DIFF
--- a/router/rootfs/etc/confd/templates/nginx.conf
+++ b/router/rootfs/etc/confd/templates/nginx.conf
@@ -65,10 +65,19 @@ http {
         ''      close;
     }
 
-    # trust http_x_forwarded_proto headers correctly indicate ssl offloading
-    map $http_x_forwarded_proto $access_scheme {
-      default $http_x_forwarded_proto;
-      ''      $scheme;
+    # The next two maps work together to determine the $access_scheme:
+    # 1. Determine if SSL may have been offloaded by the load balancer, in such cases, an HTTP request should be
+    # treated as if it were HTTPs.
+    map $http_x_forwarded_proto $tmp_access_scheme {
+      default $scheme;               # if X-Forwarded-Proto header is empty, $tmp_access_scheme will be the actual protocol used
+      "~^(.*, ?)?http$" "http";      # account for the possibility of a comma-delimited X-Forwarded-Proto header value
+      "~^(.*, ?)?https$" "https";    # account for the possibility of a comma-delimited X-Forwarded-Proto header value
+    }
+    # 2. If the request is an HTTPS request, upgrade $access_scheme to https, regardless of what the X-Forwarded-Proto
+    # header might say.
+    map $scheme $access_scheme {
+      default $tmp_access_scheme;
+      "https" "https";
     }
 
     ## HSTS instructs the browser to replace all HTTP links with HTTPS links for this domain until maxAge seconds from now


### PR DESCRIPTION
Fixes #4997

This will _also_ have the actual protocol used trump whatever the `X-Forwarded-Proto` header says about whether the request is a secure one or not.