### PR TITLE
chore(build.sh): remove unused git install

### DIFF
--- a/controller/build.sh
+++ b/controller/build.sh
@@ -11,10 +11,8 @@ if [[ -z $DOCKER_BUILD ]]; then
 fi
 
 # install required system packages
-# HACK: install git so we can install bacongobbler's fork of django-fsm
 apk add --no-cache \
   build-base \
-  git \
   libffi-dev \
   libpq \
   openldap \
@@ -41,7 +39,6 @@ pip install --disable-pip-version-check --no-cache-dir -r /app/requirements.txt
 # cleanup.
 apk del --no-cache \
   build-base \
-  git \
   libffi-dev \
   openldap-dev \
   postgresql-dev \


### PR DESCRIPTION
Controller doesn't require the django-fsm fork any longer. Not since [this change](https://github.com/deis/deis/pull/2993/files#diff-521da416471aa0210eb6bb14d746c5abL7) in #2993.