### PR TITLE
feat(contrib): Add script to restart all apps.

### DIFF
--- a/contrib/util/reset-ps-all-apps.sh
+++ b/contrib/util/reset-ps-all-apps.sh
@@ -1,0 +1,12 @@
+apps=$(curl -H "Authorization: token $DEIS_TOKEN" http://$DEIS_SERVER/v1/apps  | jq -r '.results | map(.id) | join(" ")')
+
+for app in $apps; do
+  echo "Resetting containers of $app"
+
+  originalscale=$(curl -H "Authorization: token $DEIS_TOKEN" http://$DEIS_SERVER/v1/apps/$app/containers/ 2>/dev/null | jq -r '(.results) | [group_by(.type)[] | max_by(.num)] | [map(.type), map(.num)] | transpose | map([.[0], .[1] | tostring] | join("=")) | join(" ")')
+  zeroscale=$(curl -H "Authorization: token $DEIS_TOKEN" http://$DEIS_SERVER/v1/apps/$app/containers/  2>/dev/null | jq -r '(.results) | unique_by(.type) | map([.type, "0"] | join("=")) | join(" ")')
+
+  deis ps:scale $zeroscale -a $app
+  deis ps:scale $originalscale -a $app
+  echo
+done


### PR DESCRIPTION
This is usefull after a reinstall of a cluster with stateless storage.
When the new cluster is started it will still remember the requested
scale of all applications, but all containers will be in "destroyed"
state.
This means that a `deis ps:restart` does not work and so manual
rescaling needs to be done.
This is a tedious and error-prone task if you have many applications,
so this little script takes care of that.