### PR TITLE
Revert "chore(*): bump CoreOS to 1010.5.0"

### DIFF
--- a/contrib/azure/parameters.json
+++ b/contrib/azure/parameters.json
@@ -27,7 +27,7 @@
     "value": 100
   },
   "coreosVersion": {
-    "value": "1010.5.0"
+    "value": "899.17.0"
   },
   "storageAccountType": {
     "value": "Premium_LRS"

--- a/contrib/linode/provision-linode-cluster.py
+++ b/contrib/linode/provision-linode-cluster.py
@@ -357,7 +357,7 @@ def main():
                                   help='Node data center id. Use list-data-centers to find the id.')
     provision_parser.add_argument('--cloud-config', required=False, default='linode-user-data.yaml', type=file, dest='cloud_config',
                                   help='CoreOS cloud config user-data file')
-    provision_parser.add_argument('--coreos-version', required=False, default='1010.5.0', dest='coreos_version',
+    provision_parser.add_argument('--coreos-version', required=False, default='899.17.0', dest='coreos_version',
                                   help='CoreOS version number to install')
     provision_parser.add_argument('--coreos-channel', required=False, default='stable', dest='coreos_channel',
                                   help='CoreOS channel to install from')

--- a/contrib/utils.sh
+++ b/contrib/utils.sh
@@ -13,5 +13,5 @@ function echo_green {
 }
 
 export COREOS_CHANNEL=${COREOS_CHANNEL:-stable}
-export COREOS_VERSION=${COREOS_VERSION:-1010.5.0}
+export COREOS_VERSION=${COREOS_VERSION:-899.17.0}
 export DEIS_RELEASE=1.13.1

--- a/docs/installing_deis/gce.rst
+++ b/docs/installing_deis/gce.rst
@@ -118,7 +118,7 @@ Launch 3 instances. You can choose another starting CoreOS image from the listin
       --metadata-from-file user-data=gce-user-data,sshKeys=$HOME/.ssh/deis.pub \
       --disk name=cored${num},device-name=coredocker \
       --tags deis \
-      --image coreos-stable-1010-5-0-v20160527 \
+      --image coreos-stable-899-17-0-v20160504 \
       --image-project coreos-cloud;
     done
 


### PR DESCRIPTION
This reverts commit 0d6475f60207cfcd41349782d411b3b22f371403 from #5042. Note that it leaves e8bcd6f4cf43d4afceff98f6bd526c10f5fc974f intact however, since that is a backward-compatible fix that allows the controller to run on CoreOS 1010.5.0: future-proofing seems prudent since users will likely provision from newer versions regardless.

As discussed in #5042, issue coreos/bugs#1301 is likely to crop up when using Deis v1. That issue is now fixed by coreos/coreos-overlay#2006 but may not appear in the CoreOS stable channel for a while.

So after reverting this, we can create a 1.13.2 release, and later create a 1.13.3 updating to a current CoreOS when the fix is available.