### PR TITLE
Update build.sh

### DIFF
--- a/store/base/build.sh
+++ b/store/base/build.sh
@@ -25,7 +25,7 @@ curl -sSL -o /usr/local/bin/confd https://github.com/kelseyhightower/confd/relea
 	&& chmod +x /usr/local/bin/confd
 
 curl -sSL 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc' | apt-key add -
-echo "deb http://ceph.com/debian-hammer trusty main" > /etc/apt/sources.list.d/ceph.list
+echo "deb http://download.ceph.com/debian-hammer trusty main" > /etc/apt/sources.list.d/ceph.list
 
 apt-get update && apt-get install -yq ceph lsb-release
 


### PR DESCRIPTION
Sorry to do a PR on deprecated product, but it is currently unusable without this change because of a redirect at ceph download primary mirror, that resulted in a broken build 7 weeks ago.  (Which apparently nobody has noticed until now.)

I applied the patch to build.sh, then did this on each of my Production deis v1 machines to put the updated image in their local image caches:

```
docker build --tag deis/store-base:v1.13.4 base
docker build --tag deis/store-admin:v1.13.4 admin
docker build --tag deis/store-daemon:v1.13.4 daemon
docker build --tag deis/store-gateway:v1.13.4 gateway
docker build --tag deis/store-metadata:v1.13.4 metadata
docker build --tag deis/store-monitor:v1.13.4 monitor
```

Now deis-store brings up ceph and my cluster works.  Baller.

Feel free to ignore this PR, but I am submitting it in case anyone else still has Deis v1 clusters that they care about, or for posterity.  If literally nobody else had this problem, then I'd say you've done a good job of getting people to switch to workflow.