### PR TITLE
fix(logspout): discover logger connection continuously

### DIFF
--- a/logspout/logspout.go
+++ b/logspout/logspout.go
@@ -240,6 +240,7 @@ func main() {
 			for {
 				// NOTE(bacongobbler): sleep for a bit before doing the discovery loop again
 				time.Sleep(10 * time.Second)
+				router.Remove("etcd")
 				router.Add(getEtcdRoute(etcd))
 			}
 		}()

--- a/logspout/logspout.go
+++ b/logspout/logspout.go
@@ -241,7 +241,7 @@ func main() {
 				// NOTE(bacongobbler): sleep for a bit before doing the discovery loop again
 				time.Sleep(10 * time.Second)
 				newRoute := getEtcdRoute(etcd)
-				oldRoute, err := router.Get("etcd")
+				oldRoute, err := router.Get(newRoute.ID)
 				// router.Get only returns an error if the route doesn't exist. If it does,
 				// then we can skip this check and just add the new route to the routing table
 				if err == nil &&
@@ -251,7 +251,7 @@ func main() {
 					continue
 				}
 				// NOTE(bacongobbler): this operation is a no-op if the route doesn't exist
-				router.Remove("etcd")
+				router.Remove(oldRoute.ID)
 				router.Add(newRoute)
 			}
 		}()


### PR DESCRIPTION
Logspout would only discover the logger's host/port information at
boot. When the logger is rebooted and is re-scheduled onto another
host, the logspout agents were not updated. This change makes the
agent check etcd every 10 seconds and updates the logger route
information to ensure it's sending logs to the right address.

fixes #4293