### PR TITLE
chore(buildpacks): update heroku-buildpack-scala to v70

### DIFF
--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -38,5 +38,5 @@ download_buildpack https://github.com/heroku/heroku-buildpack-play.git          
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v80
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v105
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
-download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v67
+download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v70
 download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v41


### PR DESCRIPTION
See https://github.com/heroku/heroku-buildpack-scala/compare/v67...v70

I tested this with [example-python-scala](https://github.com/deis/example-python-scala) on Vagrant with 1.13.1+.