### PR TITLE
chore(buildpacks): update heroku-buildpack-go to v46

### DIFF
--- a/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
+++ b/builder/rootfs/usr/local/src/slugbuilder/builder/install-buildpacks
@@ -39,4 +39,4 @@ download_buildpack https://github.com/heroku/heroku-buildpack-python.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v109
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v72
-download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v44
+download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v46


### PR DESCRIPTION
See https://github.com/heroku/heroku-buildpack-go/compare/v44...v46 and deis/slugbuilder#101.