### PR TITLE
docs(layout): Update notice with URL for published v2 docs

### DIFF
--- a/docs/theme/deis/layout.html
+++ b/docs/theme/deis/layout.html
@@ -88,7 +88,7 @@
 
                   <div class="version-warning important">
                       <p class="version-warning-title">Version 1</p>
-                      <p>This documentation is for Deis Workflow (v1). For v2 documentation visit <a href="https://github.com/deis/workflow/">https://github.com/deis/workflow</a>.</p>
+                      <p>This documentation is for Deis Workflow (v1). For v2 documentation visit <a href="https://deis.com/docs/workflow/">https://deis.com/docs/workflow/</a>.</p>
                   </div>
                 {% block body %}
                 {% endblock %}


### PR DESCRIPTION
Previously this was a link to the doc source. A Container
Days conference attendee just pointed out that it would
be more convenient to be linked to the published docs
instead. I think he's right.