### PR TITLE
fix(client): do not add top level command to cmdArgs

### DIFF
--- a/client/deis_test.go
+++ b/client/deis_test.go
@@ -61,6 +61,32 @@ func TestCommandSplitting(t *testing.T) {
 	}
 }
 
+func TestTopLevelCommandArgsPreparing(t *testing.T) {
+	t.Parallel()
+
+	command := "ssh"
+	argv := []string{"ssh"}
+	expected := []string{"deis-ssh"}
+	actual := prepareCmdArgs(command, argv)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v, Got %v", expected, actual)
+	}
+}
+
+func TestCommandWithParameterArgsPreparing(t *testing.T) {
+	t.Parallel()
+
+	command := "ssh --help"
+	argv := []string{"ssh --help"}
+	expected := []string{"deis-ssh --help"}
+	actual := prepareCmdArgs(command, argv)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v, Got %v", expected, actual)
+	}
+}
+
 func TestReplaceShortcutRepalce(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Background

We have a private PaaS with multiple Deis clusters (staging + two productions at the moment). We have also a tool that allows us to manage all clusters from a single web panel. It also connects other APIs such as servers provider and DNS provider. As the result we can perform actions that touches many parts of the system (for example create DNS records for all Deis workers and make CNAME to use with `DEISCTL_TUNNEL` or create a database and assign `DATABASE_URL` for a given application). We have also created plugins to extend Deis CLI. For example there is a support for database (+backups) management and easy SSH access for our developers.

## Problem

We have `deis backups:[create|show|restore|list]` commands and we want to show usage help if user tries `deis backups`. There is a problem in such case because Deis CLI invokes `deis-backups backups`. Without additional support on the plugin side, it will throw an invalid command error.

## Solution

We can solve it on the plugin side to handle unexpected arguments, but it feels not okay. Instead, Deis CLI should skip top level command (`backups` in this case) in `cmdArgv`. It already does that when used as `deis backups:list` or even `deis backups:`.

## Code snippets

The output contains `binary` and `cmdArgv` values using the following patch:

```diff
diff --git a/client/deis.go b/client/deis.go
index a256756..1377817 100644
--- a/client/deis.go
+++ b/client/deis.go
@@ -137,6 +137,10 @@ Use 'git push deis master' to deploy to an application.

                cmdArgv = append(cmdArgv, argv[1:]...)

+               fmt.Fprintf(os.Stdout, "binary: %v\n", binary)
+               fmt.Fprintf(os.Stdout, "cmdArgv: %v\n", cmdArgv)
+               return 1
+
                err = syscall.Exec(binary, cmdArgv, env)
                if err != nil {
                        parser.PrintUsage()
```

### Before

```bash
client λ ./deis backups
binary: /Users/smefju/.rbenv/shims/deis-backups
cmdArgv: [deis-backups backups]

client λ ./deis backups:list
binary: /Users/smefju/.rbenv/shims/deis-backups
cmdArgv: [deis-backups list]

client λ ./deis backups:list:details
binary: /Users/smefju/.rbenv/shims/deis-backups
cmdArgv: [deis-backups list:details]

client λ ./deis backups:list --details
binary: /Users/smefju/.rbenv/shims/deis-backups
cmdArgv: [deis-backups list --details]
```

### After

```bash
client λ ./deis backups
binary: /Users/smefju/.rbenv/shims/deis-backups
cmdArgv: [deis-backups]

client λ ./deis backups:list
binary: /Users/smefju/.rbenv/shims/deis-backups
cmdArgv: [deis-backups list]

client λ ./deis backups:list:details
binary: /Users/smefju/.rbenv/shims/deis-backups
cmdArgv: [deis-backups list:details]

client λ ./deis backups:list --details
binary: /Users/smefju/.rbenv/shims/deis-backups
cmdArgv: [deis-backups list --details]
```

### Difference

Difference is only in the first command's output.

## ToDo

* [x] skip top level command in `cmdArgv`
* [x] add specs

----

I don't have experience in GO language so feel free to propose a better solution. Tests are missing. I couldn't found any valuable materials about how to test `syscall.Exec` properly in such case. It would be great if you could drop some advice or add missing tests.