### PR TITLE
chore(buildpacks): update go, php, nodejs, python, and scala buildpacks

### DIFF
--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -30,7 +30,7 @@ mkdir -p $BUILDPACK_INSTALL_PATH
 
 download_buildpack https://github.com/heroku/heroku-buildpack-multi.git          v1.0.0
 download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v146
-download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v90
+download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v91
 download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v44
 download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v17
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v20

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -35,7 +35,7 @@ download_buildpack https://github.com/heroku/heroku-buildpack-java.git          
 download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v17
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v20
 download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v26
-download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v80
+download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v81
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v108
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v70

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -38,5 +38,5 @@ download_buildpack https://github.com/heroku/heroku-buildpack-play.git          
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v81
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v108
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
-download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v70
+download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v71
 download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v42

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -36,7 +36,7 @@ download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v20
 download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v26
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v80
-download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v105
+download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v108
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v70
 download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v41

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -39,4 +39,4 @@ download_buildpack https://github.com/heroku/heroku-buildpack-python.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v108
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v70
-download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v41
+download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v42


### PR DESCRIPTION
See 
https://github.com/heroku/heroku-buildpack-go/compare/v41...v42
https://github.com/heroku/heroku-buildpack-php/compare/v107...v108
https://github.com/heroku/heroku-buildpack-nodejs/compare/v90...v91
https://github.com/heroku/heroku-buildpack-python/compare/v80...v81
https://github.com/heroku/heroku-buildpack-scala/compare/v70...v71