### PR TITLE
fix(controller): prevent overlapping config:set operations

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -17,6 +17,6 @@ python-etcd==0.3.2
 python-ldap==2.4.19
 PyYAML==3.11
 semantic_version==2.4.2
-simpleflock==0.0.2
+simpleflock==0.0.3
 South==1.0.2
 static==1.1.1


### PR DESCRIPTION
Uses a file lock to ensure that multiple gunicorn processes can be coordinated in the container. If a `deis config:set` is in progress, another client attempting `config:set` will try to obtain the lock for 5 seconds, then return an error:
```
$ deis config:set POWERED_BY=Second
Creating config... Error: 
409 CONFLICT
error: Config changes already in progress.
[Errno 11] Resource temporarily unavailable
```

Closes #4746.
Closes #4758.