### PR TITLE
ref(client): improve client error message

### DIFF
--- a/client/controller/client/http.go
+++ b/client/controller/client/http.go
@@ -157,8 +157,6 @@ func CheckConnection(client *http.Client, controllerURL url.URL) error {
 	errorMessage := `%s does not appear to be a valid Deis controller.
 Make sure that the Controller URI is correct and the server is running.`
 
-	baseURL := controllerURL.String()
-
 	controllerURL.Path = "/v1/"
 
 	req, err := http.NewRequest("GET", controllerURL.String(), bytes.NewBuffer(nil))
@@ -171,13 +169,13 @@ Make sure that the Controller URI is correct and the server is running.`
 	res, err := client.Do(req)
 
 	if err != nil {
-		fmt.Printf(errorMessage+"\n", baseURL)
+		fmt.Printf(errorMessage+"\n", controllerURL.String())
 		return err
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != 401 {
-		return fmt.Errorf(errorMessage, baseURL)
+		return fmt.Errorf(errorMessage, controllerURL.String())
 	}
 
 	checkAPICompatibility(res.Header.Get("DEIS_API_VERSION"))

--- a/client/controller/client/http.go
+++ b/client/controller/client/http.go
@@ -155,7 +155,8 @@ func checkForErrors(res *http.Response, body string) error {
 // CheckConnection checks that the user is connected to a network and the URL points to a valid controller.
 func CheckConnection(client *http.Client, controllerURL url.URL) error {
 	errorMessage := `%s does not appear to be a valid Deis controller.
-Make sure that the Controller URI is correct and the server is running.`
+Make sure that the Controller URI is correct, the server is running and
+your client version is correct.`
 
 	controllerURL.Path = "/v1/"
 


### PR DESCRIPTION
This PR improves the resultant client error message they get when the returned response is
incorrect. This is especially important for determining the error message

Old message when using a v1 client with a v2 cluster:

```
http://deis.10.245.1.3.xip.io does not appear to be a valid Deis controller. Make sure that the
Controller URI is correct and the server is running.
```

New message:

```
http://deis.10.245.1.3.xip.io/v1/ does not appear to be a valid Deis controller. Make sure that the
Controller URI is correct and the server is running.
```

Notice the appended /v1/ path, which users can assume this is a v1 client.