### PR TITLE
chore(buildpacks): update go, scala, and php buildpacks

### DIFF
--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -36,7 +36,7 @@ download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v20
 download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v26
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v81
-download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v108
+download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v109
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v72
 download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v44

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -38,5 +38,5 @@ download_buildpack https://github.com/heroku/heroku-buildpack-play.git          
 download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v81
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v108
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
-download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v71
+download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v72
 download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v44

--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -39,4 +39,4 @@ download_buildpack https://github.com/heroku/heroku-buildpack-python.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v108
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v71
-download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v42
+download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v44


### PR DESCRIPTION
See https://github.com/heroku/heroku-buildpack-go/compare/v42...v44
and https://github.com/heroku/heroku-buildpack-scala/compare/v71...v72
and https://github.com/heroku/heroku-buildpack-php/compare/v108...v109