### PR TITLE
chore(tests): update test-etcd to v2.2.3

### DIFF
--- a/tests/fixtures/test-etcd/Dockerfile
+++ b/tests/fixtures/test-etcd/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache curl tar
 
 # ETCD_VERSION is actually used by the etcd daemon, and causes an issue if we
 # format it for our use here. So, we call this something else.
-ENV INSTALL_ETCD_VERSION v2.1.2
+ENV INSTALL_ETCD_VERSION v2.2.3
 
 # install etcd and etcdctl
 RUN curl -sSL https://github.com/coreos/etcd/releases/download/$INSTALL_ETCD_VERSION/etcd-$INSTALL_ETCD_VERSION-linux-amd64.tar.gz \


### PR DESCRIPTION
This matches the version shipped in CoreOS 899.15.0.