### PR TITLE
ref(Makefiles): remove obsolete "docker tag -f" flag

### DIFF
--- a/builder/Makefile
+++ b/builder/Makefile
@@ -53,7 +53,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag -f $(IMAGE) $(DEV_IMAGE)
+	docker tag $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
 
 set-image: check-deisctl

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -38,7 +38,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag -f $(IMAGE) $(DEV_IMAGE)
+	docker tag $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
 
 set-image: check-deisctl

--- a/database/Makefile
+++ b/database/Makefile
@@ -34,7 +34,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag -f $(IMAGE) $(DEV_IMAGE)
+	docker tag $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
 
 set-image: check-deisctl

--- a/logger/Makefile
+++ b/logger/Makefile
@@ -44,7 +44,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag -f $(IMAGE) $(DEV_IMAGE)
+	docker tag $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
 
 set-image: check-deisctl

--- a/logspout/Makefile
+++ b/logspout/Makefile
@@ -44,7 +44,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag -f $(RELEASE_IMAGE) $(DEV_DOCKER_IMAGE)
+	docker tag $(RELEASE_IMAGE) $(DEV_DOCKER_IMAGE)
 	docker push $(DEV_DOCKER_IMAGE)
 
 set-image: check-deisctl

--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -32,7 +32,7 @@ install: check-deisctl
 dev-release: push set-image
 
 push: check-registry
-	docker tag -f $(RELEASE_IMAGE) $(REMOTE_IMAGE)
+	docker tag $(RELEASE_IMAGE) $(REMOTE_IMAGE)
 	docker push $(REMOTE_IMAGE)
 
 set-image: check-deisctl

--- a/registry/Makefile
+++ b/registry/Makefile
@@ -34,7 +34,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag -f $(IMAGE) $(DEV_IMAGE)
+	docker tag $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
 
 set-image: check-deisctl

--- a/router/Makefile
+++ b/router/Makefile
@@ -46,7 +46,7 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag -f $(IMAGE) $(DEV_IMAGE)
+	docker tag $(IMAGE) $(DEV_IMAGE)
 	docker push $(DEV_IMAGE)
 
 set-image: check-deisctl

--- a/store/Makefile
+++ b/store/Makefile
@@ -70,15 +70,15 @@ run: install start
 dev-release: push set-image
 
 push: check-registry
-	docker tag -f $(ADMIN_IMAGE) $(ADMIN_DEV_IMAGE)
+	docker tag $(ADMIN_IMAGE) $(ADMIN_DEV_IMAGE)
 	docker push $(ADMIN_DEV_IMAGE)
-	docker tag -f $(DAEMON_IMAGE) $(DAEMON_DEV_IMAGE)
+	docker tag $(DAEMON_IMAGE) $(DAEMON_DEV_IMAGE)
 	docker push $(DAEMON_DEV_IMAGE)
-	docker tag -f $(GATEWAY_IMAGE) $(GATEWAY_DEV_IMAGE)
+	docker tag $(GATEWAY_IMAGE) $(GATEWAY_DEV_IMAGE)
 	docker push $(GATEWAY_DEV_IMAGE)
-	docker tag -f $(METADATA_IMAGE) $(METADATA_DEV_IMAGE)
+	docker tag $(METADATA_IMAGE) $(METADATA_DEV_IMAGE)
 	docker push $(METADATA_DEV_IMAGE)
-	docker tag -f $(MONITOR_IMAGE) $(MONITOR_DEV_IMAGE)
+	docker tag $(MONITOR_IMAGE) $(MONITOR_DEV_IMAGE)
 	docker push $(MONITOR_DEV_IMAGE)
 
 set-image: check-deisctl


### PR DESCRIPTION
Removes the `-f` flag from `docker tag` commands,  since it is an error as of Docker v1.12.

See also deis/controller#827 (for example).