### PR TITLE
fix(controller): use double quotes to escape ENV values

### DIFF
--- a/controller/registry/dockerclient.py
+++ b/controller/registry/dockerclient.py
@@ -55,8 +55,8 @@ class DockerClient(object):
     def build(self, source, config, repo, tag):
         """Add a "last-mile" layer of environment config to a Docker image for deis-registry."""
         check_blacklist(repo)
-        env = ' '.join("{}='{}'".format(
-            k, v.encode('unicode-escape').replace("'", "\\'")) for k, v in config.viewitems())
+        env = ' '.join('{}="{}"'.format(
+            k, v.encode('unicode-escape').replace('"', '\\"')) for k, v in config.viewitems())
         dockerfile = "FROM {}\nENV {}".format(source, env)
         f = io.BytesIO(dockerfile.encode('utf-8'))
         target_repo = "{}/{}:{}".format(self.registry, repo, tag)

--- a/controller/registry/tests.py
+++ b/controller/registry/tests.py
@@ -56,7 +56,7 @@ class DockerClientTest(unittest.TestCase):
         self.assertDictContainsSubset(args, kwargs)
         # test that the fileobj arg to "docker build" contains a correct Dockerfile
         f = kwargs['fileobj']
-        self.assertEqual(f.read(), "FROM ozzy/embryo:git-f3a8020\nENV POWERED_BY='Deis'")
+        self.assertEqual(f.read(), "FROM ozzy/embryo:git-f3a8020\nENV POWERED_BY=\"Deis\"")
         # Test that blacklisted image names can't be built
         with self.assertRaises(PermissionDenied):
             self.client.build('deis/controller:v1.11.1', {}, 'deis/controller', 'v1.11.1')


### PR DESCRIPTION
This fixes an issue with Docker's build system.

The following does not work:

```
><> cat Dockerfile
FROM busybox
ENV POWERED_BY='can\'t compute'
><> docker build .
Sending build context to Docker daemon 109.6 kB
Error response from daemon: Syntax error - can't find = in "compute'". Must be of the form: name=value
```

However, subbing the single quotes for double quotes works:

```
><> vim Dockerfile
><> docker build .
Sending build context to Docker daemon 109.6 kB
Step 1 : FROM busybox
 ---> 307ac631f1b5
Step 2 : ENV POWERED_BY "can\"t compute"
 ---> Using cache
 ---> 7b505fc9ce12
Successfully built 7b505fc9ce12
><> docker run 7b505fc9ce12 env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=c4d9a9278acd
POWERED_BY=can"t compute
HOME=/root
```

fixes #4796