### PR TITLE
fix(perms): user-only settings file permissions

### DIFF
--- a/client/controller/client/client.go
+++ b/client/controller/client/client.go
@@ -94,11 +94,11 @@ func (c Client) Save() error {
 		return err
 	}
 
-	if err = os.MkdirAll(path.Join(FindHome(), "/.deis/"), 0775); err != nil {
+	if err = os.MkdirAll(path.Join(FindHome(), "/.deis/"), 0700); err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(locateSettingsFile(), settingsContents, 0775)
+	return ioutil.WriteFile(locateSettingsFile(), settingsContents, 0600)
 }
 
 // Delete user's settings file.


### PR DESCRIPTION
Settings files contain auth tokens and should not be world-readable.

Backport of https://github.com/deis/workflow-cli/pull/251