### PR TITLE
imp(publisher): concurrent polling

### DIFF
--- a/publisher/server/publisher.go
+++ b/publisher/server/publisher.go
@@ -75,10 +75,17 @@ func (s *Server) Poll(ttl time.Duration) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	var wg sync.WaitGroup
 	for _, container := range containers {
-		// send container to channel for processing
-		s.publishContainer(&container, ttl)
+		wg.Add(1)
+		go func(container docker.APIContainers, ttl time.Duration) {
+			defer wg.Done()
+			// send container to channel for processing
+			s.publishContainer(&container, ttl)
+		}(container, ttl)
 	}
+	// Wait for all publish operations to complete.
+	wg.Wait()
 }
 
 // getContainer retrieves a container from the docker client based on id


### PR DESCRIPTION
I've noticed that my apps could take a very long time before getting published to the router. After investigation, I found that it was caused by the cumulation of all the HEALTHCHECK_INITIAL_DELAY.

For exemple, let's say all my apps have an initial delay of 1 minute. If I have 100 apps, it will take 1 minute to publish the first one, 2 minutes for the second, and so on. The last one will be published only after 100 minutes.

This PR fixes the issue