### PR TITLE
chore(*): update base to alpine:3.4

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 # install common packages
 RUN apk add --no-cache curl bash sudo

--- a/controller/build.sh
+++ b/controller/build.sh
@@ -17,6 +17,7 @@ apk add --no-cache \
   libpq \
   openldap \
   openldap-dev \
+  openssl \
   postgresql-dev \
   python \
   python-dev

--- a/logger/image/Dockerfile
+++ b/logger/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 ENTRYPOINT ["/bin/logger"]
 CMD ["--enable-publish"]

--- a/logspout/image/Dockerfile
+++ b/logspout/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 ENV DOCKER_HOST unix:///tmp/docker.sock
 ENV ROUTESPATH /tmp

--- a/publisher/image/Dockerfile
+++ b/publisher/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 # install curl in the image so it is possible to get the runtime
 # profiling information without any additional package installation.

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 # install common packages
 RUN apk add --no-cache curl bash sudo

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 # install common packages
 RUN apk add --no-cache \

--- a/tests/fixtures/mock-store/Dockerfile
+++ b/tests/fixtures/mock-store/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 # install common packages
 RUN apk add --no-cache curl bash sudo

--- a/tests/fixtures/mock-store/build.sh
+++ b/tests/fixtures/mock-store/build.sh
@@ -17,6 +17,7 @@ apk add --no-cache \
   file \
   gcc \
   git \
+  openssl \
   python-dev
 
 # install etcdctl

--- a/tests/fixtures/test-etcd/Dockerfile
+++ b/tests/fixtures/test-etcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 # install common packages
 RUN apk add --no-cache curl tar


### PR DESCRIPTION
Updates Docker base images to `alpine:3.4` to benefit from current code and fixes.

Leaves database intact, since upgrading to a new version of postgresql isn't a smooth upgrade path.

Mea culpa: I'm having problems with Go builds locally so I'm tossing this to Jenkins so I can test with the images it builds.