### PR TITLE
docs(upgrading): clarify AWS-specific instructions

### DIFF
--- a/docs/managing_deis/upgrading-deis.rst
+++ b/docs/managing_deis/upgrading-deis.rst
@@ -62,6 +62,12 @@ Finally, update ``deisctl`` to the new version and reinstall:
     If an in-place upgrade is required on a cluster running a version older than v1.6,
     run ``deisctl config router set proxyProtocol=1``, enable PROXY protocol for ports 80 and
     443 on the ELB, add a ``TCP 443:443`` listener.
+    
+    Elastic Load Balancer is set to perform health checks to make sure your instances are alive.
+    When you take your cluster down, there will be a brief period that your instances will be
+    marked as ``OutOfService``. If deis-cli can't connect to your cluster, check your EC2 Load
+    Balancer's health check status in the AWS web console. Wait for the instances to return to
+    ``InService`` status.
 
 Upgrade Deis clients
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/managing_deis/upgrading-deis.rst
+++ b/docs/managing_deis/upgrading-deis.rst
@@ -58,10 +58,10 @@ Finally, update ``deisctl`` to the new version and reinstall:
     When upgrading an AWS cluster older than Deis v1.6, a :ref:`migration_upgrade` is
     preferable.
 
-    On AWS, Deis enables the :ref:`PROXY protocol <proxy_protocol>` by default.
-    If an in-place upgrade is required, run ``deisctl config router set proxyProtocol=1``,
-    enable PROXY protocol for ports 80 and 443 on the ELB, add a ``TCP 443:443`` listener, and
-    change existing targets and health checks from HTTP to TCP.
+    On AWS, Deis v1.6 and above enables the :ref:`PROXY protocol <proxy_protocol>` by default.
+    If an in-place upgrade is required on a cluster running a version older than v1.6,
+    run ``deisctl config router set proxyProtocol=1``, enable PROXY protocol for ports 80 and
+    443 on the ELB, add a ``TCP 443:443`` listener.
 
 Upgrade Deis clients
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I've clarified the AWS notes to highlight that updating proxy protocol support will only be necessary when upgrading from Deis versions that are older than v1.6.

I've also changed the ELB health check note to recommend to not change it—your instances will simply return anyway, you just need to wait. I'm not sure if this is the best way to go, but I've tried *changing health checks from HTTP to TCP* (as noted in the current documentation), but I wasn't sure what port to set it to; I tried setting it to port 80 and it marked my instances as `OutOfService` anyway.

Also see #5035.