### PR TITLE
fix(Godeps,deisctl): serialize a unit test and fix a package import

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/deis/deis",
-	"GoVersion": "go1.5",
+	"GoVersion": "go1.7.3",
 	"Packages": [
 		"./..."
 	],
@@ -245,11 +245,6 @@
 		},
 		{
 			"ImportPath": "github.com/docker/docker/utils",
-			"Comment": "v1.5.0",
-			"Rev": "a8a31eff10544860d2188dddabdee4d727545796"
-		},
-		{
-			"ImportPath": "github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar",
 			"Comment": "v1.5.0",
 			"Rev": "a8a31eff10544860d2188dddabdee4d727545796"
 		},

--- a/Godeps/_workspace/src/github.com/docker/docker/graph/tags_unit_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/graph/tags_unit_test.go
@@ -7,11 +7,12 @@ import (
 	"path"
 	"testing"
 
+	"archive/tar"
+
 	"github.com/docker/docker/daemon/graphdriver"
 	_ "github.com/docker/docker/daemon/graphdriver/vfs" // import the vfs driver so it is used in the tests
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/utils"
-	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 )
 
 const (

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+	"archive/tar"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/fileutils"

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+	"archive/tar"
 )
 
 func TestCmdStreamLargeStderr(t *testing.T) {

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive_unix.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive_unix.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"syscall"
 
-	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+	"archive/tar"
 )
 
 func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/archive_windows.go
@@ -3,7 +3,7 @@
 package archive
 
 import (
-	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+	"archive/tar"
 )
 
 func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/changes.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/changes.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+	"archive/tar"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/pools"

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/diff.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/diff.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+	"archive/tar"
 
 	"github.com/docker/docker/pkg/pools"
 	"github.com/docker/docker/pkg/system"

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/diff_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/diff_test.go
@@ -3,7 +3,7 @@ package archive
 import (
 	"testing"
 
-	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+	"archive/tar"
 )
 
 func TestApplyLayerInvalidFilenames(t *testing.T) {

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/utils_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/utils_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+	"archive/tar"
 )
 
 var testUntarFns = map[string]func(string, io.Reader) error{

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/wrap.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/archive/wrap.go
@@ -2,7 +2,7 @@ package archive
 
 import (
 	"bytes"
-	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+	"archive/tar"
 	"io/ioutil"
 )
 

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/tarsum/tarsum.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/tarsum/tarsum.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+	"archive/tar"
 )
 
 const (

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/tarsum/tarsum_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/tarsum/tarsum_test.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+	"archive/tar"
 )
 
 type testLayer struct {

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/tarsum/versioning.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/tarsum/versioning.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
+	"archive/tar"
 )
 
 // versioning of the TarSum algorithm

--- a/deisctl/backend/fleet/fleet_test.go
+++ b/deisctl/backend/fleet/fleet_test.go
@@ -174,8 +174,6 @@ func (s *syncBuffer) Bytes() []byte {
 }
 
 func TestNewClient(t *testing.T) {
-	t.Parallel()
-
 	// set required flags
 	Flags.Endpoint = "http://127.0.0.1:4001"
 


### PR DESCRIPTION
Effectively restores a Go 1.5 assumption about `GOMAXPROCS=1` and rewrites an import path not to reference Google Code (RIP).