### PR TITLE
chore(requirements): remove obsolete marathon lib

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -10,7 +10,6 @@ django-auth-ldap==1.2.5
 djangorestframework==3.0.5
 docker-py==1.7.0
 gunicorn==19.3.0
-marathon==0.6.15
 paramiko==1.15.2
 psycopg2==2.6.1
 python-etcd==0.3.2


### PR DESCRIPTION
The Mesos / Marathon tech preview scheduler was removed from Deis after the 1.12 release, in #4861.