### PR TITLE
fix(controller): use django HttpResponse for logs

### DIFF
--- a/client/cmd/apps.go
+++ b/client/cmd/apps.go
@@ -168,7 +168,7 @@ func AppLogs(appID string, lines int) error {
 
 // printLogs prints each log line with a color matched to its category.
 func printLogs(logs string) error {
-	for _, log := range strings.Split(strings.Trim(logs, `\n`), `\n`) {
+	for _, log := range strings.Split(logs, "\n") {
 		category := "unknown"
 		parts := strings.Split(strings.Split(log, ": ")[0], " ")
 		if len(parts) >= 2 {

--- a/controller/api/tests/test_app.py
+++ b/controller/api/tests/test_app.py
@@ -105,32 +105,30 @@ class AppTest(TestCase):
         url = "/v1/apps/{app_id}/logs".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION="token {}".format(self.token))
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(response.data, "No logs for {}".format(app_id))
 
         # test logs - 404 from deis-logger
         mock_response.status_code = 404
         response = self.client.get(url, HTTP_AUTHORIZATION="token {}".format(self.token))
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(response.data, "No logs for {}".format(app_id))
 
         # test logs - unanticipated status code from deis-logger
         mock_response.status_code = 400
         response = self.client.get(url, HTTP_AUTHORIZATION="token {}".format(self.token))
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.data, "Error accessing logs for {}".format(app_id))
+        self.assertEqual(response.content, "Error accessing logs for {}".format(app_id))
 
         # test logs - success accessing deis-logger
         mock_response.status_code = 200
         mock_response.content = FAKE_LOG_DATA
         response = self.client.get(url, HTTP_AUTHORIZATION="token {}".format(self.token))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, FAKE_LOG_DATA)
+        self.assertEqual(response.content, FAKE_LOG_DATA)
 
         # test logs - HTTP request error while accessing deis-logger
         mock_get.side_effect = requests.exceptions.RequestException('Boom!')
         response = self.client.get(url, HTTP_AUTHORIZATION="token {}".format(self.token))
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.data, "Error accessing logs for {}".format(app_id))
+        self.assertEqual(response.content, "Error accessing logs for {}".format(app_id))
 
         # TODO: test run needs an initial build
 

--- a/controller/api/views.py
+++ b/controller/api/views.py
@@ -224,22 +224,20 @@ class AppViewSet(BaseDeisViewSet):
     def logs(self, request, **kwargs):
         app = self.get_object()
         try:
-            return Response(app.logs(request.query_params.get('log_lines',
-                                     str(settings.LOG_LINES))),
-                            status=status.HTTP_200_OK, content_type='text/plain')
+            return HttpResponse(app.logs(request.query_params.get('log_lines',
+                                         str(settings.LOG_LINES))),
+                                status=status.HTTP_200_OK, content_type='text/plain')
         except requests.exceptions.RequestException:
-            return Response("Error accessing logs for {}".format(app.id),
-                            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                            content_type='text/plain')
-        except EnvironmentError as e:
-            if e.message == 'Error accessing deis-logger':
-                return Response("Error accessing logs for {}".format(app.id),
+            return HttpResponse("Error accessing logs for {}".format(app.id),
                                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                                 content_type='text/plain')
+        except EnvironmentError as e:
+            if e.message == 'Error accessing deis-logger':
+                return HttpResponse("Error accessing logs for {}".format(app.id),
+                                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                                    content_type='text/plain')
             else:
-                return Response("No logs for {}".format(app.id),
-                                status=status.HTTP_204_NO_CONTENT,
-                                content_type='text/plain')
+                return HttpResponse(status=status.HTTP_204_NO_CONTENT)
 
     def run(self, request, **kwargs):
         app = self.get_object()

--- a/docs/reference/api-v1.7.rst
+++ b/docs/reference/api-v1.7.rst
@@ -370,7 +370,8 @@ Example Response:
     DEIS_PLATFORM_VERSION: 1.12.3
     Content-Type: text/plain
 
-    "16:51:14 deis[api]: test created initial release\n"
+    16:51:14 deis[api]: test created initial release
+    16:51:15 deis[api]: test added POWERED_BY
 
 
 Run one-off Commands


### PR DESCRIPTION
Django Rest Framework will wrap the string with quotes because
of the JSONRenderer. Django's HttpResponse class handles the
application logs as we expect it to; unmolested and untouched.

This scrubs the "No logs for appname" message we would display when
there are no logs to show, but in reality this is the correct way to
return a 204, and that message was never displayed to users because
we inject "user created initial release" when a user first runs
`deis apps:create`. Django scrubs the response content if the
status code is a 204 to comply with RFC 2616, section 4.3.

See https://github.com/django/django/blob/53ccffdb8c8e47a4d4304df453d8c79a9be295ab/django/http/utils.py#L13-L16

fixes #4657
fixes #4658